### PR TITLE
Fix file permission issues in self-hosted runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -126,8 +126,6 @@ jobs:
       - name: Run heavy Pytest
         run: |
           docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -e HOME=/tmp \
             -v "${{ github.workspace }}:/zea" \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
@@ -143,8 +141,6 @@ jobs:
       - name: Run notebook tests with Pytest
         run: |
           docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -e HOME=/tmp \
             -v "${{ github.workspace }}:/zea" \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \


### PR DESCRIPTION
**update: 

Fix is now applied serverside. Reverted some changes, but this PR removes a redundant pip install (should be handled in the docker build) 