### PR TITLE
Add n_frames to scan

### DIFF
--- a/zea/scan.py
+++ b/zea/scan.py
@@ -196,6 +196,7 @@ class Scan(Parameters):
         "sound_speed": {"type": float, "default": 1540.0},
         "sampling_frequency": {"type": float},
         "center_frequency": {"type": float},
+        "n_frames": {"type": int},
         "n_el": {"type": int},
         "n_tx": {"type": int},
         "n_ax": {"type": int},


### PR DESCRIPTION
I have added `n_frames` to the `VALID_PARAMS` for the `Scan` class. The others, `n_el`, `n_tx`, `n_ax`, and `n_ch`, were already present, only `n_frames` was missing.

The `zea.data.load_file` function would always give a warning `Skipping invalid parameter 'n_frames'` because it was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Scan API now supports a new `n_frames` integer parameter. This enables users to specify and control the exact number of frames to process during scan operations, providing greater flexibility and more granular control. The addition maintains full backward compatibility with existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->