### PR TITLE
Refactor ProbeOrientation to ProbePose and offset description

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -824,38 +824,38 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
          * - ``credit``
            - ``str``
            - scalar
-           - –
-           - 
+           - -
+           - Credit or attribution for the dataset.
            - |badge-opt|
-         * - ``probe_orientation``
-           - :class:`~zea.data.spec.ProbeOrientation`
+         * - ``probe_pose``
+           - :class:`~zea.data.spec.ProbePose`
            - group
-           - –
-           - 
+           - -
+           - Sampled probe pose at the transducer tip.
            - |badge-opt|
          * - ``voice_narration``
            - :class:`~zea.data.spec.Signal1D`
            - group
-           - –
-           - 
+           - -
+           - Voice narration signal.
            - |badge-opt|
          * - ``ecg``
            - :class:`~zea.data.spec.Signal1D`
            - group
-           - –
-           - 
+           - -
+           - Electrocardiogram signal.
            - |badge-opt|
          * - ``text_report``
            - ``str``
            - scalar
-           - –
-           - 
+           - -
+           - Free-text report associated with the study.
            - |badge-opt|
          * - ``annotations``
            - :class:`~zea.data.spec.Annotations`
            - group
-           - –
-           - 
+           - -
+           - Frame-level annotations.
            - |badge-opt|
 
       **Sub-groups**
@@ -935,33 +935,49 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - |badge-opt|
 
 
-      .. dropdown:: ``probe_orientation`` — ProbeOrientation
+      .. dropdown:: ``probe_pose`` — ProbePose
 
-         Probe pose and timing metadata.
+         Sampled probe pose metadata at the tip of the transducer.
 
          .. list-table::
             :header-rows: 1
-            :widths: 22 20 28 10 10
+            :widths: 22 16 18 7 27 10
          
             * - Field
               - Type
               - Shape
               - Unit
+              - Description
               - 
-            * - ``pose``
+            * - ``translation``
               - ``float32``
-              - (T, 6)
-              - –
+              - (T, 3)
+              - m
+              - Position of the transducer tip, ordered as (x, y, z), where x is lateral along the transducer, y is elevation (out of plane), and z is axial (depth).
               - |badge-req|
-            * - ``offset``
+            * - ``rotation``
+              - ``float32``
+              - (T, 3) or (T, 4)
+              - -
+              - Orientation associated with the transducer-tip pose in the x-lateral, y-elevation, z-axial coordinate convention, interpreted according to rotation_representation.
+              - |badge-req|
+            * - ``rotation_representation``
+              - ``str``
+              - scalar
+              - -
+              - Rotation parameterization: one of euler_xyz, quaternion_wxyz, or quaternion_xyzw.
+              - |badge-req|
+            * - ``start_time_offset``
               - ``float32``
               - scalar
-              - –
+              - s
+              - Time offset between the first transmit event of the ultrasound acquisition and sample 0 of this data. Negative means this data starts before the first transmit event; positive means it starts after.
               - |badge-req|
             * - ``sampling_frequency``
               - ``float32``
               - scalar
-              - –
+              - Hz
+              - Sampling frequency.
               - |badge-req|
 
 
@@ -971,27 +987,31 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
          .. list-table::
             :header-rows: 1
-            :widths: 22 20 28 10 10
+            :widths: 22 16 18 7 27 10
          
             * - Field
               - Type
               - Shape
               - Unit
+              - Description
               - 
             * - ``samples``
               - ``uint8`` | ``float32`` | ``int16`` | ``complex64``
               - (T)
-              - –
+              - -
+              - Signal samples.
               - |badge-req|
-            * - ``offset``
+            * - ``start_time_offset``
               - ``float32``
               - scalar
-              - –
+              - s
+              - Time offset between the first transmit event of the ultrasound acquisition and sample 0 of this data. Negative means this data starts before the first transmit event; positive means it starts after.
               - |badge-req|
             * - ``sampling_frequency``
               - ``float32``
               - scalar
