### PR TITLE
Timeout fix nvidia-smi

### DIFF
--- a/zea/internal/device.py
+++ b/zea/internal/device.py
@@ -76,9 +76,13 @@ def get_gpu_memory(verbose=True):
     def _output_to_list(x):
         return x.decode("ascii").split("\n")[:-1]
 
-    COMMAND = ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"]
+    COMMAND = [
+        "nvidia-smi",
+        "--query-gpu=memory.free",
+        "--format=csv,noheader,nounits",
+    ]
     try:
-        memory_free_info = _output_to_list(sp.check_output(COMMAND, timeout=3))
+        memory_free_info = _output_to_list(sp.check_output(COMMAND))
     except sp.SubprocessError as e:
         log.warning(f"Failed to retrieve GPU memory: {e}")
         return []


### PR DESCRIPTION
Fixed a bug introduced in #90 which added timeout (too short) somewhere in init_device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable timeout for GPU status queries (env var) so slow queries can be tuned.

* **Bug Fixes**
  * Gracefully handles query timeouts by logging a warning and falling back to CPU usage to avoid failures.
  * Improves reliability on systems with slow GPU responses without changing reported outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->