### PR TITLE
Changed warning that implied pytorch is not supported

### DIFF
--- a/zea/backend/__init__.py
+++ b/zea/backend/__init__.py
@@ -1,4 +1,4 @@
-"""Backend subpackage for ``zea``.
+"""Backend-specific utilities.
 
 This subpackage provides backend-specific utilities for the ``zea`` library. Most backend logic is handled by Keras 3, but a few features require custom wrappers to ensure compatibility and performance across JAX, TensorFlow, and PyTorch.
 
@@ -9,7 +9,7 @@ Key Features
 ------------
 
 - **JIT Compilation** (:func:`zea.backend.jit`):
-  Provides a unified interface for just-in-time (JIT) compilation of functions, dispatching to the appropriate backend (JAX or TensorFlow) as needed. This enables accelerated execution of computationally intensive routines.
+  Provides a unified interface for just-in-time (JIT) compilation of functions, dispatching to the appropriate backend (JAX or TensorFlow) as needed. This enables accelerated execution of computationally intensive routines. Note that jit compilation is not yet supported when using the `torch` backend.
 
 - **Automatic Differentiation** (:class:`zea.backend.AutoGrad`):
   Offers a backend-agnostic wrapper for automatic differentiation, allowing gradient computation regardless of the underlying ML library.
@@ -108,7 +108,7 @@ def _jit_compile(func, jax=True, tensorflow=True, **kwargs):
         return func
     else:
         log.warning(
-            f"Unsupported backend: {backend}. Supported backends are 'tensorflow' and 'jax'."
+            f"JIT compilation not currently supported for backend {backend}. Supported backends are 'tensorflow' and 'jax'."
         )
         log.warning("Falling back to non-compiled mode.")
         return func


### PR DESCRIPTION
When running the examples, _jit_compile is hit and issues a warning that torch is not supported. It didn't specify it's talking about JITting though, so it looked like the package was telling the user torch isn't supported altogether.