### PR TITLE
Release v0.0.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as follows:"
 title: "zea: A Toolbox for Cognitive Ultrasound Imaging"
-version: 0.0.2
+version: 0.0.3
 doi: 10.0000/placeholder-doi  # Replace with actual DOI later
 date-released: 2025-07-01     # Replace with actual date of release
 repository-code: https://github.com/tue-bmd/zea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zea"
-version = "0.0.2"
+version = "0.0.3"
 description = "A Toolbox for Cognitive Ultrasound Imaging. Provides a set of tools for processing of ultrasound data, all built in your favorite machine learning framework."
 authors = [
     { name = "Tristan Stevens", email = "t.s.w.stevens@tue.nl" },

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -7,7 +7,7 @@ from . import log
 
 # dynamically add __version__ attribute (see pyproject.toml)
 # __version__ = __import__("importlib.metadata").metadata.version(__package__)
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 
 def setup():


### PR DESCRIPTION
version bump to v0.0.3

Release message below:

---

## What's Changed
* Update readme by @tristan-deep in https://github.com/tue-bmd/zea/pull/40
* Removed pydicom dependency by @Louisvh in https://github.com/tue-bmd/zea/pull/54
* Fixed jit_options being ignored for the PatchedGrid in Pipeline.from_default() by @Louisvh in https://github.com/tue-bmd/zea/pull/51
* Changed warning that implied pytorch is not supported by @Louisvh in https://github.com/tue-bmd/zea/pull/35
* Precommit hooks added to CI pipeline by @Louisvh in https://github.com/tue-bmd/zea/pull/58
* Syntax notebook fix by @tristan-deep in https://github.com/tue-bmd/zea/pull/60
* Speed up slow notebook test by @Louisvh in https://github.com/tue-bmd/zea/pull/61
* Tensor caching for parameters by @benluijten in https://github.com/tue-bmd/zea/pull/21
* Greedy entropy bug fix by @OisinNolan in https://github.com/tue-bmd/zea/pull/67
* Sync configs to HF by @tristan-deep in https://github.com/tue-bmd/zea/pull/68
* Clean up and refactor by @wesselvannierop in https://github.com/tue-bmd/zea/pull/65
* Prevent error when probe is unknown by @vincentvdschaft in https://github.com/tue-bmd/zea/pull/63