-              - –
+              - Hz
+              - Sampling frequency.
               - |badge-req|
 
 

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -26,7 +26,7 @@ from zea.data.spec import (
     ImageSc,
     MetadataSpec,
     MetricsSpec,
-    ProbeOrientation,
+    ProbePose,
     ScanSpec,
     Segmentation,
     ShearWaveElastographyMap,
@@ -422,14 +422,19 @@ def generate() -> str:
         "",
     ]
     meta_subs = [
-        ("subject", Subject),
-        ("annotations", Annotations),
-        ("probe_orientation", ProbeOrientation),
-        ("ecg / voice_narration", Signal1D),
+        ("subject", Subject, True),
+        ("annotations", Annotations, True),
+        ("probe_pose", ProbePose, False),
+        ("ecg / voice_narration", Signal1D, False),
     ]
-    for label, cls in meta_subs:
+    for label, cls, compact in meta_subs:
         lines += [
-            rst_dropdown(cls, f"``{label}`` \u2014 {cls.__name__}", base_indent=2, compact=True),
+            rst_dropdown(
+                cls,
+                f"``{label}`` \u2014 {cls.__name__}",
+                base_indent=2,
+                compact=compact,
+            ),
             "",
         ]
 

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -687,9 +687,16 @@ class TestMetadataMetricsAccessors:
         metadata = {
             "subject": {"id": "patient_01", "type": "human", "age": np.uint8(30), "sex": "f"},
             "credit": "Test Lab",
+            "probe_pose": {
+                "translation": np.zeros((25, 3), dtype=np.float32),
+                "rotation": np.zeros((25, 4), dtype=np.float32),
+                "rotation_representation": "quaternion_wxyz",
+                "start_time_offset": np.float32(-0.1),
+                "sampling_frequency": np.float32(50.0),
+            },
             "ecg": {
                 "samples": rng.standard_normal(100).astype(np.float32),
-                "offset": np.float32(0.0),
+                "start_time_offset": np.float32(0.0),
                 "sampling_frequency": np.float32(500.0),
             },
             "annotations": {
@@ -710,7 +717,12 @@ class TestMetadataMetricsAccessors:
             assert meta.subject.id == "patient_01"
             assert meta.subject.age == 30
             assert meta.credit == "Test Lab"
+            assert meta.probe_pose.translation.shape == (25, 3)
+            assert meta.probe_pose.rotation.shape == (25, 4)
+            assert meta.probe_pose.rotation_representation == "quaternion_wxyz"
+            assert meta.probe_pose.start_time_offset == np.float32(-0.1)
             assert meta.ecg.samples.shape == (100,)
+            assert meta.ecg.start_time_offset == np.float32(0.0)
             np.testing.assert_array_equal(meta.annotations.view, ["a4c"] * n_frames)
 
     def test_metrics_round_trip(self, tmp_path):

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -648,7 +648,9 @@ class TestProbePoseValidation:
             )
 
     def test_probe_pose_rejects_mismatched_time_dimension(self):
-        with pytest.raises(ValueError, match="translation and rotation must have the same number of time samples"):
+        with pytest.raises(
+            ValueError, match="translation and rotation must have the same number of time samples"
+        ):
             ProbePose(
                 translation=np.zeros((25, 3), dtype=np.float32),
                 rotation=np.zeros((24, 3), dtype=np.float32),

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -11,6 +11,7 @@ from zea.data.spec import (
     Image,
     Map,
     MetricsSpec,
+    ProbePose,
     ScanSpec,
     Segmentation,
     Signal1D,
@@ -64,19 +65,21 @@ def _example_metadata():
             "fat_percentage": np.float32(17.5),
         },
         "credit": "example-lab",
-        "probe_orientation": {
-            "pose": np.zeros((25, 6), dtype=np.float32),
-            "offset": np.float32(0.0),
+        "probe_pose": {
+            "translation": np.zeros((25, 3), dtype=np.float32),
+            "rotation": np.zeros((25, 3), dtype=np.float32),
+            "rotation_representation": "euler_xyz",
+            "start_time_offset": np.float32(0.0),
             "sampling_frequency": np.float32(50.0),
         },
         "voice_narration": {
             "samples": np.zeros((100), dtype=np.uint8),
-            "offset": np.float32(0.0),
+            "start_time_offset": np.float32(0.0),
             "sampling_frequency": np.float32(8000.0),
         },
         "ecg": {
             "samples": np.zeros((100), dtype=np.uint8),
-            "offset": np.float32(0.0),
+            "start_time_offset": np.float32(0.0),
             "sampling_frequency": np.float32(250.0),
         },
         "text_report": "normal acquisition",
@@ -216,7 +219,7 @@ def test_scan_dimension_count_consistency():
 def test_signal_nd_accepts_variable_trailing_dimensions_with_ellipsis():
     signal = SignalND(
         samples=np.zeros((10, 3, 4, 5), dtype=np.float32),
-        offset=np.float32(0.0),
+        start_time_offset=np.float32(0.0),
         sampling_frequency=np.float32(1000.0),
     )
 
@@ -227,7 +230,7 @@ def test_signal_nd_rejects_missing_time_dimension_for_ellipsis_shape():
     with pytest.raises(ValueError, match=r"samples has shape \(\), expected one of"):
         SignalND(
             samples=np.array(1.0, dtype=np.float32),
-            offset=np.float32(0.0),
+            start_time_offset=np.float32(0.0),
             sampling_frequency=np.float32(1000.0),
         )
 
@@ -314,7 +317,7 @@ def test_metadata_accepts_custom_signal_nd_keys_and_warns():
             metadata={
                 "custom_signal": {
                     "samples": np.zeros((32, 3), dtype=np.float16),
-                    "offset": np.float32(0.0),
+                    "start_time_offset": np.float32(0.0),
                     "sampling_frequency": np.float32(120.0),
                 }
             },
@@ -552,9 +555,9 @@ class TestMetadataAndMetricsValidationErrors:
             Subject(age="forty two")
 
     def test_signal_missing_required_field_raises(self):
-        """Signal1D requires both offset and sampling_frequency."""
+        """Signal1D requires both start_time_offset and sampling_frequency."""
         with pytest.raises(TypeError, match="sampling_frequency"):
-            Signal1D(samples=np.zeros(100, dtype=np.float32), offset=np.float32(0.0))
+            Signal1D(samples=np.zeros(100, dtype=np.float32), start_time_offset=np.float32(0.0))
 
     def test_metrics_wrong_shape_raises(self):
         """coherence_factor must be 1-D (n_frames,), not 2-D."""
@@ -578,3 +581,103 @@ class TestMetadataAndMetricsValidationErrors:
                     }
                 },
             )
