### PR TITLE
Fix latest tagging issue with CI image

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,7 +71,9 @@ jobs:
             INSTALL_TF=cpu
             DEV=true
           push: true
-          tags: ${{ env.BASE_IMAGE }}:${{ needs.tag.outputs.docker_tag }}
+          tags: |
+            ${{ env.BASE_IMAGE }}:${{ needs.tag.outputs.docker_tag }}
+            ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('{0}:latest', env.BASE_IMAGE) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
When doing a forked PR, the latest ghcr image is being used, however latest was never tagged properly (just SHA tag). That should be fixed now.

This will fix the failed test run in #264, due to an outdated image.