### PR TITLE
Removed pydicom dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3898,24 +3898,12 @@ files = [
 [package.dependencies]
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
-[[package]]
-name = "pydicom"
-version = "3.0.1"
-description = "A pure Python package for reading and writing DICOM data"
-optional = false
-python-versions = ">=3.10"
-groups = ["main"]
-files = [
-    {file = "pydicom-3.0.1-py3-none-any.whl", hash = "sha256:db32f78b2641bd7972096b8289111ddab01fb221610de8d7afa835eb938adb41"},
-    {file = "pydicom-3.0.1.tar.gz", hash = "sha256:7b8be344b5b62493c9452ba6f5a299f78f8a6ab79786c729b0613698209603ec"},
-]
-
 [package.extras]
-basic = ["numpy", "types-pydicom"]
-dev = ["black (==24.8.0)", "mypy (==1.11.2)", "pre-commit", "pydicom-data", "pytest", "pytest-cov", "ruff (==0.6.3)", "types-requests"]
+basic = ["numpy"]
+dev = ["black (==24.8.0)", "mypy (==1.11.2)", "pre-commit", "pytest", "pytest-cov", "ruff (==0.6.3)", "types-requests"]
 docs = ["matplotlib", "numpy", "numpydoc", "pillow", "sphinx", "sphinx-copybutton", "sphinx-gallery", "sphinx_rtd_theme", "sphinxcontrib-jquery", "sphinxcontrib-napoleon"]
 gpl-license = ["pylibjpeg[libjpeg]"]
-pixeldata = ["numpy", "pillow", "pyjpegls", "pylibjpeg[openjpeg]", "pylibjpeg[rle]", "python-gdcm"]
+pixeldata = ["numpy", "pillow", "pyjpegls", "pylibjpeg[openjpeg]", "pylibjpeg[rle]"]
 
 [[package]]
 name = "pygments"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "wandb >=0.18",
     "wget >=3.2",
     # can we make these optional or remove?
-    "pydicom >=2.4",
     "scikit-image >=0.23",
     "scikit-learn >=1.4",
 ]

--- a/zea/io_lib.py
+++ b/zea/io_lib.py
@@ -12,16 +12,14 @@ from pathlib import Path
 
 import imageio
 import numpy as np
-import pydicom
 import tqdm
 import yaml
 from PIL import Image
-from pydicom.pixels import convert_color_space
 
 from zea import log
 from zea.data.file import File
 
-_SUPPORTED_VID_TYPES = [".avi", ".mp4", ".gif", ""]
+_SUPPORTED_VID_TYPES = [".avi", ".mp4", ".gif"]
 _SUPPORTED_IMG_TYPES = [".jpg", ".png", ".JPEG", ".PNG", ".jpeg"]
 _SUPPORTED_ZEA_TYPES = [".hdf5", ".h5"]
 
@@ -29,7 +27,7 @@ _SUPPORTED_ZEA_TYPES = [".hdf5", ".h5"]
 def load_video(filename):
     """Load a video file and return a numpy array of frames.
 
-    Supported file types: avi, mp4, gif, dcm.
+    Supported file types: avi, mp4, gif.
 
     Args:
         filename (str): The path to the video file.
@@ -64,9 +62,6 @@ def load_video(filename):
         cap.release()
     elif extension == ".gif":
         frames = imageio.mimread(filename)
-    elif extension == "":
-        ds = pydicom.dcmread(filename)
-        frames = convert_color_space(ds.pixel_array, "YBR_FULL", "RGB")
     else:
         raise ValueError("Unsupported file extension")
     frames = [cv2.cvtColor(frame, cv2.COLOR_RGB2GRAY) for frame in frames]

--- a/zea/tools/selection_tool.py
+++ b/zea/tools/selection_tool.py
@@ -729,7 +729,7 @@ def update_imshow_with_mask(
 def main():
     """Main function for interactive selector on multiple images."""
     print(
-        "Select as many images as you like, OR select 1 video / gif / dicom, "
+        "Select as many images as you like, OR select 1 video / gif, "
         "and close window to continue..."
     )
     images = []


### PR DESCRIPTION
Pydicom was broken (see: issue #53); this PR removes it altogether. We only used it for loading dicom videos in the iolib, but it wasn't actually checking the video metadata properly before loading, so the current implementation would actually fail for most dcm videos. We could at some point re-add support, but then we should probably support all versions of dicom video, rather than just one of the options; maybe better to ask users to convert any dicom videos they want to use into a more predictable format first.