+
+
+class TestProbePoseValidation:
+    def test_probe_pose_accepts_euler_xyz(self):
+        pose = ProbePose(
+            translation=np.zeros((25, 3), dtype=np.float32),
+            rotation=np.zeros((25, 3), dtype=np.float32),
+            rotation_representation="euler_xyz",
+            start_time_offset=np.float32(-0.1),
+            sampling_frequency=np.float32(50.0),
+        )
+
+        assert pose.translation.shape == (25, 3)
+        assert pose.rotation.shape == (25, 3)
+
+    def test_probe_pose_accepts_quaternion_wxyz(self):
+        pose = ProbePose(
+            translation=np.zeros((25, 3), dtype=np.float32),
+            rotation=np.zeros((25, 4), dtype=np.float32),
+            rotation_representation="quaternion_wxyz",
+            start_time_offset=np.float32(0.2),
+            sampling_frequency=np.float32(50.0),
+        )
+
+        assert pose.rotation.shape == (25, 4)
+
+    def test_probe_pose_accepts_quaternion_xyzw(self):
+        pose = ProbePose(
+            translation=np.zeros((25, 3), dtype=np.float32),
+            rotation=np.zeros((25, 4), dtype=np.float32),
+            rotation_representation="quaternion_xyzw",
+            start_time_offset=np.float32(0.2),
+            sampling_frequency=np.float32(50.0),
+        )
+
+        assert pose.rotation.shape == (25, 4)
+
+    def test_probe_pose_requires_rotation_representation(self):
+        with pytest.raises(TypeError, match="rotation_representation"):
+            ProbePose(
+                translation=np.zeros((25, 3), dtype=np.float32),
+                rotation=np.zeros((25, 3), dtype=np.float32),
+                start_time_offset=np.float32(0.0),
+                sampling_frequency=np.float32(50.0),
+            )
+
+    def test_probe_pose_rejects_euler_with_quaternion_width(self):
+        with pytest.raises(ValueError, match="rotation shape does not match"):
+            ProbePose(
+                translation=np.zeros((25, 3), dtype=np.float32),
+                rotation=np.zeros((25, 4), dtype=np.float32),
+                rotation_representation="euler_xyz",
+                start_time_offset=np.float32(0.0),
+                sampling_frequency=np.float32(50.0),
+            )
+
+    def test_probe_pose_rejects_quaternion_with_euler_width(self):
+        with pytest.raises(ValueError, match="rotation shape does not match"):
+            ProbePose(
+                translation=np.zeros((25, 3), dtype=np.float32),
+                rotation=np.zeros((25, 3), dtype=np.float32),
+                rotation_representation="quaternion_wxyz",
+                start_time_offset=np.float32(0.0),
+                sampling_frequency=np.float32(50.0),
+            )
+
+    def test_probe_pose_rejects_mismatched_time_dimension(self):
+        with pytest.raises(ValueError, match="translation and rotation must have the same number of time samples"):
+            ProbePose(
+                translation=np.zeros((25, 3), dtype=np.float32),
+                rotation=np.zeros((24, 3), dtype=np.float32),
+                rotation_representation="euler_xyz",
+                start_time_offset=np.float32(0.0),
+                sampling_frequency=np.float32(50.0),
+            )
+
+    def test_probe_pose_rejects_non_positive_sampling_frequency(self):
+        with pytest.raises(ValueError, match="Sampling frequency must be positive"):
+            ProbePose(
+                translation=np.zeros((25, 3), dtype=np.float32),
+                rotation=np.zeros((25, 3), dtype=np.float32),
+                rotation_representation="euler_xyz",
+                start_time_offset=np.float32(0.0),
+                sampling_frequency=np.float32(0.0),
+            )
+
+    def test_signal_accepts_negative_and_positive_start_time_offset(self):
+        negative = Signal1D(
+            samples=np.zeros(10, dtype=np.float32),
+            start_time_offset=np.float32(-0.25),
+            sampling_frequency=np.float32(1000.0),
+        )
+        positive = SignalND(
+            samples=np.zeros((10, 2), dtype=np.float32),
+            start_time_offset=np.float32(0.25),
+            sampling_frequency=np.float32(1000.0),
+        )
+
+        assert negative.start_time_offset < 0
+        assert positive.start_time_offset > 0

