### PR TITLE
Fix missing quadDecim in vantage NXT systems

### DIFF
--- a/zea/data/convert/matlab.py
+++ b/zea/data/convert/matlab.py
@@ -369,7 +369,12 @@ def read_sampling_frequency(file):
     """
     # Read the sampling frequency from the file
     adc_rate = dereference_index(file, file["Receive"]["decimSampleRate"], 0)
-    quaddecim = dereference_index(file, file["Receive"]["quadDecim"], 0)
+
+    # The Vantage NXT has renamed this field to sampleSkip
+    if "quadDecim" in file["Receive"]:
+        quaddecim = dereference_index(file, file["Receive"]["quadDecim"], 0)
+    else:
+        quaddecim = 1.0
 
     sampling_frequency = adc_rate / quaddecim * 1e6
 


### PR DESCRIPTION
The 3D Verasonics system has Vantage NXT devices, which apparently do not have the quadDecim field. This update disregards the quadDecim field if it is absent.