### PR TITLE
Spec coordinates & extent

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -191,7 +191,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``beamformed_data``
 
-         Beamformed (beamsummed) data. Pixels are ``float32`` in (n_frames, x, z, n_ch) or (n_frames, x, z, y, n_ch); ``labels`` names each channel (RF or I/Q).
+         Beamformed (beamsummed) data. Pixels are ``float32`` in (n_frames, z, x, n_ch) or (n_frames, z, x, y, n_ch); ``labels`` names each channel (RF or I/Q).
 
          .. list-table::
             :header-rows: 1
@@ -204,7 +204,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y, n_ch) or (n_frames, x, z, n_ch)
+              - (n_frames, z, x, y, n_ch) or (n_frames, z, x, n_ch)
               - –
               - |badge-req|
             * - ``extent``
@@ -230,7 +230,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``envelope_data``
 
-         Envelope-detected data. Pixels are ``float32`` in (n_frames, x, z) or (n_frames, x, z, y).
+         Envelope-detected data. Pixels are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).
 
          .. list-table::
             :header-rows: 1
@@ -243,7 +243,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -269,7 +269,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``image_sc``
 
-         Scan-converted image. Pixels are ``float32`` in (n_frames, x, z) or (n_frames, x, z, y).
+         Scan-converted image. Pixels are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).
 
          .. list-table::
             :header-rows: 1
@@ -282,7 +282,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``uint8``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -308,7 +308,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``image``
 
-         Reconstructed (log-compressed) image. Pixels are ``uint8`` in (n_frames, x, z) or (n_frames, x, z, y).
+         Reconstructed (log-compressed) image. Pixels are ``uint8`` in (n_frames, z, x) or (n_frames, z, x, y).
 
          .. list-table::
             :header-rows: 1
@@ -321,7 +321,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``uint8``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -347,7 +347,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``segmentation``
 
-         Semantic segmentation mask. Pixels are ``bool`` in (n_frames, x, z, y, n_labels); ``labels`` names each channel.
+         Semantic segmentation mask. Pixels are ``bool`` in (n_frames, z, x, y, n_labels); ``labels`` names each channel.
 
          .. list-table::
             :header-rows: 1
@@ -360,7 +360,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``bool``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -399,7 +399,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -438,7 +438,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -477,7 +477,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -516,7 +516,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``
@@ -555,7 +555,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``pixels``
               - ``float32``
