### PR TITLE
Add jit speedup to example notebook

### DIFF
--- a/docs/source/notebooks/data/zea_simulation_example.ipynb
+++ b/docs/source/notebooks/data/zea_simulation_example.ipynb
@@ -338,7 +338,7 @@
      "text": [
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No azimuth angles provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'center_frequency', 'xlims', 'zlims', 'n_el'}. Make sure this is intended. This warning will only be shown once.\n"
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'zlims', 'xlims', 'center_frequency', 'n_el'}. Make sure this is intended. This warning will only be shown once.\n"
      ]
     }
    ],
@@ -399,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "8aa8873d",
    "metadata": {},
    "outputs": [
@@ -407,8 +407,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Timing with JIT compilation: 0.0020 seconds per run\n",
-      "Timing without JIT compilation: 0.2065 seconds per run\n"
+      "Timing with JIT compilation: 0.0243 seconds per run\n",
+      "Timing without JIT compilation: 0.2104 seconds per run\n"
      ]
     }
    ],


### PR DESCRIPTION
Regarding #270

Kept the fish example the same since it is only ~4 sec, so I didn't want to distract from the tutorial.

Instead, added a final cell that shows you how to JIT with a small time comparison 

<img width="1517" height="466" alt="image" src="https://github.com/user-attachments/assets/88b7c814-ceb5-45e6-acfb-e97eba1d08eb" />

See: https://zea--282.org.readthedocs.build/en/282/notebooks/data/zea_simulation_example.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Just-In-Time compilation (JIT)" section to the data simulation notebook with explanatory text and placeholders for JAX, PyTorch, and TensorFlow backends.

* **New Features**
  * Added runnable examples showing JIT/script usage and timing comparisons to demonstrate performance benefits.

* **Refactor**
  * Simplified how simulation examples pass arguments for clarity.

* **Bug Fixes**
  * Clarified and improved warning/debug messages shown during pipeline runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->