--- a/zea/data/file_operations.py
+++ b/zea/data/file_operations.py
@@ -84,7 +84,7 @@ def save_file(
         metadata (dict, optional): Metadata to store in the ``metadata`` group, validated against
             :class:`~zea.data.spec.MetadataSpec`.  Standard keys include ``"subject"``,
             ``"credit"``, ``"annotations"``, ``"text_report"``, ``"ecg"``,
-            ``"probe_orientation"``, and ``"voice_narration"``.  Custom signal keys are also
+            ``"probe_pose"``, and ``"voice_narration"``.  Custom signal keys are also
             accepted and stored as :class:`~zea.data.spec.SignalND` entries.  Example::
 
                 metadata = {

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1218,19 +1218,35 @@ class Subject(Spec):
 
 @dataclass
 class Signal(Spec):
-    """Base class for additional signals with timing offset and sampling frequency metadata.
+    """Base class for additional signals with timing and sampling-frequency metadata.
 
     Args:
-        offset: Time offset in seconds relative to frame timing.
+        start_time_offset: Time offset in seconds between the first transmit event
+            of the ultrasound acquisition and sample 0 of this data. Negative
+            means this data starts before the first transmit event; positive
+            means it starts after.
         sampling_frequency: Sampling frequency in Hz for the additional signal samples.
     """
 
-    offset: np.ndarray | float
+    start_time_offset: np.ndarray | float
     sampling_frequency: np.ndarray | float
 
     SCHEMA = {
-        "offset": {"dtype": np.float32, "shape": ()},
+        "start_time_offset": {"dtype": np.float32, "shape": ()},
         "sampling_frequency": {"dtype": np.float32, "shape": ()},
+    }
+
+    FIELD_METADATA = {
+        "start_time_offset": {
+            "unit": "s",
+            "description": (
+                "Time offset between the first transmit event of the ultrasound "
+                "acquisition and sample 0 of this data. Negative means this data "
+                "starts before the first transmit event; positive means it starts "
+                "after."
+            ),
+        },
+        "sampling_frequency": {"unit": "Hz", "description": "Sampling frequency."},
     }
 
     def __post_init__(self):
@@ -1241,21 +1257,88 @@ class Signal(Spec):
 
 
 @dataclass
-class ProbeOrientation(Signal):
-    """Probe pose and timing metadata.
+class ProbePose(Signal):
+    """Sampled probe pose metadata at the tip of the transducer.
+
+    The pose uses the coordinate convention x = lateral along the transducer,
+    y = elevation (out of plane), and z = axial (depth).
 
     Args:
-        pose: Probe pose in meters of shape (T, 6), ordered as (x, y, z, az, el, roll).
-        offset: Time offset in seconds relative to frame timing.
-        sampling_frequency: Sampling frequency in Hz for probe orientation samples.
+        translation: Position of the transducer tip in meters of shape (T, 3),
+            ordered as (x, y, z).
+        rotation: Orientation of the transducer tip of shape (T, 3) or (T, 4),
+            interpreted according to ``rotation_representation``.
+        rotation_representation: Rotation parameterization. Supported values are
+            ``"euler_xyz"``, ``"quaternion_wxyz"``, and ``"quaternion_xyzw"``.
+        start_time_offset: Time offset in seconds between the first transmit event
+            of the ultrasound acquisition and sample 0 of this data.
+        sampling_frequency: Sampling frequency in Hz for probe pose samples.
     """
 
-    pose: np.ndarray
+    translation: np.ndarray
+    rotation: np.ndarray
+    rotation_representation: str
 
     SCHEMA = {
-        "pose": {"dtype": np.float32, "shape": ("T", 6)},
+        "translation": {"dtype": np.float32, "shape": ("T", 3)},
+        "rotation": {"dtype": np.float32, "shape": (("T", 3), ("T", 4))},
+        "rotation_representation": {"dtype": str, "shape": ()},
         **Signal.SCHEMA,
     }
+
+    FIELD_METADATA = {
+        "translation": {
+            "unit": "m",
+            "description": (
+                "Position of the transducer tip, ordered as (x, y, z), where x is "
+                "lateral along the transducer, y is elevation (out of plane), and "
+                "z is axial (depth)."
+            ),
+        },
+        "rotation": {
+            "unit": "-",
+            "description": (
+                "Orientation associated with the transducer-tip pose in the "
+                "x-lateral, y-elevation, z-axial coordinate convention, interpreted "
+                "according to rotation_representation."
+            ),
+        },
+        "rotation_representation": {
+            "unit": "-",
+            "description": (
+                "Rotation parameterization: one of euler_xyz, quaternion_wxyz, "
+                "or quaternion_xyzw."
+            ),
+        },
+        **Signal.FIELD_METADATA,
+    }
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        valid_representations = {
+            "euler_xyz": 3,
+            "quaternion_wxyz": 4,
+            "quaternion_xyzw": 4,
+        }
+        if self.translation.shape[0] != self.rotation.shape[0]:
+            raise ValueError(
+                "translation and rotation must have the same number of time samples, "
+                f"got {self.translation.shape[0]} and {self.rotation.shape[0]}"
+            )
+        if self.rotation_representation not in valid_representations:
+            valid = ", ".join(sorted(valid_representations))
+            raise ValueError(
+                f"rotation_representation must be one of {{{valid}}}, "
+                f"got {self.rotation_representation!r}"
+            )
+
+        expected_width = valid_representations[self.rotation_representation]
+        if self.rotation.shape[1] != expected_width:
+            raise ValueError(
+                "rotation shape does not match rotation_representation: "
+                f"got {self.rotation.shape} for {self.rotation_representation!r}"
+            )
 
 
 @dataclass
@@ -1264,7 +1347,8 @@ class Signal1D(Signal):
 
     Args:
         samples: Signal samples of shape (T) and type uint8 or float32 or int16 or complex64.
-        offset: Time offset in seconds relative to frame timing.
+        start_time_offset: Time offset in seconds between the first transmit event
+            of the ultrasound acquisition and sample 0 of this data.
         sampling_frequency: Sampling frequency in Hz for signal samples.
     """
 
@@ -1275,6 +1359,11 @@ class Signal1D(Signal):
         **Signal.SCHEMA,
     }
 
+    FIELD_METADATA = {
+        "samples": {"unit": "-", "description": "Signal samples."},
+        **Signal.FIELD_METADATA,
+    }
+
 
 @dataclass
 class SignalND(Signal):
@@ -1282,7 +1371,8 @@ class SignalND(Signal):
 
     Args:
         samples: Signal samples of shape (T, ...) and type uint8 or float32 or int16 or complex64.
-        offset: Time offset in seconds relative to frame timing.
+        start_time_offset: Time offset in seconds between the first transmit event
+            of the ultrasound acquisition and sample 0 of this data.
         sampling_frequency: Sampling frequency in Hz for signal samples.
     """
 
@@ -1291,6 +1381,11 @@ class SignalND(Signal):
     SCHEMA = {
         "samples": {"dtype": (np.uint8, np.float32, np.int16, np.complex64), "shape": ("T", "...")},
         **Signal.SCHEMA,
+    }
+
+    FIELD_METADATA = {
+        "samples": {"unit": "-", "description": "Signal samples."},
+        **Signal.FIELD_METADATA,
     }
 
 
@@ -1324,7 +1419,7 @@ class MetadataSpec(Spec):
 
     subject: Subject | dict = field(default_factory=Subject)
     credit: str | None = None
-    probe_orientation: ProbeOrientation | dict | None = None
+    probe_pose: ProbePose | dict | None = None
     voice_narration: Signal1D | dict | None = None
     ecg: Signal1D | dict | None = None
     text_report: str | None = None
@@ -1333,18 +1428,27 @@ class MetadataSpec(Spec):
     SCHEMA = {
         "subject": {"spec": Subject},
         "credit": {"dtype": str, "shape": ()},
-        "probe_orientation": {"spec": ProbeOrientation},
+        "probe_pose": {"spec": ProbePose},
         "voice_narration": {"spec": Signal1D},
         "ecg": {"spec": Signal1D},
         "text_report": {"dtype": str, "shape": ()},
         "annotations": {"spec": Annotations},
     }
 
+    FIELD_METADATA = {
+        "credit": {"unit": "-", "description": "Credit or attribution for the dataset."},
+        "probe_pose": {"unit": "-", "description": "Sampled probe pose at the transducer tip."},
+        "voice_narration": {"unit": "-", "description": "Voice narration signal."},
+        "ecg": {"unit": "-", "description": "Electrocardiogram signal."},
+        "text_report": {"unit": "-", "description": "Free-text report associated with the study."},
+        "annotations": {"unit": "-", "description": "Frame-level annotations."},
+    }
+
     def __init__(
         self,
         subject: Subject | dict | None = None,
         credit: str | None = None,
-        probe_orientation: ProbeOrientation | dict | None = None,
+        probe_pose: ProbePose | dict | None = None,
         voice_narration: Signal1D | dict | None = None,
         ecg: Signal1D | dict | None = None,
         text_report: str | None = None,
@@ -1353,7 +1457,7 @@ class MetadataSpec(Spec):
     ):
         self.subject = subject
         self.credit = credit
-        self.probe_orientation = probe_orientation
+        self.probe_pose = probe_pose
         self.voice_narration = voice_narration
         self.ecg = ecg
         self.text_report = text_report

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1306,8 +1306,7 @@ class ProbePose(Signal):
         "rotation_representation": {
             "unit": "-",
             "description": (
-                "Rotation parameterization: one of euler_xyz, quaternion_wxyz, "
-                "or quaternion_xyzw."
+                "Rotation parameterization: one of euler_xyz, quaternion_wxyz, or quaternion_xyzw."
             ),
         },
         **Signal.FIELD_METADATA,


### PR DESCRIPTION
Replaces the old ProbeOrientation spec (single pose array of shape (T, 6)) with a new ProbePose class that separates translation and rotation into explicit fields:

translation: (T, 3) in meters
rotation: (T, 3) or (T, 4) depending on rotation_representation (euler_xyz, quaternion_wxyz, quaternion_xyzw)
Validation ensures the representation and rotation shape are consistent

Also renames Signal.offset to start_time_offset with a clearer description: the time offset between the first transmit event of the ultrasound acquisition and sample 0 of the signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata documentation to reflect renamed and restructured fields.

* **New Features**
  * Enhanced probe position metadata with detailed translation and rotation components, replacing the previous single-value representation.

* **Breaking Changes**
  * Renamed metadata field `probe_orientation` to `probe_pose`.
  * Renamed timing field `offset` to `start_time_offset` across signal metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->