### PR TITLE
Greedy entropy bug fix

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -102,6 +102,29 @@ def test_greedy_entropy():
     assert np.count_nonzero(first_row) == n_actions
     assert np.count_nonzero(selected_lines[0]) == n_actions
 
+    # Test that the algorithm hasn't changed by comparing to a correct hard-coded value
+    h, w = 64, 64
+    rand_img_1 = np.random.rand(h, w, 1).astype(np.float32)
+    rand_img_2 = np.random.rand(h, w, 1).astype(np.float32)
+
+    # manually make lines 2 and 3 very correlated
+    rand_img_1[:, 2] = rand_img_1[:, 3]
+    rand_img_2[:, 2] = rand_img_2[:, 3]
+
+    particles = np.stack([rand_img_1, rand_img_2], axis=0)
+    particles = np.expand_dims(particles, axis=0)
+    particles = np.squeeze(particles, axis=-1)
+
+    n_actions = 1
+    agent = selection.GreedyEntropy(n_actions, w, h, w)
+    selected_lines, mask = agent.sample(particles)
+    
+    correct_line_index = 17
+    correct_selected_lines = [False]*64
+    correct_selected_lines[correct_line_index] = True
+    correct_selected_lines = [correct_selected_lines]
+    assert np.all(selected_lines == correct_selected_lines)
+
 
 def test_covariance_sampling_lines():
     """Test CovarianceSamplingLines action selection."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -118,9 +118,9 @@ def test_greedy_entropy():
     n_actions = 1
     agent = selection.GreedyEntropy(n_actions, w, h, w)
     selected_lines, mask = agent.sample(particles)
-    
+
     correct_line_index = 17
-    correct_selected_lines = [False]*64
+    correct_selected_lines = [False] * 64
     correct_selected_lines[correct_line_index] = True
     correct_selected_lines = [correct_selected_lines]
     assert np.all(selected_lines == correct_selected_lines)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -128,32 +128,44 @@ def test_greedy_entropy():
 
 def test_covariance_sampling_lines():
     """Test CovarianceSamplingLines action selection."""
-    np.random.seed(2)
-    h, w = 8, 8
-    rand_img_1 = np.random.rand(h, w, 1).astype(np.float32)
-    rand_img_2 = np.random.rand(h, w, 1).astype(np.float32)
+    rng = np.random.default_rng(2)
+    h, w = 16, 16
+    rand_img_1 = rng.uniform(0, 1, (h, w)).astype(np.float32)
+    rand_img_2 = rng.uniform(0, 1, (h, w)).astype(np.float32)
 
     # manually make lines 2 and 3 very correlated
     rand_img_1[:, 2] = rand_img_1[:, 3]
     rand_img_2[:, 2] = rand_img_2[:, 3]
 
-    particles = np.stack([rand_img_1, rand_img_2], axis=0)[None, ...]
-    particles = np.squeeze(particles, axis=-1)  # shape (n_particles, 1, h, w)
+    # manually add a line on the right edge (i.e. high variance with eachother)
+    rand_img_1[:, -1] = 1.0
+    rand_img_2[:, -1] = 0.0
 
+    particles = np.stack([rand_img_1, rand_img_2], axis=0)[None]  # (batch, n_particles, h, w)
+
+    # CASE 1: Single action
     n_actions = 1
     agent = selection.CovarianceSamplingLines(n_actions, w, h, w, n_masks=200)
-    _, mask = agent.sample(particles)
+    selected_lines, mask = agent.sample(particles)
+    assert selected_lines.ndim == 2
+    selected_lines = ops.squeeze(selected_lines, axis=0)  # remove batch dim
     assert mask.shape == (1, h, w)
-    first_row = mask[0, 0]
-    assert np.count_nonzero(first_row) == n_actions
+    assert np.count_nonzero(selected_lines) == n_actions
 
+    # regression
+    assert 15 in np.flatnonzero(selected_lines)
+
+    # CASE 2: Two actions
     n_actions = 2
     agent = selection.CovarianceSamplingLines(n_actions, w, h, w, n_masks=200)
-    _, mask = agent.sample(particles)
+    selected_lines, mask = agent.sample(particles)
+    assert selected_lines.ndim == 2
+    selected_lines = ops.squeeze(selected_lines, axis=0)  # remove batch dim
     assert mask.shape == (1, h, w)
-    first_row = mask[0, 0]
-    first_row = mask[0, 0]
-    assert np.count_nonzero(first_row) == n_actions
+    assert np.count_nonzero(selected_lines) == n_actions
+
+    # regression
+    assert 15 in np.flatnonzero(selected_lines) and 0 in np.flatnonzero(selected_lines)
 
 
 def test_single_action():

--- a/zea/agent/selection.py
+++ b/zea/agent/selection.py
@@ -432,9 +432,14 @@ class CovarianceSamplingLines(LinesActionModel):
                 generation. Defaults to None.
 
         Returns:
-            Tensor: The mask of shape (batch_size, img_size, img_size)
+            Tuple[Tensor, Tensor]:
+                - Newly selected lines as k-hot vectors, shaped (batch_size, n_possible_actions)
+                - Masks of shape (batch_size, img_height, img_width)
         """
         batch_size, n_particles, rows, _ = ops.shape(particles)
+
+        # [batch_size, rows, cols, n_particles]
+        particles = ops.transpose(particles, (0, 2, 3, 1))
 
         # [batch_size, rows * stack_n_cols, n_possible_actions, n_particles]
         shape = [
@@ -445,7 +450,7 @@ class CovarianceSamplingLines(LinesActionModel):
         ]
         particles = ops.reshape(particles, shape)
 
-        # [batch_size, rows, n_possible_actions, n_possible_actions]
+        # [batch_size, rows * stack_n_cols, n_possible_actions, n_possible_actions]
         cov_matrix = tensor_ops.batch_cov(particles)
 
         # Sum over the row dimension [batch_size, n_possible_actions, n_possible_actions]

--- a/zea/agent/selection.py
+++ b/zea/agent/selection.py
@@ -105,6 +105,8 @@ class GreedyEntropy(LinesActionModel):
             std_dev (float, optional): The standard deviation of the RBF. Defaults to 1.
             num_lines_to_update (int, optional): The number of lines around the selected line
                 to update. Must be odd.
+            entropy_sigma (float, optional): The standard deviation of the Gaussian
+                Mixture components used to approximate the posterior.
         """
         super().__init__(n_actions, n_possible_actions, img_width, img_height)
 


### PR DESCRIPTION
* Discovered a bug in `GreedyEntropy` for the case where `n_possible_actions` =/= `img_width`. 
* This was caused by `ops.reshape` stacking vectors in the wrong order.
* The fix involves adding a transpose before and after the reshape to make sure that the order is correct.
* I also added a regression test that just asserts the line selected by greedy entropy with a hard coded 'correct answer', which should help prevent any unintended regressions if we change things in future.
* Also an extra minor change I made it so that `entropy_sigma` can be specified in the constructor rather than being hard coded.

Edit by @wesselvannierop:
* Added missing transpose to `CovarianceSamplingLines`, and add regression test for this too.