### PR TITLE
Release v0.0.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as follows:"
 title: "zea: A Toolbox for Cognitive Ultrasound Imaging"
-version: 0.0.3
+version: 0.0.4
 doi: 10.0000/placeholder-doi  # Replace with actual DOI later
 date-released: 2025-07-01     # Replace with actual date of release
 repository-code: https://github.com/tue-bmd/zea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "zea"
-version = "0.0.3"
+version = "0.0.4"
 description = "A Toolbox for Cognitive Ultrasound Imaging. Provides a set of tools for processing of ultrasound data, all built in your favorite machine learning framework."
 authors = [
     { name = "Tristan Stevens", email = "t.s.w.stevens@tue.nl" },

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -7,7 +7,7 @@ from . import log
 
 # dynamically add __version__ attribute (see pyproject.toml)
 # __version__ = __import__("importlib.metadata").metadata.version(__package__)
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 def setup():


### PR DESCRIPTION
version bump to v0.0.3

Release message below:

---
## What's Changed
* Update `GreedyEntropy` entropy approximation to match cognitive ultrasound paper by @OisinNolan in https://github.com/tue-bmd/zea/pull/73
* Fix error when only one type of waveform by @vincentvdschaft in https://github.com/tue-bmd/zea/pull/74
* Diffusion call choose network and training type by @tristan-deep in https://github.com/tue-bmd/zea/pull/75
* Various improvements by @wesselvannierop in https://github.com/tue-bmd/zea/pull/78
