### PR TITLE
Clean markdown block notebook example

### DIFF
--- a/docs/source/notebooks/data/zea_simulation_example.ipynb
+++ b/docs/source/notebooks/data/zea_simulation_example.ipynb
@@ -338,7 +338,7 @@
      "text": [
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No azimuth angles provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'n_el', 'zlims', 'center_frequency', 'xlims'}. Make sure this is intended. This warning will only be shown once.\n"
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'center_frequency', 'xlims', 'n_el', 'zlims'}. Make sure this is intended. This warning will only be shown once.\n"
      ]
     }
    ],
@@ -429,19 +429,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Timing with JIT compilation: 0.0247 seconds per run\n",
-      "Timing without JIT compilation: 0.2084 seconds per run\n"
+      "\u001b[1mFunction Timing Statistics\u001b[0m\n",
+      "=====================================================================================================\n",
+      "\u001b[36mFunction\u001b[0m              \u001b[32mMean\u001b[0m          \u001b[32mMedian\u001b[0m        \u001b[32mStd Dev\u001b[0m       \u001b[33mMin\u001b[0m           \u001b[33mMax\u001b[0m           \u001b[35mCount\u001b[0m    \n",
+      "-----------------------------------------------------------------------------------------------------\n",
+      "\u001b[36msimulate_rf\u001b[0m           \u001b[32m0.220066\u001b[0m      \u001b[32m0.218923\u001b[0m      \u001b[32m0.021850\u001b[0m      \u001b[33m0.189399\u001b[0m      \u001b[33m0.255911\u001b[0m      \u001b[35m30\u001b[0m       \n",
+      "\u001b[36msimulate_rf (JIT)\u001b[0m     \u001b[32m0.004081\u001b[0m      \u001b[32m0.003444\u001b[0m      \u001b[32m0.003207\u001b[0m      \u001b[33m0.003159\u001b[0m      \u001b[33m0.020947\u001b[0m      \u001b[35m30\u001b[0m       \n"
      ]
     }
    ],
    "source": [
-    "import timeit\n",
+    "from zea.utils import FunctionTimer\n",
     "\n",
-    "t_jit = timeit.timeit(lambda: simulate_rf_jit(**simulation_args), number=30) / 30\n",
-    "print(f\"Timing with JIT compilation: {t_jit:.4f} seconds per run\")\n",
+    "# Warm-up JIT compilation before benchmarking\n",
+    "simulate_rf_jit(**simulation_args)\n",
     "\n",
-    "t = timeit.timeit(lambda: simulate_rf(**simulation_args), number=30) / 30\n",
-    "print(f\"Timing without JIT compilation: {t:.4f} seconds per run\")"
+    "timer = FunctionTimer()\n",
+    "timed_rf = timer(simulate_rf, name=\"simulate_rf\")\n",
+    "timed_rf_jit = timer(simulate_rf_jit, name=\"simulate_rf (JIT)\")\n",
+    "\n",
+    "for _ in range(30):\n",
+    "    timed_rf_jit(**simulation_args)\n",
+    "    timed_rf(**simulation_args)\n",
+    "\n",
+    "timer.print()"
    ]
   },
   {


### PR DESCRIPTION
See discussion here
https://github.com/tue-bmd/zea/pull/282#discussion_r2917534327

To check: https://zea--286.org.readthedocs.build/en/286/notebooks/data/zea_simulation_example.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified JIT guidance across backends and emphasized JAX as a recommended starting point with a new JAX-focused example showing how to apply jit.
  * Added benchmarking cells and a detailed timing table to compare JIT vs non-JIT performance; reworked timing outputs and explanatory notes.
  * Reorganized and reworded the JIT section (distinct backend headings), updated explanatory text, and adjusted notebook flow and warning/debug messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->