### PR TITLE
Remove try except block

### DIFF
--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -76,14 +76,14 @@ def get_gpu_memory(verbose=True):
     def _output_to_list(x):
         return x.decode("ascii").split("\n")[:-1]
 
-    COMMAND = ["nvidia-smi", "--query-gpu=memory.free", "--format=csv"]
+    COMMAND = ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"]
     try:
-        memory_free_info = _output_to_list(sp.check_output(COMMAND, timeout=3))[1:]
+        memory_free_info = _output_to_list(sp.check_output(COMMAND, timeout=3))
     except sp.SubprocessError as e:
         log.warning(f"Failed to retrieve GPU memory: {e}")
         return []
 
-    memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
+    memory_free_values = [int(x) for x in memory_free_info]
 
     # only show enabled devices
     if os.environ.get("CUDA_VISIBLE_DEVICES", "") != "":

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -76,8 +76,13 @@ def get_gpu_memory(verbose=True):
         return x.decode("ascii").split("\n")[:-1]
 
     COMMAND = "nvidia-smi --query-gpu=memory.free --format=csv"
-
-    memory_free_info = _output_to_list(sp.check_output(COMMAND.split()))[1:]
+    try:
+        memory = get_gpu_memory(verbose=verbose)
+    except (sp.CalledProcessError, sp.TimeoutExpired, FileNotFoundError) as e:
+        log.error(f"Failed to query GPU memory via nvidia-smi: {e}. Falling back to CPU.")
+        return _cpu_case()
+    if memory is None:  # nvidia-smi not available, fallback to CPU
+        return _cpu_case()
 
     memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
 

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -80,7 +80,7 @@ def get_gpu_memory(verbose=True):
 
     try:
         memory_free_info = _output_to_list(sp.check_output(COMMAND.split()))[1:]
-    except sp.CalledProcessError as e:
+    except Exception as e:
         log.warning(f"Failed to retrieve GPU memory: {e}")
         return []
 

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -76,11 +76,10 @@ def get_gpu_memory(verbose=True):
     def _output_to_list(x):
         return x.decode("ascii").split("\n")[:-1]
 
-    COMMAND = "nvidia-smi --query-gpu=memory.free --format=csv"
-
+    COMMAND = ["nvidia-smi", "--query-gpu=memory.free", "--format=csv"]
     try:
-        memory_free_info = _output_to_list(sp.check_output(COMMAND.split()))[1:]
-    except Exception as e:
+        memory_free_info = _output_to_list(sp.check_output(COMMAND, timeout=3))[1:]
+    except sp.SubprocessError as e:
         log.warning(f"Failed to retrieve GPU memory: {e}")
         return []
 

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -95,10 +95,12 @@ def get_gpu_memory(verbose=True):
         gpus = [int(gpu) for gpu in gpus.split(",")][: len(memory_free_values)]
         if verbose:
             # Report the number of disabled GPUs out of the total
-            num_disabled_gpus = len(memory_free_values) - len(gpus)
             num_gpus = len(memory_free_values)
-
-            print(f"{num_disabled_gpus / num_gpus} GPUs were disabled")
+            num_disabled_gpus = num_gpus - len(gpus)
+            if num_gpus > 0:
+                print(f"{num_disabled_gpus}/{num_gpus} GPUs were disabled")
+            else:
+                print("No GPUs detected by nvidia-smi.")
 
         memory_free_values = [memory_free_values[gpu] for gpu in gpus]
 

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -255,7 +255,7 @@ def get_device(device="auto:1", verbose=True, hide_others=True):
             os.environ["CUDA_VISIBLE_DEVICES"] = ""
         # returns None to indicate CPU
 
-    if device.lower() == "cpu":
+    if isinstance(device, str) and device.lower() == "cpu":
         return _cpu_case()
 
     if verbose:

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -69,7 +69,7 @@ def get_gpu_memory(verbose=True):
     if not check_nvidia_smi():
         log.warning(
             "nvidia-smi is not available. Please install nvidia-utils. "
-            "Cannot retrieve GPU memory. Falling back to CPU.."
+            "Cannot retrieve GPU memory. Falling back to CPU."
         )
         return []
 
@@ -84,6 +84,10 @@ def get_gpu_memory(verbose=True):
         return []
 
     memory_free_values = [int(x) for x in memory_free_info]
+
+    if verbose:
+        header = "GPU settings"
+        print("-" * 2 + header.center(50 - 4, "-") + "-" * 2)
 
     # only show enabled devices
     if os.environ.get("CUDA_VISIBLE_DEVICES", "") != "":
@@ -257,10 +261,6 @@ def get_device(device="auto:1", verbose=True, hide_others=True):
 
     if isinstance(device, str) and device.lower() == "cpu":
         return _cpu_case()
-
-    if verbose:
-        header = "GPU settings"
-        print("-" * 2 + header.center(50 - 4, "-") + "-" * 2)
 
     memory = get_gpu_memory(verbose=verbose)
     if len(memory) == 0:  # nvidia-smi not working, fallback to CPU

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -71,7 +71,7 @@ def get_gpu_memory(verbose=True):
             "nvidia-smi is not available. Please install nvidia-utils. "
             "Cannot retrieve GPU memory. Falling back to CPU.."
         )
-        return None
+        return []
 
     def _output_to_list(x):
         return x.decode("ascii").split("\n")[:-1]

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -76,10 +76,8 @@ def get_gpu_memory(verbose=True):
         return x.decode("ascii").split("\n")[:-1]
 
     COMMAND = "nvidia-smi --query-gpu=memory.free --format=csv"
-    try:
-        memory_free_info = _output_to_list(sp.check_output(COMMAND.split()))[1:]
-    except Exception as e:
-        print(f"An error occurred: {e}")
+
+    memory_free_info = _output_to_list(sp.check_output(COMMAND.split()))[1:]
 
     memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
 

--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -76,13 +76,8 @@ def get_gpu_memory(verbose=True):
         return x.decode("ascii").split("\n")[:-1]
 
     COMMAND = "nvidia-smi --query-gpu=memory.free --format=csv"
-    try:
-        memory = get_gpu_memory(verbose=verbose)
-    except (sp.CalledProcessError, sp.TimeoutExpired, FileNotFoundError) as e:
-        log.error(f"Failed to query GPU memory via nvidia-smi: {e}. Falling back to CPU.")
-        return _cpu_case()
-    if memory is None:  # nvidia-smi not available, fallback to CPU
-        return _cpu_case()
+
+    memory_free_info = _output_to_list(sp.check_output(COMMAND.split()))[1:]
 
     memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
 


### PR DESCRIPTION
The function `get_gpu_memory` has a try-except block that catches any errors with running `nvidia-smi`, but if there is an error the next line will fail anyway with a less clear error message. I have now removed the try-except block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable GPU detection and safer fallback to CPU when GPU info can't be queried; avoids crashes on timeout and parsing errors. Logs clearer GPU status messages (including disabled/total GPU counts or "No GPUs detected") and shows GPU settings only when relevant.
* **Chores**
  * No changes to public APIs or interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->