### PR TITLE
Update zeahub phantom location

### DIFF
--- a/docs/source/notebooks/pipeline/3d_beamforming_example.ipynb
+++ b/docs/source/notebooks/pipeline/3d_beamforming_example.ipynb
@@ -125,7 +125,7 @@
     }
    ],
    "source": [
-    "path = \"hf://zeahub/phantoms/16-12-25-CIRS-Focused-3d.hdf5\"\n",
+    "path = \"hf://zeahub/phantoms/2025_12_16_cirs_focused_3d.hdf5\"\n",
     "\n",
     "rf_data, scan, probe = load_file(\n",
     "    path=path,\n",


### PR DESCRIPTION
- Updates the location of the 3D CIRS acquisition to be in [`zeahub/phantoms`](https://huggingface.co/datasets/zeahub/phantoms/tree/main), where we can group phantom scans as a single zea dataset, rather than having one dataset per file.
- This is referenced in the 3D beamforming pipeline example, so the only code change is updating the path there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated 3D beamforming example notebook with enhanced runtime logging and additional status messages.
  * Refined warning output to include more unused input keys and removed an outdated debug message.
  * Switched the example data used by the notebook from a CIRS dataset to a phantom dataset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->