### PR TITLE
Release v0.0.13

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as follows:"
 title: "zea: A Toolbox for Cognitive Ultrasound Imaging"
-version: 0.0.12
+version: 0.0.13
 doi: 10.48550/arXiv.2512.01433
 date-released: 2026-04-20
 repository-code: https://github.com/tue-bmd/zea

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "zea"
-version = "0.0.12"
+version = "0.0.13"
 description = "A Toolbox for Cognitive Ultrasound Imaging. Provides a set of tools for processing of ultrasound data, all built in your favorite machine learning framework."
 authors = [
     { name = "Tristan Stevens", email = "t.s.w.stevens@tue.nl" },


### PR DESCRIPTION
Version bump to v0.0.13

## What's Changed
* Bump ruff from 0.15.10 to 0.15.11 in the python-packages group across 1 directory by @dependabot[bot] in https://github.com/tue-bmd/zea/pull/326
* Don't downgrade `keras_ops.py` when developer uses older Keras version by @Copilot in https://github.com/tue-bmd/zea/pull/325
* Fix protobuf version mismatch warning when importing zea with JAX by @Copilot in https://github.com/tue-bmd/zea/pull/332
* Change docker build arg defaults by @Copilot in https://github.com/tue-bmd/zea/pull/334
* Nuclear diffusion for cardiac ultrasound dehazing by @tristan-deep in https://github.com/tue-bmd/zea/pull/335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.0.13

<!-- end of auto-generated comment: release notes by coderabbit.ai -->