### PR TITLE
Fix docker image latest tag

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,7 +41,9 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.backend }}-cpu:${{ needs.tag.outputs.docker_tag }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.backend }}-cpu:${{ needs.tag.outputs.docker_tag }}
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}/{2}-cpu:latest', env.REGISTRY, env.IMAGE_PREFIX, matrix.backend) || '' }}
           build-args: |
             INSTALL_JAX=${{ contains('all,jax', matrix.backend) && 'cpu' || 'false' }}
             INSTALL_TORCH=${{ contains('all,torch', matrix.backend) && 'cpu' || 'false' }}
@@ -56,7 +58,9 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.backend }}:${{ needs.tag.outputs.docker_tag }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.backend }}:${{ needs.tag.outputs.docker_tag }}
+            ${{ startsWith(github.ref, 'refs/tags/') && format('{0}/{1}/{2}:latest', env.REGISTRY, env.IMAGE_PREFIX, matrix.backend) || '' }}
           build-args: |
             INSTALL_JAX=${{ (matrix.backend == 'all' || matrix.backend == 'jax') && 'gpu' || 'false' }}
             INSTALL_TORCH=${{ (matrix.backend == 'all' || matrix.backend == 'torch') && 'gpu' || 'false' }}

--- a/.github/workflows/set-tag.yaml
+++ b/.github/workflows/set-tag.yaml
@@ -18,8 +18,6 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" || ("${{ github.event_name }}" == "push" && "${{ github.ref }}" != "refs/heads/main" && ! "${{ github.ref }}" =~ ^refs/tags/) ]]; then
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "tag=latest" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/ ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "release" ]]; then


### PR DESCRIPTION
Previously, "latest" tag was set on push to main but that was never triggered in the workflow, so i removed that. Now "latest" will be tagged on release. Fixes #156 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Revised Docker image tagging: uses multiline tag blocks and emits a "latest" label when builds are triggered from a git tag, otherwise keeps commit-SHA tagging.
  * Removed the special-case that set "latest" for main-branch pushes.
  * Preserved existing build arguments and caching behavior; minor formatting/debug echo unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->