-              - (n_frames, x, z, y, n_spatial_ch) or (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``extent``

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -115,7 +115,7 @@ extent.  Pass it as a sub-dict under the key you want:
     from zea import File
 
     n_frames = 2
-    pixels = np.zeros((n_frames, 64, 64, 1), dtype=np.uint8)   # (frames, x, z[, channels])
+    pixels = np.zeros((n_frames, 64, 64, 1), dtype=np.uint8)   # (frames, z, x[, channels])
     extent = np.array([x_min, x_max, y_min, y_max, z_min, z_max], dtype=np.float32)  # metres
 
     f = File.create(

--- a/docs/source/notebooks/pipeline/doppler_example.ipynb
+++ b/docs/source/notebooks/pipeline/doppler_example.ipynb
@@ -326,7 +326,7 @@
     "    scan.sound_speed,\n",
     "    hamming_size=10,  # spatial smoothing with Hamming window\n",
     ")\n",
-    "plt.imshow(d * 100, cmap=\"bwr\", extent=scan.extent(imshow=True) * 1e3)\n",
+    "plt.imshow(d * 100, cmap=\"bwr\", extent=scan.extent_imshow * 1e3)\n",
     "plt.title(\"Doppler image (cm/s)\")\n",
     "plt.xlabel(\"X (mm)\")\n",
     "plt.ylabel(\"Z (mm)\")\n",

--- a/docs/source/notebooks/pipeline/doppler_example.ipynb
+++ b/docs/source/notebooks/pipeline/doppler_example.ipynb
@@ -302,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "1d1c01e5",
    "metadata": {},
    "outputs": [

--- a/docs/source/notebooks/pipeline/doppler_example.ipynb
+++ b/docs/source/notebooks/pipeline/doppler_example.ipynb
@@ -302,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "1d1c01e5",
    "metadata": {},
    "outputs": [
@@ -326,7 +326,7 @@
     "    scan.sound_speed,\n",
     "    hamming_size=10,  # spatial smoothing with Hamming window\n",
     ")\n",
-    "plt.imshow(d * 100, cmap=\"bwr\", extent=scan.extent * 1e3)\n",
+    "plt.imshow(d * 100, cmap=\"bwr\", extent=scan.extent(imshow=True) * 1e3)\n",
     "plt.title(\"Doppler image (cm/s)\")\n",
     "plt.xlabel(\"X (mm)\")\n",
     "plt.ylabel(\"Z (mm)\")\n",

--- a/docs/source/notebooks/pipeline/polar_grid_example.ipynb
+++ b/docs/source/notebooks/pipeline/polar_grid_example.ipynb
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "b44250f5",
    "metadata": {},
    "outputs": [],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "ea9ea615",
    "metadata": {},
    "outputs": [],
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "009c6fd1",
    "metadata": {},
    "outputs": [],
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "0dde4c4f",
    "metadata": {},
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a952f37a",
    "metadata": {},
    "outputs": [
@@ -249,7 +249,7 @@
      "output_type": "stream",
      "text": [
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No azimuth angles provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'n_el', 'zlims', 'xlims'}. Make sure this is intended. This warning will only be shown once.\n"
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'zlims', 'xlims', 'n_el'}. Make sure this is intended. This warning will only be shown once.\n"
      ]
     }
    ],
@@ -262,7 +262,28 @@
     "image_cart = pipeline(**parameters, **simulation_parameters)[\"data\"]\n",
     "\n",
     "# Define the extent for the cartesian grid\n",
-    "extent_cart = scan.extent(imshow=True).copy()"
+    "extent_cart = scan.extent_imshow.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "26ca44d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-0.02 ,  0.02 ,  0.   ,  0.   ,  0.   ,  0.035])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scan.extent()"
    ]
   },
   {
@@ -277,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "165584fa",
    "metadata": {},
    "outputs": [
@@ -309,7 +330,7 @@
     "image_polar = pipeline_sc(**parameters, **simulation_parameters)[\"data\"]\n",
     "\n",
     "# Define the extent for the polar grid\n",
-    "extent_polar = scan.extent(imshow=True).copy()"
+    "extent_polar = scan.extent_imshow.copy()"
    ]
   },
   {

--- a/docs/source/notebooks/pipeline/polar_grid_example.ipynb
+++ b/docs/source/notebooks/pipeline/polar_grid_example.ipynb
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "a952f37a",
    "metadata": {},
    "outputs": [
@@ -262,7 +262,7 @@
     "image_cart = pipeline(**parameters, **simulation_parameters)[\"data\"]\n",
     "\n",
     "# Define the extent for the cartesian grid\n",
-    "extent_cart = scan.extent.copy()"
+    "extent_cart = scan.extent(imshow=True).copy()"
    ]
   },
   {
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "165584fa",
    "metadata": {},
    "outputs": [
@@ -309,7 +309,7 @@
     "image_polar = pipeline_sc(**parameters, **simulation_parameters)[\"data\"]\n",
     "\n",
     "# Define the extent for the polar grid\n",
-    "extent_polar = scan.extent.copy()"
+    "extent_polar = scan.extent(imshow=True).copy()"
    ]
   },
   {

--- a/docs/source/notebooks/pipeline/polar_grid_example.ipynb
+++ b/docs/source/notebooks/pipeline/polar_grid_example.ipynb
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "a952f37a",
    "metadata": {},
    "outputs": [
@@ -277,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "165584fa",
    "metadata": {},
    "outputs": [

--- a/docs/source/notebooks/pipeline/polar_grid_example.ipynb
+++ b/docs/source/notebooks/pipeline/polar_grid_example.ipynb
@@ -100,7 +100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "b44250f5",
    "metadata": {},
    "outputs": [],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "ea9ea615",
    "metadata": {},
    "outputs": [],
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "009c6fd1",
    "metadata": {},
    "outputs": [],
@@ -212,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0dde4c4f",
    "metadata": {},
    "outputs": [
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "a952f37a",
    "metadata": {},
    "outputs": [
@@ -266,27 +266,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "26ca44d4",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([-0.02 ,  0.02 ,  0.   ,  0.   ,  0.   ,  0.035])"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "scan.extent()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "a90ba7ae",
    "metadata": {},
@@ -298,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "165584fa",
    "metadata": {},
    "outputs": [

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -288,11 +288,11 @@ ROOT_ATTRS_TABLE = """\
 
 # Short descriptions for each spatial map type
 MAP_DESCRIPTIONS = {
-    "beamformed_data": "Beamformed (beamsummed) data. Pixels are ``float32`` in (n_frames, x, z, n_ch) or (n_frames, x, z, y, n_ch); ``labels`` names each channel (RF or I/Q).",  # noqa: E501
-    "envelope_data": "Envelope-detected data. Pixels are ``float32`` in (n_frames, x, z) or (n_frames, x, z, y).",  # noqa: E501
-    "image_sc": "Scan-converted image. Pixels are ``float32`` in (n_frames, x, z) or (n_frames, x, z, y).",  # noqa: E501
-    "image": "Reconstructed (log-compressed) image. Pixels are ``uint8`` in (n_frames, x, z) or (n_frames, x, z, y).",  # noqa: E501
-    "segmentation": "Semantic segmentation mask. Pixels are ``bool`` in (n_frames, x, z, y, n_labels); ``labels`` names each channel.",  # noqa: E501
+    "beamformed_data": "Beamformed (beamsummed) data. Pixels are ``float32`` in (n_frames, z, x, n_ch) or (n_frames, z, x, y, n_ch); ``labels`` names each channel (RF or I/Q).",  # noqa: E501
+    "envelope_data": "Envelope-detected data. Pixels are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
+    "image_sc": "Scan-converted image. Pixels are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
+    "image": "Reconstructed (log-compressed) image. Pixels are ``uint8`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
+    "segmentation": "Semantic segmentation mask. Pixels are ``bool`` in (n_frames, z, x, y, n_labels); ``labels`` names each channel.",  # noqa: E501
     "sos_map": "Speed-of-sound map in m/s. Pixels are ``float32``.",
     "strain_percentage_map": "Strain map in %. Pixels are ``float32``.",
     "shear_wave_elastography_map": "Shear-wave elastography map in m/s. Pixels are ``float32``.",

--- a/tests/test_transmit_schemes.py
+++ b/tests/test_transmit_schemes.py
@@ -163,7 +163,7 @@ def test_transmit_schemes(
     # Check if the scatterer is in the right location in the image
     _test_location(
         image.T,
-        extent=scan.extent(imshow=True),
+        extent=scan.extent_imshow,
         true_position=ultrasound_scatterers["positions"][0, target_scatterer_index],
     )
     # Check that the pipeline produced the expected outputs
@@ -228,7 +228,7 @@ def test_polar_grid(default_pipeline: ops.Pipeline, ultrasound_scatterers):
     # Check if the scatterer is in the right location in the image
     _test_location(
         image.T,
-        extent=scan.extent(imshow=True),
+        extent=scan.extent_imshow,
         true_position=ultrasound_scatterers["positions"][0, target_scatterer_index],
     )
 

--- a/tests/test_transmit_schemes.py
+++ b/tests/test_transmit_schemes.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from zea import ops
-from zea.beamform.phantoms import fish, rose, fibonacci, lissajous, golden_ratio
+from zea.beamform.phantoms import fibonacci, fish, golden_ratio, lissajous, rose
 from zea.internal.core import DEFAULT_DYNAMIC_RANGE
 from zea.internal.dummy_scan import _get_probe, _get_scan
 
@@ -163,7 +163,7 @@ def test_transmit_schemes(
     # Check if the scatterer is in the right location in the image
     _test_location(
         image.T,
-        extent=scan.extent,
+        extent=scan.extent(imshow=True),
         true_position=ultrasound_scatterers["positions"][0, target_scatterer_index],
     )
     # Check that the pipeline produced the expected outputs
@@ -228,7 +228,7 @@ def test_polar_grid(default_pipeline: ops.Pipeline, ultrasound_scatterers):
     # Check if the scatterer is in the right location in the image
     _test_location(
         image.T,
-        extent=scan.extent,
+        extent=scan.extent(imshow=True),
         true_position=ultrasound_scatterers["positions"][0, target_scatterer_index],
     )
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -525,7 +525,7 @@ class Map(Spec):
             if np.any(self.extent[..., 2] > self.extent[..., 3]):
                 raise ValueError("Map extent ylims must have ymin <= ymax")
             if np.any(self.extent[..., 4] > self.extent[..., 5]):
-                raise ValueError("Map extent zlims must have zmax <= zmin")
+                raise ValueError("Map extent zlims must have zmin <= zmax")
 
             # Ultrasound specific warning: if extent values are unusually large, log a warning
             if np.any(self.extent >= 1.0) or np.any(self.extent <= -1.0):
@@ -699,6 +699,8 @@ class SosMap(FloatMap):
         pixels: The speed-of-sound map pixels in m/s of shape (n_frames, z, x, y)
             and type float32.
         extent: The speed-of-sound map extent in meters of shape (n_frames, 6) or (6,).
+            A shape of (6,) is broadcast to all frames. Values are ordered as
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
     """
 
     def __post_init__(self):
@@ -722,6 +724,8 @@ class StrainPercentageMap(FloatMap):
     Args:
         pixels: The strain pixels in % of shape (n_frames, z, x, y) and type float32.
         extent: The strain extent in meters of shape (n_frames, 6) or (6,).
+            A shape of (6,) is broadcast to all frames. Values are ordered as
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
     """
 
     def __post_init__(self):

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -477,7 +477,7 @@ class Map(Spec):
 
     Args:
         pixels: The map pixels of shape (n_frames, z, x, y, n_ch) or (n_frames, z, x, y)
-            and type uint8 or float32 or int16.
+            or (n_frames, z, x, n_ch) or (n_frames, z, x) and type uint8 or float32 or int16.
         extent: The map extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
             (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -476,7 +476,7 @@ class Map(Spec):
     The most flexible map spec, which can be used for any spatially aligned data product.
 
     Args:
-        pixels: The map pixels of shape (n_frames, x, z, y, n_ch) or (n_frames, x, z, y)
+        pixels: The map pixels of shape (n_frames, z, x, y, n_ch) or (n_frames, z, x, y)
             and type uint8 or float32 or int16.
         extent: The map extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
@@ -499,9 +499,9 @@ class Map(Spec):
         "pixels": {
             "dtype": (np.uint8, np.float32, np.int16, np.complex64),
             "shape": (
-                ("n_frames", "x", "z", "y", "n_spatial_ch"),
-                ("n_frames", "x", "z", "y"),
-                ("n_frames", "x", "z"),
+                ("n_frames", "z", "x", "y", "n_spatial_ch"),
+                ("n_frames", "z", "x", "y"),
+                ("n_frames", "z", "x"),
             ),
         },
         "extent": {"dtype": np.float32, "shape": (("n_frames", 6), (6,))},
@@ -578,7 +578,7 @@ class Segmentation(BooleanMap):
     """Segmentation data and spatial extent metadata.
 
     Args:
-        pixels: The segmentation pixels of shape (n_frames, x, z, y, n_labels) and type bool.
+        pixels: The segmentation pixels of shape (n_frames, z, x, y, n_labels) and type bool.
         extent: The segmentation extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
             (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
@@ -588,7 +588,7 @@ class Segmentation(BooleanMap):
 
     def __post_init__(self):
         assert self.pixels.ndim == 5, (
-            "Segmentation pixels must have 5 dimensions (n_frames, x, z, y, n_labels)"
+            "Segmentation pixels must have 5 dimensions (n_frames, z, x, y, n_labels)"
         )
         super().__post_init__()
 
@@ -598,7 +598,7 @@ class Image(UnsignedIntMap):
     """Reconstructed (log-compressed) image data and spatial extent metadata.
 
     Args:
-        pixels: The image pixels of shape (n_frames, x, z, y) and type uint8.
+        pixels: The image pixels of shape (n_frames, z, x, y) and type uint8.
         extent: The image extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
             (radius_min, radius_max, theta_min, theta_max, phi_min, phi_max) and stored as float32.
@@ -610,8 +610,8 @@ class BeamformedData(FloatMap):
     """Beamformed (beamsummed) data and spatial extent metadata.
 
     Args:
-        pixels: The beamformed data of shape (n_frames, x, z, n_ch) or
-            (n_frames, x, z, y, n_ch) and type float32.
+        pixels: The beamformed data of shape (n_frames, z, x, n_ch) or
+            (n_frames, z, x, y, n_ch) and type float32.
             n_ch is 1 for RF data or 2 for IQ data.
         extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
@@ -625,8 +625,8 @@ class BeamformedData(FloatMap):
         "pixels": {
             "dtype": np.float32,
             "shape": (
-                ("n_frames", "x", "z", "y", "n_ch"),
-                ("n_frames", "x", "z", "n_ch"),
+                ("n_frames", "z", "x", "y", "n_ch"),
+                ("n_frames", "z", "x", "n_ch"),
             ),
         },
         "labels": {"dtype": np.str_, "shape": ("n_ch",)},
@@ -653,8 +653,8 @@ class EnvelopeData(FloatMap):
     """Envelope-detected data and spatial extent metadata.
 
     Args:
-        pixels: The envelope data of shape (n_frames, x, z) or
-            (n_frames, x, z, y) and type float32.
+        pixels: The envelope data of shape (n_frames, z, x) or
+            (n_frames, z, x, y) and type float32.
         extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
             (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
@@ -665,8 +665,8 @@ class EnvelopeData(FloatMap):
         "pixels": {
             "dtype": np.float32,
             "shape": (
-                ("n_frames", "x", "z", "y"),
-                ("n_frames", "x", "z"),
+                ("n_frames", "z", "x", "y"),
+                ("n_frames", "z", "x"),
             ),
         },
     }
@@ -677,8 +677,8 @@ class ImageSc(UnsignedIntMap):
     """Scan-converted image data and spatial extent metadata.
 
     Args:
-        pixels: The scan-converted image of shape (n_frames, x, z) or
-            (n_frames, x, z, y) and type float32.
+        pixels: The scan-converted image of shape (n_frames, z, x) or
+            (n_frames, z, x, y) and type float32.
         extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
             (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
@@ -690,7 +690,7 @@ class SosMap(FloatMap):
     """Speed-of-sound map data and spatial extent metadata.
 
     Args:
-        pixels: The speed-of-sound map pixels in m/s of shape (n_frames, x, z, y)
+        pixels: The speed-of-sound map pixels in m/s of shape (n_frames, z, x, y)
             and type float32.
         extent: The speed-of-sound map extent in meters of shape (n_frames, 6) or (6,).
     """
@@ -714,7 +714,7 @@ class StrainPercentageMap(FloatMap):
     """Strain map data and spatial extent metadata.
 
     Args:
-        pixels: The strain pixels in % of shape (n_frames, x, z, y) and type float32.
+        pixels: The strain pixels in % of shape (n_frames, z, x, y) and type float32.
         extent: The strain extent in meters of shape (n_frames, 6) or (6,).
     """
 
@@ -731,7 +731,7 @@ class ShearWaveElastographyMap(FloatMap):
 
     Args:
         pixels: The shear-wave elastography pixels in m/s of shape
-            (n_frames, x, z, y) and type float32.
+            (n_frames, z, x, y) and type float32.
         extent: The SWE extent in meters of shape (n_frames, 6) or (6,).
     """
 
@@ -747,7 +747,7 @@ class TissueDopplerMap(FloatMap):
     """Tissue Doppler data and spatial extent metadata.
 
     Args:
-        pixels: The tissue Doppler pixels in m/s of shape (n_frames, x, z, y)
+        pixels: The tissue Doppler pixels in m/s of shape (n_frames, z, x, y)
             and type float32.
         extent: The tissue Doppler extent in meters of shape (n_frames, 6) or (6,).
     """
@@ -765,7 +765,7 @@ class ColorDopplerMap(FloatMap):
 
     Args:
         pixels: The color Doppler velocity pixels in m/s of shape
-            (n_frames, x, z, y) and type float32. Positive values
+            (n_frames, z, x, y) and type float32. Positive values
             indicate flow towards the transducer, negative values
             indicate flow away from the transducer.
         extent: The color Doppler extent in meters of shape (n_frames, 6) or (6,).

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -480,7 +480,7 @@ class Map(Spec):
             and type uint8 or float32 or int16.
         extent: The map extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
         labels: The labels corresponding to the `n_ch` channels in the pixels.
             This is required when pixels have an n_ch dimension, and should be None otherwise.
             For IQ data, this would typically be ["I", "Q"].
@@ -581,7 +581,7 @@ class Segmentation(BooleanMap):
         pixels: The segmentation pixels of shape (n_frames, z, x, y, n_labels) and type bool.
         extent: The segmentation extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
         labels: The labels corresponding to the segmentation pixels, where each unique value
             in the pixels corresponds to a label in this list of shape (n_labels,) and type str.
     """
@@ -615,7 +615,7 @@ class BeamformedData(FloatMap):
             n_ch is 1 for RF data or 2 for IQ data.
         extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
         labels: The labels for the channel dimension, e.g. ["RF"] or ["I", "Q"].
             Auto-generated from n_ch if not provided.
     """
@@ -657,7 +657,7 @@ class EnvelopeData(FloatMap):
             (n_frames, z, x, y) and type float32.
         extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
     """
 
     SCHEMA = {
@@ -681,7 +681,7 @@ class ImageSc(UnsignedIntMap):
             (n_frames, z, x, y) and type float32.
         extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
             A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmax, zmin) and stored as float32.
+            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
     """
 
 

--- a/zea/internal/notebooks.py
+++ b/zea/internal/notebooks.py
@@ -16,7 +16,7 @@ def animate_images(
         raise ValueError("images must be a non-empty sequence.")
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
     if scan is not None:
-        extent = scan.extent * 1e3 if getattr(scan, "extent") is not None else None
+        extent = scan.extent(imshow=True) * 1e3 if getattr(scan, "extent") is not None else None
     else:
         extent = None
     im = ax.imshow(np.array(images[0]), animated=True, cmap=cmap, extent=extent)

--- a/zea/internal/notebooks.py
+++ b/zea/internal/notebooks.py
@@ -16,7 +16,7 @@ def animate_images(
         raise ValueError("images must be a non-empty sequence.")
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
     if scan is not None:
-        extent = scan.extent(imshow=True) * 1e3 if getattr(scan, "extent") is not None else None
+        extent = scan.extent_imshow * 1e3 if getattr(scan, "extent_imshow") is not None else None
     else:
         extent = None
     im = ax.imshow(np.array(images[0]), animated=True, cmap=cmap, extent=extent)

--- a/zea/ops/keras_ops.py
+++ b/zea/ops/keras_ops.py
@@ -10,7 +10,7 @@ They can be used in zea pipelines like any other :class:`zea.Operation`, for exa
     >>> op = Squeeze(axis=1)
 
 This file is generated automatically. Do not edit manually.
-Generated with Keras 3.12.0
+Generated with Keras 3.14.0
 """
 
 import keras
@@ -207,6 +207,16 @@ class Array(Lambda):
             super().__init__(func=keras.ops.array, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("Array", "keras.ops.array") from e
+
+@ops_registry("keras.ops.array_split")
+class ArraySplit(Lambda):
+    """Operation wrapping keras.ops.array_split."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.array_split, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("ArraySplit", "keras.ops.array_split") from e
 
 @ops_registry("keras.ops.average")
 class Average(Lambda):
@@ -528,6 +538,16 @@ class Deg2rad(Lambda):
         except AttributeError as e:
             raise MissingKerasOps("Deg2rad", "keras.ops.deg2rad") from e
 
+@ops_registry("keras.ops.depth_to_space")
+class DepthToSpace(Lambda):
+    """Operation wrapping keras.ops.depth_to_space."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.depth_to_space, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("DepthToSpace", "keras.ops.depth_to_space") from e
+
 @ops_registry("keras.ops.det")
 class Det(Lambda):
     """Operation wrapping keras.ops.det."""
@@ -617,6 +637,16 @@ class Elu(Lambda):
             super().__init__(func=keras.ops.elu, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("Elu", "keras.ops.elu") from e
+
+@ops_registry("keras.ops.empty_like")
+class EmptyLike(Lambda):
+    """Operation wrapping keras.ops.empty_like."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.empty_like, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("EmptyLike", "keras.ops.empty_like") from e
 
 @ops_registry("keras.ops.erf")
 class Erf(Lambda):
@@ -718,6 +748,26 @@ class Flip(Lambda):
         except AttributeError as e:
             raise MissingKerasOps("Flip", "keras.ops.flip") from e
 
+@ops_registry("keras.ops.fliplr")
+class Fliplr(Lambda):
+    """Operation wrapping keras.ops.fliplr."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.fliplr, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Fliplr", "keras.ops.fliplr") from e
+
+@ops_registry("keras.ops.flipud")
+class Flipud(Lambda):
+    """Operation wrapping keras.ops.flipud."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.flipud, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Flipud", "keras.ops.flipud") from e
+
 @ops_registry("keras.ops.floor")
 class Floor(Lambda):
     """Operation wrapping keras.ops.floor."""
@@ -727,6 +777,16 @@ class Floor(Lambda):
             super().__init__(func=keras.ops.floor, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("Floor", "keras.ops.floor") from e
+
+@ops_registry("keras.ops.fold")
+class Fold(Lambda):
+    """Operation wrapping keras.ops.fold."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.fold, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Fold", "keras.ops.fold") from e
 
 @ops_registry("keras.ops.full_like")
 class FullLike(Lambda):
@@ -847,6 +907,26 @@ class Histogram(Lambda):
             super().__init__(func=keras.ops.histogram, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("Histogram", "keras.ops.histogram") from e
+
+@ops_registry("keras.ops.hsplit")
+class Hsplit(Lambda):
+    """Operation wrapping keras.ops.hsplit."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.hsplit, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Hsplit", "keras.ops.hsplit") from e
+
+@ops_registry("keras.ops.i0")
+class I0(Lambda):
+    """Operation wrapping keras.ops.i0."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.i0, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("I0", "keras.ops.i0") from e
 
 @ops_registry("keras.ops.ifft2")
 class Ifft2(Lambda):
@@ -1188,6 +1268,136 @@ class NanToNum(Lambda):
         except AttributeError as e:
             raise MissingKerasOps("NanToNum", "keras.ops.nan_to_num") from e
 
+@ops_registry("keras.ops.nanargmax")
+class Nanargmax(Lambda):
+    """Operation wrapping keras.ops.nanargmax."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanargmax, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanargmax", "keras.ops.nanargmax") from e
+
+@ops_registry("keras.ops.nanargmin")
+class Nanargmin(Lambda):
+    """Operation wrapping keras.ops.nanargmin."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanargmin, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanargmin", "keras.ops.nanargmin") from e
+
+@ops_registry("keras.ops.nancumprod")
+class Nancumprod(Lambda):
+    """Operation wrapping keras.ops.nancumprod."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nancumprod, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nancumprod", "keras.ops.nancumprod") from e
+
+@ops_registry("keras.ops.nancumsum")
+class Nancumsum(Lambda):
+    """Operation wrapping keras.ops.nancumsum."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nancumsum, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nancumsum", "keras.ops.nancumsum") from e
+
+@ops_registry("keras.ops.nanmax")
+class Nanmax(Lambda):
+    """Operation wrapping keras.ops.nanmax."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanmax, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanmax", "keras.ops.nanmax") from e
+
+@ops_registry("keras.ops.nanmean")
+class Nanmean(Lambda):
+    """Operation wrapping keras.ops.nanmean."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanmean, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanmean", "keras.ops.nanmean") from e
+
+@ops_registry("keras.ops.nanmedian")
+class Nanmedian(Lambda):
+    """Operation wrapping keras.ops.nanmedian."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanmedian, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanmedian", "keras.ops.nanmedian") from e
+
+@ops_registry("keras.ops.nanmin")
+class Nanmin(Lambda):
+    """Operation wrapping keras.ops.nanmin."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanmin, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanmin", "keras.ops.nanmin") from e
+
+@ops_registry("keras.ops.nanprod")
+class Nanprod(Lambda):
+    """Operation wrapping keras.ops.nanprod."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanprod, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanprod", "keras.ops.nanprod") from e
+
+@ops_registry("keras.ops.nanquantile")
+class Nanquantile(Lambda):
+    """Operation wrapping keras.ops.nanquantile."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanquantile, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanquantile", "keras.ops.nanquantile") from e
+
+@ops_registry("keras.ops.nanstd")
+class Nanstd(Lambda):
+    """Operation wrapping keras.ops.nanstd."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanstd, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanstd", "keras.ops.nanstd") from e
+
+@ops_registry("keras.ops.nansum")
+class Nansum(Lambda):
+    """Operation wrapping keras.ops.nansum."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nansum, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nansum", "keras.ops.nansum") from e
+
+@ops_registry("keras.ops.nanvar")
+class Nanvar(Lambda):
+    """Operation wrapping keras.ops.nanvar."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.nanvar, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Nanvar", "keras.ops.nanvar") from e
+
 @ops_registry("keras.ops.ndim")
 class Ndim(Lambda):
     """Operation wrapping keras.ops.ndim."""
@@ -1278,6 +1488,16 @@ class Prod(Lambda):
         except AttributeError as e:
             raise MissingKerasOps("Prod", "keras.ops.prod") from e
 
+@ops_registry("keras.ops.ptp")
+class Ptp(Lambda):
+    """Operation wrapping keras.ops.ptp."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.ptp, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Ptp", "keras.ops.ptp") from e
+
 @ops_registry("keras.ops.qr")
 class Qr(Lambda):
     """Operation wrapping keras.ops.qr."""
@@ -1297,6 +1517,16 @@ class Quantile(Lambda):
             super().__init__(func=keras.ops.quantile, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("Quantile", "keras.ops.quantile") from e
+
+@ops_registry("keras.ops.rad2deg")
+class Rad2deg(Lambda):
+    """Operation wrapping keras.ops.rad2deg."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.rad2deg, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Rad2deg", "keras.ops.rad2deg") from e
 
 @ops_registry("keras.ops.ravel")
 class Ravel(Lambda):
@@ -1508,6 +1738,16 @@ class Sin(Lambda):
         except AttributeError as e:
             raise MissingKerasOps("Sin", "keras.ops.sin") from e
 
+@ops_registry("keras.ops.sinc")
+class Sinc(Lambda):
+    """Operation wrapping keras.ops.sinc."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.sinc, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Sinc", "keras.ops.sinc") from e
+
 @ops_registry("keras.ops.sinh")
 class Sinh(Lambda):
     """Operation wrapping keras.ops.sinh."""
@@ -1587,6 +1827,16 @@ class Sort(Lambda):
             super().__init__(func=keras.ops.sort, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("Sort", "keras.ops.sort") from e
+
+@ops_registry("keras.ops.space_to_depth")
+class SpaceToDepth(Lambda):
+    """Operation wrapping keras.ops.space_to_depth."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.space_to_depth, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("SpaceToDepth", "keras.ops.space_to_depth") from e
 
 @ops_registry("keras.ops.sparse_plus")
 class SparsePlus(Lambda):
@@ -1888,6 +2138,16 @@ class Unstack(Lambda):
         except AttributeError as e:
             raise MissingKerasOps("Unstack", "keras.ops.unstack") from e
 
+@ops_registry("keras.ops.vander")
+class Vander(Lambda):
+    """Operation wrapping keras.ops.vander."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.vander, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Vander", "keras.ops.vander") from e
+
 @ops_registry("keras.ops.var")
 class Var(Lambda):
     """Operation wrapping keras.ops.var."""
@@ -1927,6 +2187,16 @@ class ViewAsReal(Lambda):
             super().__init__(func=keras.ops.view_as_real, **kwargs)
         except AttributeError as e:
             raise MissingKerasOps("ViewAsReal", "keras.ops.view_as_real") from e
+
+@ops_registry("keras.ops.vsplit")
+class Vsplit(Lambda):
+    """Operation wrapping keras.ops.vsplit."""
+
+    def __init__(self, **kwargs):
+        try:
+            super().__init__(func=keras.ops.vsplit, **kwargs)
+        except AttributeError as e:
+            raise MissingKerasOps("Vsplit", "keras.ops.vsplit") from e
 
 @ops_registry("keras.ops.zeros_like")
 class ZerosLike(Lambda):

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -413,18 +413,9 @@ class Scan(Parameters):
         return zlims
 
     @cache_with_dependencies("grid", "grid_type", "distance_to_apex")
-    def extent(self, imshow=False):
-        """The extent of the beamforming grid in the format: (xmin, xmax, ymin, ymax, zmin, zmax).
-
-        Args:
-            imshow (bool): Whether to return extent in the format compatible with ``plt.imshow``
-                for 2D grids, allowing direct use via ``extent=scan.extent(imshow=True)`` .
-                In this case, the extent is returned as (xmin, xmax, zmax, zmin).
-
-        Returns:
-            np.ndarray: The extent of the beamforming grid in the format
-            (xmin, xmax, ymin, ymax, zmin, zmax) or (xmin, xmax, zmax, zmin)
-            if imshow=True.
+    def extent(self):
+        """
+        The extent of the beamforming grid in the format: (xmin, xmax, ymin, ymax, zmin, zmax).
         """
         xlims = (self.grid[:, :, 0].min(), self.grid[:, :, 0].max())
         ylims = (self.grid[:, :, 1].min(), self.grid[:, :, 1].max())
@@ -433,11 +424,6 @@ class Scan(Parameters):
         # For polar grids, adjust zlims to account for distance to apex
         if self.grid_type == "polar":
             zlims = (zlims[0] + self.distance_to_apex, zlims[1])
-
-        if imshow:
-            if ylims[0] != ylims[1]:
-                log.warning("Are you sure you want to use 2D imshow extent for a 3D grid?")
-            return np.array([xlims[0], xlims[1], zlims[1], zlims[0]])
 
         return np.array(
             [
@@ -449,6 +435,19 @@ class Scan(Parameters):
                 zlims[1],
             ]
         )
+
+    @cache_with_dependencies("extent")
+    def extent_imshow(self):
+        """The extent of the beamforming grid in the format: (xmin, xmax, ymin, ymax, zmin, zmax).
+
+        Returns:
+            np.ndarray: The extent of the beamforming grid in the format (xmin, xmax, zmax, zmin).
+                This format can be used directly in matplotlib's ``plt.imshow``.
+        """
+        xlims_0, xlims_1, ylims_0, ylims_1, zlims_0, zlims_1 = self.extent
+        if ylims_0 != ylims_1:
+            log.warning("Are you sure you want to use 2D imshow extent for a 3D grid?")
+        return np.array([xlims_0, xlims_1, zlims_1, zlims_0])
 
     @cache_with_dependencies("grid")
     def flatgrid(self):

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -422,7 +422,7 @@ class Scan(Parameters):
         Args:
             imshow (bool): Whether to return extent in the format compatible with
             `plt.imshow` for 2D grids, allowing direct use via
-            `plt.imshow(x, extent=scan.extent)`. In this case, the extent
+            `plt.imshow(x, extent=scan.extent(imshow=True))`. In this case, the extent
             is returned as (xmin, xmax, zmax, zmin).
 
         Returns:

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -413,18 +413,46 @@ class Scan(Parameters):
         return zlims
 
     @cache_with_dependencies("grid", "grid_type", "distance_to_apex")
-    def extent(self):
-        """The extent of the beamforming grid in the format (xmin, xmax, zmax, zmin).
-        Can be directly used with `plt.imshow(x, extent=scan.extent)` for visualization.
+    def extent(self, imshow=False):
+        """The extent of the beamforming grid in the format: (xmin, xmax, ymin, ymax, zmin, zmax).
+
+        An optional bool parameter "imshow" can be passed to return an extent
+        (xmin, xmax, zmax, zmin) compatible with `plt.imshow` for 2D grids.
+
+        Args:
+            imshow (bool): Whether to return extent in the format compatible with
+            `plt.imshow` for 2D grids, allowing direct use via
+            `plt.imshow(x, extent=scan.extent)`. In this case, the extent
+            is returned as (xmin, xmax, zmax, zmin).
+
+        Returns:
+            np.ndarray: The extent of the beamforming grid in the format
+            (xmin, xmax, ymin, ymax, zmin, zmax) or (xmin, xmax, zmax, zmin)
+            if imshow=True.
         """
         xlims = (self.grid[:, :, 0].min(), self.grid[:, :, 0].max())
+        ylims = (self.grid[:, :, 1].min(), self.grid[:, :, 1].max())
         zlims = (self.grid[:, :, 2].min(), self.grid[:, :, 2].max())
 
         # For polar grids, adjust zlims to account for distance to apex
         if self.grid_type == "polar":
             zlims = (zlims[0] + self.distance_to_apex, zlims[1])
 
-        return np.array([xlims[0], xlims[1], zlims[1], zlims[0]])
+        if imshow:
+            if ylims[0] != ylims[1]:
+                log.warning("Are you sure you want to use 2D imshow extent for a 3D grid?")
+            return np.array([xlims[0], xlims[1], zlims[1], zlims[0]])
+
+        return np.array(
+            [
+                xlims[0],
+                xlims[1],
+                ylims[0],
+                ylims[1],
+                zlims[0],
+                zlims[1],
+            ]
+        )
 
     @cache_with_dependencies("grid")
     def flatgrid(self):

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -417,9 +417,9 @@ class Scan(Parameters):
         """
         The extent of the beamforming grid in the format: (xmin, xmax, ymin, ymax, zmin, zmax).
         """
-        xlims = (self.grid[:, :, 0].min(), self.grid[:, :, 0].max())
-        ylims = (self.grid[:, :, 1].min(), self.grid[:, :, 1].max())
-        zlims = (self.grid[:, :, 2].min(), self.grid[:, :, 2].max())
+        xlims = (self.grid[..., 0].min(), self.grid[..., 0].max())
+        ylims = (self.grid[..., 1].min(), self.grid[..., 1].max())
+        zlims = (self.grid[..., 2].min(), self.grid[..., 2].max())
 
         # For polar grids, adjust zlims to account for distance to apex
         if self.grid_type == "polar":

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -416,14 +416,10 @@ class Scan(Parameters):
     def extent(self, imshow=False):
         """The extent of the beamforming grid in the format: (xmin, xmax, ymin, ymax, zmin, zmax).
 
-        An optional bool parameter "imshow" can be passed to return an extent
-        (xmin, xmax, zmax, zmin) compatible with `plt.imshow` for 2D grids.
-
         Args:
-            imshow (bool): Whether to return extent in the format compatible with
-            `plt.imshow` for 2D grids, allowing direct use via
-            `plt.imshow(x, extent=scan.extent(imshow=True))`. In this case, the extent
-            is returned as (xmin, xmax, zmax, zmin).
+            imshow (bool): Whether to return extent in the format compatible with ``plt.imshow``
+                for 2D grids, allowing direct use via ``extent=scan.extent(imshow=True)`` .
+                In this case, the extent is returned as (xmin, xmax, zmax, zmin).
 
         Returns:
             np.ndarray: The extent of the beamforming grid in the format


### PR DESCRIPTION
For https://github.com/tue-bmd/zea/pull/307, addresses:
> Fix 3D extend for default post beamformed spatial maps

Two changes: 
1) updates the comments / docs regarding the coordinate ordering for spatial `Map`s so that they match zea grids, which are based on matrix / matplotlib conventions ([row, then column](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html#:~:text=The%20first%20two%20dimensions%20(M%2C%20N)%20define%20the%20rows%20and%20columns%20of%20the%20image.)), i.e. (z, x, y) rather than (x, y, z). 
2) for `extent`, we were previously defining `scan.extent` to match matplotlib imshow too, which is somewhat strangely defined as ([left, right, bottom, top](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html#:~:text=floats%20(left%2C%20right%2C%20bottom%2C%20top))), which translates to (xmin, xmax, **zmax, zmin**), since imshow flips the z direction. Since matplotlib doesn't have a 3D extent, I thought it could be confusing for us to define our extent based on this (would it then become (xmin, xmax, zmax, zmin, ymin, ymax)? there isn't even an imshow-like function that this would be compatible with!). In light of this, I've updated our `Scan.extent` to by default return a straightforward 3D extent (xmin, xmax, ymin, ymax, zmin, zmax), but with a new function 'extent_imshow'  that returns the old behaviour. Curious what your thoughts are on this.


(P.S. this also moves the autogen'd pre-commit code back to keras 3.14, I accidentally pushed with 3.12 in a previous commit)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated spatial map pipeline documentation to reflect corrected axis ordering across beamformed data, image, and segmentation types.

* **New Features**
  * Added 25+ new Keras operations including array manipulation, statistical, and transformation functions.
  * Enhanced extent computation with new visualization mode parameter.

* **Bug Fixes**
  * Corrected coordinate system interpretation in example documentation and notebooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->