### PR TITLE
Update `GreedyEntropy` entropy approximation to match cognitive ultrasound paper

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -119,7 +119,7 @@ def test_greedy_entropy():
     agent = selection.GreedyEntropy(n_actions, w, h, w)
     selected_lines, mask = agent.sample(particles)
 
-    correct_line_index = 15
+    correct_line_index = 17
     correct_selected_lines = [False] * 64
     correct_selected_lines[correct_line_index] = True
     correct_selected_lines = [correct_selected_lines]

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -119,7 +119,7 @@ def test_greedy_entropy():
     agent = selection.GreedyEntropy(n_actions, w, h, w)
     selected_lines, mask = agent.sample(particles)
 
-    correct_line_index = 17
+    correct_line_index = 15
     correct_selected_lines = [False] * 64
     correct_selected_lines[correct_line_index] = True
     correct_selected_lines = [correct_selected_lines]

--- a/zea/agent/selection.py
+++ b/zea/agent/selection.py
@@ -179,17 +179,16 @@ class GreedyEntropy(LinesActionModel):
         return gaussian_error_per_pixel_stacked
 
     def compute_pixelwise_entropy(self, particles):
-        """Compute the entropy for each line using a Gaussian Mixture Model.
-
+        """
         This function computes the entropy for each line using a Gaussian Mixture Model
         approximation of the posterior distribution.
-        For more details see Section 4 here: https://arxiv.org/abs/2406.14388
+        For more details see Section VI. B here: https://arxiv.org/pdf/2410.13310
 
         Args:
             particles (Tensor): Particles of shape (batch_size, n_particles, height, width)
 
         Returns:
-            Tensor: batch of entropies per line, of shape (batch, n_possible_actions)
+            Tensor: batch of entropies per pixel, of shape (batch, height, width)
         """
         n_particles = ops.shape(particles)[1]
         gaussian_error_per_pixel_stacked = GreedyEntropy.compute_pairwise_pixel_gaussian_error(

--- a/zea/agent/selection.py
+++ b/zea/agent/selection.py
@@ -191,6 +191,7 @@ class GreedyEntropy(LinesActionModel):
         Returns:
             Tensor: batch of entropies per line, of shape (batch, n_possible_actions)
         """
+        n_particles = ops.shape(particles)[1]
         gaussian_error_per_pixel_stacked = GreedyEntropy.compute_pairwise_pixel_gaussian_error(
             particles,
             self.stack_n_cols,
@@ -199,11 +200,13 @@ class GreedyEntropy(LinesActionModel):
         )
         # sum out first dimension of (n_particles x n_particles) error matrix
         # [n_particles, batch, height, width]
-        pixelwise_entropy_sum_j = ops.sum(gaussian_error_per_pixel_stacked, axis=1)
+        pixelwise_entropy_sum_j = ops.sum(
+            (1 / n_particles) * gaussian_error_per_pixel_stacked, axis=1
+        )
         log_pixelwise_entropy_sum_j = ops.log(pixelwise_entropy_sum_j)
         # sum out second dimension of (n_particles x n_particles) error matrix
         # [batch, height, width]
-        pixelwise_entropy = ops.sum(log_pixelwise_entropy_sum_j, axis=1)
+        pixelwise_entropy = -ops.sum((1 / n_particles) * log_pixelwise_entropy_sum_j, axis=1)
         return pixelwise_entropy
 
     def select_line_and_reweight_entropy(self, entropy_per_line):

--- a/zea/agent/selection.py
+++ b/zea/agent/selection.py
@@ -191,7 +191,7 @@ class GreedyEntropy(LinesActionModel):
             Tensor: batch of entropies per pixel, of shape (batch, height, width)
         """
         n_particles = ops.shape(particles)[1]
-        gaussian_error_per_pixel_stacked = GreedyEntropy.compute_pairwise_pixel_gaussian_error(
+        gaussian_error_per_pixel_stacked = self.compute_pairwise_pixel_gaussian_error(
             particles,
             self.stack_n_cols,
             self.n_possible_actions,


### PR DESCRIPTION
We have been using an upper bound to GMM entropy, but the lower bound listed in [1] is tighter.

This updates the greedy entropy approximation to pixelwise:
$\hat{H} = -\sum_i^{N_p} \frac{1}{N_p} \log \sum_j^{N_p} \frac{1}{N_p} \exp \left[ - \frac{(x^{(i)}-x^{(j)})^2}{2\sigma_x^2} \right]$

I also do some renaming to make it clear where we compute the pixelwise entropy map versus summing along the image height to get the linewise entropy map.

[1] https://arxiv.org/abs/2410.13310