### PR TITLE
Ensure pitch is positive

### DIFF
--- a/zea/beamform/pfield.py
+++ b/zea/beamform/pfield.py
@@ -101,7 +101,7 @@ def compute_pfield(
     # array params
     probe_geometry = ops.convert_to_tensor(probe_geometry, dtype="float32")
 
-    pitch = probe_geometry[1, 0] - probe_geometry[0, 0]  # element pitch
+    pitch = ops.abs(probe_geometry[1, 0] - probe_geometry[0, 0])  # element pitch
 
     kerf = 0.1 * pitch  # for now this is hardcoded
     element_width = pitch - kerf


### PR DESCRIPTION
The pfield weighting would produce an error with the 3d transducer because the pitch is computed by subtracting the x-position of the first two elements, which would produce a negative number.

Note: This might go wrong for 3D probes and even 2D probes anyway. We might want a more robust way to do this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed element pitch calculation in beamforming to ensure consistent and reliable results regardless of element ordering
  * Enhanced robustness of downstream calculations by removing sign dependency in pitch computation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->