### PR TITLE
Set weights for ema network during diffusion `train_step`

### DIFF
--- a/zea/data/convert/matlab.py
+++ b/zea/data/convert/matlab.py
@@ -150,11 +150,6 @@ def dereference_index(file, dataset, index, event=None, subindex=None):
         else:
             return file[reference][subindex]
     else:
-        if index > 0:
-            log.warning(
-                f"index {index} is not a reference. You are probably "
-                "incorrectly indexing a dataset."
-            )
         return dataset
 
 
@@ -935,7 +930,7 @@ def get_frame_indices(file, frames):
         frame_indices (np.ndarray): The frame indices.
     """
     # Read the number of frames from the file
-    n_frames = int(file["Resource"]["RcvBuffer"]["numFrames"][0][0])
+    n_frames = int(dereference_index(file, file["Resource"]["RcvBuffer"]["numFrames"], 0)[0][0])
 
     if isinstance(frames, str) and frames == "all":
         # Create an array of all frame-indices


### PR DESCRIPTION
The current train step for the diffusion model didn't update the weights value for the expected moving average (ema) network, but it was using the ema_network for inference, see: https://github.com/tue-bmd/zea/blob/b5c70ef99a86cd22f31ce127ad162d9ebc408744/zea/models/diffusion.py#L186

This PR copies over the code from our diffusion repo necessary to update these ema weights during the train_step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an exponential moving average (EMA) model copy and exposes EMA settings for inference.

* **Enhancements**
  * Configurable EMA strength and explicit min/max diffusion timing parameters.
  * Training now maintains EMA weights each step; evaluation/inference can use the EMA model.
  * Timing bounds used for diffusion sampling are now configurable.

* **Documentation**
  * Init and sampling docs updated to describe EMA behavior and timing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->