### PR TITLE
Dataloader: adds shape attribute and seeds pipeline

### DIFF
--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -22,6 +22,7 @@ from .. import DEFAULT_TEST_SEED
 CAMUS_DATASET_PATH = HFPath("hf://zeahub/camus-sample")
 CAMUS_FILE = CAMUS_DATASET_PATH / "val/patient0401/patient0401_4CH_half_sequence.hdf5"
 DUMMY_IMAGE_SHAPE = (28, 28)
+DUMMY_N_FRAMES = 100
 
 
 @pytest.fixture
@@ -30,7 +31,7 @@ def dummy_hdf5(tmp_path):
     file_path = tmp_path / "dummy_data.hdf5"
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
     with h5py.File(file_path, "w") as f:
-        data = rng.standard_normal((100, *DUMMY_IMAGE_SHAPE))
+        data = rng.standard_normal((DUMMY_N_FRAMES, *DUMMY_IMAGE_SHAPE))
         f.create_dataset("data", data=data)
     return file_path
 
@@ -208,7 +209,7 @@ def test_dataloader(
     shuffle_keys = []
     for _ in range(n_shuffle_iters):
         h = ""
-        for batch in iter(dataset):
+        for batch in dataset:
             key = hashlib.md5(pickle.dumps(batch)).hexdigest()
             h += key
         shuffle_keys.append(h)
@@ -691,3 +692,46 @@ def test_summary(dummy_hdf5, capsys):
     captured = capsys.readouterr()
     assert "Dataloader with" in captured.out
     assert "samples" in captured.out
+
+
+def test_shape_attribute(dummy_hdf5):
+    """Test that the shape attribute is set correctly."""
+
+    # Without returning filenames
+    loader = Dataloader(
+        dummy_hdf5,
+        key="data",
+        shuffle=False,
+        validate=False,
+        batch_size=1,
+    )
+    batch = next(iter(loader))
+    assert batch.shape == (1, *DUMMY_IMAGE_SHAPE, 1)
+    assert loader.shape == (1, *DUMMY_IMAGE_SHAPE, 1)
+
+    # With returning filenames
+    loader = Dataloader(
+        dummy_hdf5,
+        key="data",
+        shuffle=False,
+        validate=False,
+        batch_size=1,
+        return_filename=True,
+    )
+    batch = next(iter(loader))
+    assert batch[0].shape == (1, *DUMMY_IMAGE_SHAPE, 1)
+    assert loader.shape == (1, *DUMMY_IMAGE_SHAPE, 1)
+
+
+def test_len_attribute(dummy_hdf5):
+    """Test that the len attribute is set correctly."""
+
+    # Without returning filenames
+    loader = Dataloader(
+        dummy_hdf5,
+        key="data",
+        shuffle=False,
+        validate=False,
+        batch_size=1,
+    )
+    assert len(loader) == DUMMY_N_FRAMES

--- a/zea/data/dataloader.py
+++ b/zea/data/dataloader.py
@@ -370,8 +370,8 @@ class Dataloader:
         shuffle: Shuffle dataset each epoch. Default is ``True``.
         return_filename: Return filename metadata together with each sample.
             Default is ``False``.
-        seed: Random seed used for shuffling. Default is ``None``.
-            If ``None`` and ``shuffle=True``, a random seed is generated.
+        seed: Random seed used for dataloader (e.g. shuffling). Default is ``None``.
+            If ``None`` a random seed is generated.
         limit_n_samples: Limit total number of samples (useful for debugging).
             Default is ``None`` (no limit).
         limit_n_frames: Limit frames loaded per file to the first N frames.
@@ -502,7 +502,7 @@ class Dataloader:
         self.shuffle = shuffle
 
         # Grain requires a concrete seed for shuffle — generate one if needed
-        if seed is None and shuffle:
+        if seed is None:
             seed = int(np.random.default_rng().integers(0, 2**31))
         self.seed = seed
         self._rng = np.random.default_rng(seed)
@@ -559,8 +559,13 @@ class Dataloader:
 
         self._map_dataset = self._build_pipeline(seed)
 
+        if return_filename:
+            self._shape = self._map_dataset[0][0].shape
+        else:
+            self._shape = self._map_dataset[0].shape
+
     def _build_pipeline(self, seed: int):
-        """Build the Grain MapDataset pipeline with the given shuffle seed."""
+        """Build the Grain MapDataset pipeline with the given seed."""
         cfg = self._pipeline_cfg
 
         def _ds_map(ds, fn):
@@ -569,6 +574,9 @@ class Dataloader:
             return ds.map(fn)
 
         ds = grain.MapDataset.source(self.source)
+
+        # Set the seed for the whole pipeline
+        ds = ds.seed(seed)
 
         if self.shuffle:
             ds = ds.shuffle(seed=seed)
@@ -609,7 +617,12 @@ class Dataloader:
         """The underlying ``grain.MapDataset``."""
         return self._map_dataset
 
-    def to_iter_dataset(self):
+    @property
+    def shape(self):
+        """Output shape of one batch (or sample if unbatched)."""
+        return self._shape
+
+    def to_iter_dataset(self) -> grain.IterDataset:
         """Convert to a ``grain.IterDataset`` with prefetching.
 
         This is called automatically when you iterate, but you can call


### PR DESCRIPTION
Dataloader now has shape attribute to get the shape and the `grain.MapDataset` is seeded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dataloader now exposes a `shape` property to retrieve output dimensions for batch samples.

* **Bug Fixes**
  * Improved seed handling to ensure consistent pipeline determinism across all configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->