### PR TITLE
Clean-up and improve selecting transmits

### DIFF
--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -109,6 +109,22 @@ def test_selected_transmits_affects_shape(attr, expected_shape):
     else:
         assert val.shape == (expected_shape[0],)
 
+    # Select with some numpy array
+    scan.set_transmits(np.arange(3))
+    val = getattr(scan, attr)
+    if val.ndim == 2:
+        assert val.shape[0] == 3
+    else:
+        assert val.shape == (3,)
+
+    # Select with a list
+    scan.set_transmits([1, 2, 3])
+    val = getattr(scan, attr)
+    if val.ndim == 2:
+        assert val.shape[0] == 3
+    else:
+        assert val.shape == (3,)
+
 
 def test_set_attributes():
     """Test setting attributes of Scan class."""

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -108,3 +108,13 @@ def test_selected_transmits_affects_shape(attr, expected_shape):
         assert val.shape[0] == expected_shape[0]
     else:
         assert val.shape == (expected_shape[0],)
+
+
+def test_set_attributes():
+    """Test setting attributes of Scan class."""
+    scan = Scan(**scan_args)
+
+    scan.selected_transmits = [0]
+
+    with pytest.raises(AttributeError):
+        scan.grid = np.zeros((10, 10))

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -321,6 +321,16 @@ class Scan(Parameters):
         if n_tx_total is None:
             raise ValueError("n_tx must be set before calling set_transmits")
 
+        # Handle array-like - convert to list of indices
+        if isinstance(selection, np.ndarray):
+            if len(selection.shape) == 0:
+                # Handle scalar numpy array
+                return self.set_transmits(int(selection))
+            elif len(selection.shape) == 1:
+                selection = selection.tolist()
+            else:
+                raise ValueError(f"Invalid array shape: {selection.shape}")
+
         # Handle None and "all" - use all transmits
         if selection is None or selection == "all":
             self._selected_transmits = None
@@ -356,16 +366,6 @@ class Scan(Parameters):
             self._invalidate("selected_transmits")
             self._invalidate_dependents("selected_transmits")
             return self
-
-        # Handle array-like - convert to list of indices
-        if isinstance(selection, np.ndarray):
-            if len(selection.shape) == 0:
-                # Handle scalar numpy array
-                return self.set_transmits(int(selection))
-            elif len(selection.shape) == 1:
-                selection = selection.tolist()
-            else:
-                raise ValueError(f"Invalid array shape: {selection.shape}")
 
         # Handle list of indices
         if isinstance(selection, list):

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -298,26 +298,6 @@ class Scan(Parameters):
         """The number of currently selected transmits."""
         return len(self.selected_transmits)
 
-    def _invalidate_selected_transmits(self):
-        """Explicitly invalidate the selected_transmits cache and its dependents."""
-        for key in [
-            "selected_transmits",
-            # also invalidate properties that depend on selected_transmits
-            "polar_angles",
-            "azimuth_angles",
-            "t0_delays",
-            "tx_apodizations",
-            "focus_distances",
-            "initial_times",
-            "time_to_next_transmit",
-            "pfield",
-            "flat_pfield",
-        ]:
-            if key in self._cache:
-                self._cache.pop(key)
-                self._computed.discard(key)
-                self._dependency_versions.pop(key, None)
-
     def set_transmits(self, selection):
         """Select which transmit events to use.
 
@@ -344,13 +324,15 @@ class Scan(Parameters):
         # Handle None and "all" - use all transmits
         if selection is None or selection == "all":
             self._selected_transmits = None
-            self._invalidate_selected_transmits()
+            self._invalidate("selected_transmits")
+            self._invalidate_dependents("selected_transmits")
             return self
 
         # Handle "center" - use center transmit
         if selection == "center":
             self._selected_transmits = [n_tx_total // 2]
-            self._invalidate_selected_transmits()
+            self._invalidate("selected_transmits")
+            self._invalidate_dependents("selected_transmits")
             return self
 
         # Handle integer - select evenly spaced transmits
@@ -371,7 +353,8 @@ class Scan(Parameters):
                 tx_indices = np.linspace(0, n_tx_total - 1, selection)
                 self._selected_transmits = list(np.rint(tx_indices).astype(int))
 
-            self._invalidate_selected_transmits()
+            self._invalidate("selected_transmits")
+            self._invalidate_dependents("selected_transmits")
             return self
 
         # Handle array-like - convert to list of indices
@@ -396,7 +379,8 @@ class Scan(Parameters):
             self._selected_transmits = [
                 int(i) for i in selection
             ]  # Convert numpy integers to Python ints
-            self._invalidate_selected_transmits()
+            self._invalidate("selected_transmits")
+            self._invalidate_dependents("selected_transmits")
             return self
 
         # Aliasing check
@@ -559,3 +543,10 @@ class Scan(Parameters):
         time = np.mean(np.sum(self.time_to_next_transmit, axis=1))
         fps = 1 / time
         return fps
+
+    def __setattr__(self, key, value):
+        if key == "selected_transmits":
+            # If setting selected_transmits, call set_transmits to handle logic
+            self.set_transmits(value)
+            return
+        return super().__setattr__(key, value)


### PR DESCRIPTION
- Automatically discovers which attributes depend on `selected_transmits` (and this found some missing ones from the hardcoded list).
- `scan.selected_transmits = [0]` calls `scan.set_transmits`, before this gave a non-descriptive recursion error.
- [Fix for using set_transmits with a numpy array](https://github.com/tue-bmd/zea/pull/23/commits/c4cfbd2cfd79cd73d40f52e7b503c72228fecbe6)