### PR TITLE
Add initial_step parameter to diffusion track progress method

### DIFF
--- a/zea/models/diffusion.py
+++ b/zea/models/diffusion.py
@@ -730,13 +730,13 @@ class DiffusionModel(DeepGenerativeModel):
 
     def start_track_progress(self, diffusion_steps, initial_step=0):
         """Initialize the progress tracking for the diffusion process.
-
         For diffusion animation we keep track of the diffusion progress.
         For large number of steps, we do not store all the images due to memory constraints.
         """
         self.track_progress = []
-        if diffusion_steps > 50:
-            self.track_progress_interval = (diffusion_steps - initial_step) // 50
+        remaining = max(1, diffusion_steps - int(initial_step))
+        if remaining > 50:
+            self.track_progress_interval = remaining // 50
         else:
             self.track_progress_interval = 1
 

--- a/zea/models/diffusion.py
+++ b/zea/models/diffusion.py
@@ -728,7 +728,7 @@ class DiffusionModel(DeepGenerativeModel):
             )
         return next_noisy_images
 
-    def start_track_progress(self, diffusion_steps):
+    def start_track_progress(self, diffusion_steps, initial_step=0):
         """Initialize the progress tracking for the diffusion process.
 
         For diffusion animation we keep track of the diffusion progress.
@@ -736,7 +736,7 @@ class DiffusionModel(DeepGenerativeModel):
         """
         self.track_progress = []
         if diffusion_steps > 50:
-            self.track_progress_interval = diffusion_steps // 50
+            self.track_progress_interval = (diffusion_steps - initial_step) // 50
         else:
             self.track_progress_interval = 1
 


### PR DESCRIPTION
Include option to specify initial_step in diffusion track_progress, meaning that the progress tracking is done based on the amount of diffusion steps taken, rather than total num_steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress tracking can start from a specified initial step so resumed or partial runs show correct progress.
  * Update intervals now scale with remaining steps for smoother, more consistent progress updates on long runs.
  * Backward compatible behavior preserved for runs starting at step zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->