### PR TITLE
Add warnings for optional scan fields, fix nested warnings

### DIFF
--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -12,6 +12,7 @@ from zea.data.spec import (
     FileSpec,
     Image,
     Map,
+    MetadataSpec,
     MetricsSpec,
     ProbePose,
     ScanSpec,
@@ -444,7 +445,7 @@ def test_subject_id_warning_for_missing_id():
             },
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-    assert any("Subject ID is not provided" in m for m in messages)
+    assert any("Optional Subject field 'id' is not set" in m for m in messages)
 
 
 class TestScanValidationErrors:
@@ -837,7 +838,53 @@ class TestScanSpecSaveWarnings:
                 metadata={"subject": {"type": "human"}},
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-        assert any("Subject ID is not provided" in m for m in messages)
+        assert any("Optional Subject field 'id' is not set" in m for m in messages)
+
+
+class TestSubjectFieldWarnings:
+    """log.warning calls emitted when Subject optional fields are None."""
+
+    @pytest.mark.parametrize(
+        "field",
+        ["id", "type", "age", "sex", "fat_percentage"],
+    )
+    def test_optional_subject_field_missing_warns(self, field):
+        with patch("zea.log.warning") as mock_warn:
+            Subject()
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any(f"Optional Subject field '{field}' is not set" in m for m in messages)
+
+    def test_no_warning_when_all_fields_provided(self):
+        with patch("zea.log.warning") as mock_warn:
+            Subject(
+                id="patient-001",
+                type="human",
+                age=np.uint8(42),
+                sex="f",
+                fat_percentage=np.float32(17.5),
+            )
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert not any("Optional Subject field" in m for m in messages)
+
+
+class TestMetadataSpecFieldWarnings:
+    """log.warning calls emitted when MetadataSpec optional fields are None."""
+
+    @pytest.mark.parametrize(
+        "field",
+        ["credit", "probe_pose", "voice_narration", "ecg", "text_report", "annotations"],
+    )
+    def test_optional_metadata_field_missing_warns(self, field):
+        with patch("zea.log.warning") as mock_warn:
+            MetadataSpec()
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any(f"Optional MetadataSpec field '{field}' is not set" in m for m in messages)
+
+    def test_no_warning_when_field_is_provided(self):
+        with patch("zea.log.warning") as mock_warn:
+            MetadataSpec(credit="Doe et al.")
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert not any("Optional MetadataSpec field 'credit'" in m for m in messages)
 
 
 class TestLoadingWarnings:

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -733,13 +733,9 @@ class TestScanSpecSaveWarnings:
     @pytest.mark.parametrize(
         "field",
         [
-            "time_to_next_transmit",
-            "azimuth_angles",
-            "sound_speed",
-            "tgc_gain_curve",
-            "element_width",
-            "waveforms_one_way",
-            "waveforms_two_way",
+            f.name
+            for f in fields(ScanSpec)
+            if f.default is None and f.name in ScanSpec.FIELD_METADATA
         ],
     )
     def test_optional_scan_field_missing_warns(self, field):
@@ -844,10 +840,7 @@ class TestScanSpecSaveWarnings:
 class TestSubjectFieldWarnings:
     """log.warning calls emitted when Subject optional fields are None."""
 
-    @pytest.mark.parametrize(
-        "field",
-        ["id", "type", "age", "sex", "fat_percentage"],
-    )
+    @pytest.mark.parametrize("field", list(Subject.SCHEMA))
     def test_optional_subject_field_missing_warns(self, field):
         with patch("zea.log.warning") as mock_warn:
             Subject()
@@ -872,7 +865,7 @@ class TestMetadataSpecFieldWarnings:
 
     @pytest.mark.parametrize(
         "field",
-        ["credit", "probe_pose", "voice_narration", "ecg", "text_report", "annotations"],
+        [f.name for f in fields(MetadataSpec) if f.default is None],
     )
     def test_optional_metadata_field_missing_warns(self, field):
         with patch("zea.log.warning") as mock_warn:

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1020,9 +1020,9 @@ class TestLoadingWarnings:
 
         with patch("zea.log.warning") as mock_warn:
             with File(path) as f:
-                try:
+                # scan() emits the legacy-waveforms warning, then fails because the
+                # file has no other scan parameters (n_tx is unset).
+                with pytest.raises(ValueError):
                     f.scan()
-                except Exception:
-                    pass
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any("waveforms_one_way" in m and "stored as a dictionary" in m for m in messages)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1,5 +1,7 @@
 from dataclasses import fields, is_dataclass
+from unittest.mock import patch
 
+import h5py
 import numpy as np
 import pytest
 
@@ -310,7 +312,7 @@ def test_dataset_builder_dimension_consistency_across_nested_specs():
 def test_metadata_accepts_custom_signal_nd_keys_and_warns():
     n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
 
-    with pytest.warns(match="Custom signal key\(s\) added to 'metadata'"):
+    with patch("zea.log.warning") as mock_warn:
         dataset = FileSpec(
             data={"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)},
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
@@ -323,7 +325,8 @@ def test_metadata_accepts_custom_signal_nd_keys_and_warns():
             },
             metrics={},
         )
-
+    messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+    assert any("Custom signal key(s) added to 'metadata'" in m for m in messages)
     assert isinstance(dataset.metadata.custom_signal, SignalND)
     assert "custom_signal" in dataset.to_dict()["metadata"]
 
@@ -343,7 +346,7 @@ def test_metadata_custom_key_requires_signal_nd_spec():
 def test_data_accepts_custom_map_keys_and_warns():
     n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
 
-    with pytest.warns(match="Custom spatial map key\(s\) added to 'data'"):
+    with patch("zea.log.warning") as mock_warn:
         dataset = FileSpec(
             data={
                 "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
@@ -356,7 +359,8 @@ def test_data_accepts_custom_map_keys_and_warns():
             },
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
         )
-
+    messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+    assert any("Custom spatial map key(s) added to 'data'" in m for m in messages)
     assert isinstance(dataset.data, DataSpec)
     assert isinstance(dataset.data.custom_map, Map)
     assert "custom_map" in dataset.to_dict()["data"]
@@ -422,9 +426,7 @@ def test_schema_keys_match_dataclass_fields_for_all_specs():
 def test_subject_id_warning_for_missing_id():
     n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
 
-    with pytest.warns(
-        match="Subject ID is not provided; please consider adding an ID for better traceability"
-    ):
+    with patch("zea.log.warning") as mock_warn:
         FileSpec(
             data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
@@ -441,6 +443,8 @@ def test_subject_id_warning_for_missing_id():
                 "coherence_factor": np.ones((n_frames,), dtype=np.float32),
             },
         )
+    messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+    assert any("Subject ID is not provided" in m for m in messages)
 
 
 class TestScanValidationErrors:
@@ -704,3 +708,182 @@ def test_image_spec_accepts_neginf():
     values_positive = np.full((2, 8, 8), 0.1, dtype=np.float32)
     with pytest.raises(ValueError, match="dB scale"):
         Image(values=values_positive, extent=extent)
+
+
+def _scan_bare(n_tx: int = 2, n_el: int = 4):
+    """Minimal ScanSpec dict with only required fields (all optionals left as None)."""
+    return {
+        "probe_geometry": np.zeros((n_el, 3), dtype=np.float32),
+        "sampling_frequency": np.float32(30e6),
+        "center_frequency": np.float32(5e6),
+        "demodulation_frequency": np.float32(5e6),
+        "initial_times": np.zeros((n_tx,), dtype=np.float32),
+        "t0_delays": np.zeros((n_tx, n_el), dtype=np.float32),
+        "tx_apodizations": np.ones((n_tx, n_el), dtype=np.float32),
+        "focus_distances": np.zeros((n_tx,), dtype=np.float32),
+        "transmit_origins": np.zeros((n_tx, 3), dtype=np.float32),
+        "polar_angles": np.zeros((n_tx,), dtype=np.float32),
+    }
+
+
+class TestScanSpecSaveWarnings:
+    """log.warning calls emitted during ScanSpec / FileSpec construction."""
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "time_to_next_transmit",
+            "azimuth_angles",
+            "sound_speed",
+            "tgc_gain_curve",
+            "element_width",
+            "waveforms_one_way",
+            "waveforms_two_way",
+        ],
+    )
+    def test_optional_scan_field_missing_warns(self, field):
+        with patch("zea.log.warning") as mock_warn:
+            ScanSpec(**_scan_bare())
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any(f"ScanSpec field '{field}' is not set" in m for m in messages)
+
+    def test_probe_geometry_out_of_range_warns(self):
+        scan = _scan_bare()
+        scan["probe_geometry"] = np.full((4, 3), 2.0, dtype=np.float32)
+        with patch("zea.log.warning") as mock_warn:
+            ScanSpec(**scan)
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Probe geometry values are unusually large" in m for m in messages)
+
+    def test_focus_distances_large_warns(self):
+        scan = _scan_bare()
+        scan["focus_distances"] = np.full((2,), 1.5, dtype=np.float32)
+        with patch("zea.log.warning") as mock_warn:
+            ScanSpec(**scan)
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Focus distances greater than or equal to 1 meter" in m for m in messages)
+
+    def test_transmit_origins_out_of_range_warns(self):
+        scan = _scan_bare()
+        scan["transmit_origins"] = np.full((2, 3), 2.0, dtype=np.float32)
+        with patch("zea.log.warning") as mock_warn:
+            ScanSpec(**scan)
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Transmit origin values are unusually large" in m for m in messages)
+
+    def test_map_extent_not_provided_warns(self):
+        with patch("zea.log.warning") as mock_warn:
+            Image(values=np.zeros((2, 8, 8, 1), dtype=np.uint8))
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Map extent is not provided" in m for m in messages)
+
+    def test_map_extent_out_of_range_warns(self):
+        with patch("zea.log.warning") as mock_warn:
+            Image(
+                values=np.zeros((2, 8, 8, 1), dtype=np.uint8),
+                extent=np.array([0.0, 2.0, 0.0, 1.0, -1.0, 0.0], dtype=np.float32),
+            )
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Map extent values are unusually large" in m for m in messages)
+
+    def test_sos_map_low_values_warns(self):
+        with patch("zea.log.warning") as mock_warn:
+            SosMap(
+                values=np.full((2, 8, 8, 1), 100.0, dtype=np.float32),
+                extent=np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            )
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Speed-of-sound map contains values below 300 m/s" in m for m in messages)
+
+    def test_custom_data_map_key_warns(self):
+        n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+        with patch("zea.log.warning") as mock_warn:
+            FileSpec(
+                data={
+                    "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
+                    "custom_map": {
+                        "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
+                        "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+                    },
+                },
+                scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+            )
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Custom spatial map key(s) added to 'data'" in m for m in messages)
+
+    def test_custom_metadata_signal_key_warns(self):
+        n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+        with patch("zea.log.warning") as mock_warn:
+            FileSpec(
+                data={"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)},
+                scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+                metadata={
+                    "custom_signal": {
+                        "samples": np.zeros((32, 3), dtype=np.float16),
+                        "start_time_offset": np.float32(0.0),
+                        "sampling_frequency": np.float32(120.0),
+                    }
+                },
+            )
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Custom signal key(s) added to 'metadata'" in m for m in messages)
+
+    def test_subject_id_missing_warns(self):
+        n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+        with patch("zea.log.warning") as mock_warn:
+            FileSpec(
+                data={"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)},
+                scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+                metadata={"subject": {"type": "human"}},
+            )
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Subject ID is not provided" in m for m in messages)
+
+
+class TestLoadingWarnings:
+    """log.warning calls emitted when reading a zea File."""
+
+    def test_no_scan_group_warns(self, tmp_path):
+        path = tmp_path / "no_scan.hdf5"
+        with h5py.File(path, "w") as f:
+            g = f.create_group("data")
+            g.create_dataset("raw_data", data=np.zeros((2, 2, 8, 4, 1), dtype=np.float32))
+
+        with patch("zea.log.warning") as mock_warn:
+            with File(path) as f:
+                f.get_parameters()
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("Could not find scan parameters in file" in m for m in messages)
+
+    def test_focus_distances_in_wavelengths_warns(self, tmp_path):
+        """focus_distances stored as wavelengths (>= 1, not inf) triggers a warning on load."""
+        path = tmp_path / "wavelength_focus.hdf5"
+        with h5py.File(path, "w") as f:
+            s = f.create_group("scan")
+            s.create_dataset("focus_distances", data=np.full((2,), 10.0, dtype=np.float32))
+            s.create_dataset("sound_speed", data=np.float32(1540.0))
+            s.create_dataset("center_frequency", data=np.float32(5e6))
+
+        with patch("zea.log.warning") as mock_warn:
+            with File(path) as f:
+                f.get_parameters()
+        messages = [str(c.args[0]).lower() for c in mock_warn.call_args_list]
+        assert any("focus distances" in m and "wavelength" in m for m in messages)
+
+    def test_waveforms_stored_as_dict_warns(self, tmp_path):
+        """Legacy waveforms stored as an HDF5 group (dict-like) trigger a warning on load."""
+        path = tmp_path / "waveforms_dict.hdf5"
+        with h5py.File(path, "w") as f:
+            s = f.create_group("scan")
+            wv = s.create_group("waveforms_one_way")
+            wv.create_dataset("0", data=np.zeros(10, dtype=np.float32))
+            wv.create_dataset("1", data=np.zeros(10, dtype=np.float32))
+
+        with patch("zea.log.warning") as mock_warn:
+            with File(path) as f:
+                try:
+                    f.scan()
+                except Exception:
+                    pass
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert any("waveforms_one_way" in m and "stored as a dictionary" in m for m in messages)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -327,26 +327,33 @@ def test_dataset_builder_dimension_consistency_across_nested_specs():
         )
 
 
-def test_metadata_accepts_custom_signal_nd_keys_and_warns():
+def test_metadata_accepts_custom_signal_nd_keys_and_warns(tmp_path):
     n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
-
+    data = {"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)}
+    metadata = {
+        "custom_signal": {
+            "samples": np.zeros((32, 3), dtype=np.float16),
+            "start_time_offset": np.float32(0.0),
+            "sampling_frequency": np.float32(120.0),
+        }
+    }
+    dataset = FileSpec(
+        data=data,
+        scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+        metadata=metadata,
+        metrics={},
+    )
+    assert isinstance(dataset.metadata.custom_signal, SignalND)
+    assert "custom_signal" in dataset.to_dict()["metadata"]
     with patch("zea.log.warning") as mock_warn:
-        dataset = FileSpec(
-            data={"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)},
+        File.create(
+            tmp_path / "test.hdf5",
+            data=data,
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
-            metadata={
-                "custom_signal": {
-                    "samples": np.zeros((32, 3), dtype=np.float16),
-                    "start_time_offset": np.float32(0.0),
-                    "sampling_frequency": np.float32(120.0),
-                }
-            },
-            metrics={},
+            metadata=metadata,
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
     assert any("Custom signal key(s) added to 'metadata'" in m for m in messages)
-    assert isinstance(dataset.metadata.custom_signal, SignalND)
-    assert "custom_signal" in dataset.to_dict()["metadata"]
 
 
 def test_metadata_custom_key_requires_signal_nd_spec():
@@ -361,27 +368,32 @@ def test_metadata_custom_key_requires_signal_nd_spec():
         )
 
 
-def test_data_accepts_custom_map_keys_and_warns():
+def test_data_accepts_custom_map_keys_and_warns(tmp_path):
     n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
-
+    data = {
+        "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
+        "custom_map": {
+            "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
+            "coordinates": np.zeros((n_frames, 16, 12, 3), dtype=np.float32),
+            "description": "This is a custom map",
+            "unit": "mm",
+        },
+    }
+    dataset = FileSpec(
+        data=data,
+        scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+    )
+    assert isinstance(dataset.data, DataSpec)
+    assert isinstance(dataset.data.custom_map, Map)
+    assert "custom_map" in dataset.to_dict()["data"]
     with patch("zea.log.warning") as mock_warn:
-        dataset = FileSpec(
-            data={
-                "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
-                "custom_map": {
-                    "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
-                    "coordinates": np.zeros((n_frames, 16, 12, 3), dtype=np.float32),
-                    "description": "This is a custom map",
-                    "unit": "mm",
-                },
-            },
+        File.create(
+            tmp_path / "test.hdf5",
+            data=data,
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
     assert any("Custom spatial map key(s) added to 'data'" in m for m in messages)
-    assert isinstance(dataset.data, DataSpec)
-    assert isinstance(dataset.data.custom_map, Map)
-    assert "custom_map" in dataset.to_dict()["data"]
 
 
 def test_data_custom_key_requires_map_spec():
@@ -891,35 +903,39 @@ class TestScanSpecSaveWarnings:
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any("Speed-of-sound map contains values below 300 m/s" in m for m in messages)
 
-    def test_custom_data_map_key_warns(self):
+    def test_custom_data_map_key_warns(self, tmp_path):
         n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+        data = {
+            "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
+            "custom_map": {
+                "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
+                "coordinates": np.zeros((n_frames, 16, 12, 1, 3), dtype=np.float32),
+            },
+        }
         with patch("zea.log.warning") as mock_warn:
-            FileSpec(
-                data={
-                    "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
-                    "custom_map": {
-                        "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
-                        "coordinates": np.zeros((n_frames, 16, 12, 1, 3), dtype=np.float32),
-                    },
-                },
+            File.create(
+                tmp_path / "test.hdf5",
+                data=data,
                 scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any("Custom spatial map key(s) added to 'data'" in m for m in messages)
 
-    def test_custom_metadata_signal_key_warns(self):
+    def test_custom_metadata_signal_key_warns(self, tmp_path):
         n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+        metadata = {
+            "custom_signal": {
+                "samples": np.zeros((32, 3), dtype=np.float16),
+                "start_time_offset": np.float32(0.0),
+                "sampling_frequency": np.float32(120.0),
+            }
+        }
         with patch("zea.log.warning") as mock_warn:
-            FileSpec(
+            File.create(
+                tmp_path / "test.hdf5",
                 data={"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)},
                 scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
-                metadata={
-                    "custom_signal": {
-                        "samples": np.zeros((32, 3), dtype=np.float16),
-                        "start_time_offset": np.float32(0.0),
-                        "sampling_frequency": np.float32(120.0),
-                    }
-                },
+                metadata=metadata,
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any("Custom signal key(s) added to 'metadata'" in m for m in messages)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -464,6 +464,26 @@ def test_subject_id_warning_for_missing_id():
     assert any("Optional Subject field 'id' is not set" in m for m in messages)
 
 
+def test_subject_id_warning_includes_field_metadata_description():
+    n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
+
+    with patch("zea.log.warning") as mock_warn:
+        FileSpec(
+            data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+            scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+            metadata={
+                "subject": {
+                    "type": "human",
+                    "age": np.uint8(42),
+                    "sex": "f",
+                    "fat_percentage": np.float32(17.5),
+                }
+            },
+        )
+    messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+    assert any("subject-wise splits" in m for m in messages)
+
+
 class TestScanValidationErrors:
     """TypeError / ValueError raised by Scan spec validation."""
 

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -424,6 +424,22 @@ def test_schema_keys_match_dataclass_fields_for_all_specs():
         )
 
 
+def test_field_metadata_keys_are_subset_of_schema_for_all_specs():
+    """FIELD_METADATA keys must be a subset of SCHEMA keys."""
+    for obj in vars(spec_module).values():
+        if (
+            isinstance(obj, type)
+            and issubclass(obj, Spec)
+            and obj is not Spec
+            and is_dataclass(obj)
+            and hasattr(obj, "FIELD_METADATA")
+        ):
+            extra = set(obj.FIELD_METADATA.keys()) - set(obj.SCHEMA.keys())
+            assert not extra, (
+                f"{obj.__name__} FIELD_METADATA has keys not in SCHEMA: {sorted(extra)}"
+            )
+
+
 def test_subject_id_warning_for_missing_id():
     n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -82,7 +82,8 @@ def _warn_custom_keys(data: dict, metadata: dict):
         log.warning(
             f"Custom spatial map key(s) added to 'data': {', '.join(sorted(custom_maps))}. "
             "These are validated as generic Map specs. "
-            f"If your data matches an existing type, prefer one of the supported spatial maps: {supported}."
+            "If your data matches an existing type, prefer one of the supported "
+            f"spatial maps: {supported}."
         )
     custom_signals = [k for k in metadata if k not in MetadataSpec.SCHEMA]
     if custom_signals:
@@ -90,7 +91,8 @@ def _warn_custom_keys(data: dict, metadata: dict):
         log.warning(
             f"Custom signal key(s) added to 'metadata': {', '.join(sorted(custom_signals))}. "
             "These are validated as generic SignalND specs. "
-            f"If your signal matches an existing type, prefer one of the supported signal fields: {supported}."
+            "If your signal matches an existing type, prefer one of the supported "
+            f"signal fields: {supported}."
         )
 
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -74,6 +74,26 @@ def assert_key(file: h5py.File, key: str):
         raise KeyError(f"{key} not found in file")
 
 
+def _warn_custom_keys(data: dict, metadata: dict):
+    """Warn about custom keys in data/metadata dicts when saving."""
+    custom_maps = [k for k in data if k not in DataSpec.SCHEMA]
+    if custom_maps:
+        supported = ", ".join(k for k, v in DataSpec.SCHEMA.items() if "spec" in v)
+        log.warning(
+            f"Custom spatial map key(s) added to 'data': {', '.join(sorted(custom_maps))}. "
+            "These are validated as generic Map specs. "
+            f"If your data matches an existing type, prefer one of the supported spatial maps: {supported}."
+        )
+    custom_signals = [k for k in metadata if k not in MetadataSpec.SCHEMA]
+    if custom_signals:
+        supported = ", ".join(k for k, v in MetadataSpec.SCHEMA.items() if "spec" in v)
+        log.warning(
+            f"Custom signal key(s) added to 'metadata': {', '.join(sorted(custom_signals))}. "
+            "These are validated as generic SignalND specs. "
+            f"If your signal matches an existing type, prefer one of the supported signal fields: {supported}."
+        )
+
+
 class File(h5py.File):
     """h5py.File in zea format."""
 
@@ -205,6 +225,7 @@ class File(h5py.File):
         if description is not None:
             kwargs["description"] = description
 
+        _warn_custom_keys(kwargs.get("data", {}), kwargs.get("metadata", {}))
         spec = FileSpec(**kwargs)
         spec.save(str(path), compression=compression)
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1175,21 +1175,13 @@ class ScanSpec(Spec):
                 self.demodulation_frequency = self.demodulation_frequency[0]
 
         # Warn about optional fields that were not provided
-        _optional_scan_fields = {
-            "time_to_next_transmit": "time between transmit events (n_frames, n_tx)",
-            "azimuth_angles": "azimuthal angles of transmit beams (n_tx,) in radians",
-            "sound_speed": "speed of sound in m/s",
-            "tgc_gain_curve": "time-gain-compensation curve (n_ax,)",
-            "element_width": "element width of the probe in meters",
-            "waveforms_one_way": "one-way transmit waveforms (n_tx, n_samples)",
-            "waveforms_two_way": "two-way transmit waveforms (n_tx, n_samples)",
-        }
-        for s_field, description in _optional_scan_fields.items():
-            if getattr(self, s_field) is None:
+        _optional_names = {f.name for f in fields(self) if f.default is None}
+        for field_name, meta in self.FIELD_METADATA.items():
+            if field_name in _optional_names and getattr(self, field_name) is None:
                 log.warning(
-                    f"Optional ScanSpec field '{s_field}' is not set."
-                    f"Description: {description}. "
-                    f"Defaulted to None."
+                    f"Optional ScanSpec field '{field_name}' is not set. "
+                    f"Description: {meta['description']} "
+                    "Defaulted to None."
                 )
 
 
@@ -1224,20 +1216,9 @@ class Subject(Spec):
         if self.id is not None and not self.id.strip():
             raise ValueError("Subject ID cannot be an empty string")
 
-        _optional_subject_fields = {
-            "id": "subject identifier for traceability and subject-wise splits",
-            "type": "subject type (e.g. 'human', 'phantom', 'animal')",
-            "age": "subject age in years",
-            "sex": "subject sex",
-            "fat_percentage": "subject fat percentage",
-        }
-        for s_field, description in _optional_subject_fields.items():
-            if getattr(self, s_field) is None:
-                log.warning(
-                    f"Optional Subject field '{s_field}' is not set. "
-                    f"Description: {description}. "
-                    "Defaulted to None."
-                )
+        for field_name in self.SCHEMA:
+            if getattr(self, field_name) is None:
+                log.warning(f"Optional Subject field '{field_name}' is not set. Defaulted to None.")
 
         if self.fat_percentage is not None and (
             self.fat_percentage < 0 or self.fat_percentage > 100
@@ -1537,19 +1518,12 @@ class MetadataSpec(Spec):
                 f"signal fields: {suggested_signal_keys}."
             )
 
-        _optional_metadata_fields = {
-            "credit": "credit or attribution for the dataset",
-            "probe_pose": "sampled probe pose at the transducer tip",
-            "voice_narration": "voice narration signal",
-            "ecg": "electrocardiogram signal",
-            "text_report": "free-text report associated with the study",
-            "annotations": "frame-level annotations",
-        }
-        for s_field, description in _optional_metadata_fields.items():
-            if getattr(self, s_field) is None:
+        _optional_names = {f.name for f in fields(type(self)) if f.default is None}
+        for field_name, meta in type(self).FIELD_METADATA.items():
+            if field_name in _optional_names and getattr(self, field_name, None) is None:
                 log.warning(
-                    f"Optional MetadataSpec field '{s_field}' is not set. "
-                    f"Description: {description}. "
+                    f"Optional MetadataSpec field '{field_name}' is not set. "
+                    f"Description: {meta['description']} "
                     "Defaulted to None."
                 )
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -967,23 +967,6 @@ class DataSpec(Spec):
                         f"got n_ch={n_ch} (shape {arr.shape})."
                     )
 
-        suggested_map_keys = ", ".join(
-            sorted(
-                key
-                for key, value in type(self).SCHEMA.items()
-                if "spec" in value and issubclass(value["spec"], Map)
-            )
-        )
-
-        if getattr(self, "_extra_map_keys", ()):
-            custom_keys = ", ".join(sorted(self._extra_map_keys))
-            log.warning(
-                f"Custom spatial map key(s) added to 'data': {custom_keys}. "
-                "These are validated as generic Map specs. "
-                "If your data matches an existing type, prefer one of the supported "
-                f"spatial maps: {suggested_map_keys}."
-            )
-
 
 @dataclass
 class ScanSpec(Spec):
@@ -1500,23 +1483,6 @@ class MetadataSpec(Spec):
 
     def __post_init__(self):
         super().__post_init__()
-
-        suggested_signal_keys = ", ".join(
-            sorted(
-                key
-                for key, value in type(self).SCHEMA.items()
-                if "spec" in value and issubclass(value["spec"], Signal)
-            )
-        )
-
-        if getattr(self, "_extra_signal_keys", ()):
-            custom_keys = ", ".join(sorted(self._extra_signal_keys))
-            log.warning(
-                f"Custom signal key(s) added to 'metadata': {custom_keys}. "
-                "These are validated as generic SignalND specs. "
-                "If your signal matches an existing type, prefer one of the supported "
-                f"signal fields: {suggested_signal_keys}."
-            )
 
         self.warn_missing_optional_fields()
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1219,6 +1219,10 @@ class Subject(Spec):
         "fat_percentage": {"dtype": np.float32, "shape": ()},
     }
 
+    FIELD_METADATA = {
+        "id": {"description": "Subject ID. Needed for subject-wise splits."},
+    }
+
     def __post_init__(self):
         super().__post_init__()
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1185,7 +1185,7 @@ class ScanSpec(Spec):
             "waveforms_two_way": "two-way transmit waveforms (n_tx, n_samples)",
         }
         for s_field, description in _optional_scan_fields.items():
-            if getattr(self, field) is None:
+            if getattr(self, s_field) is None:
                 log.warning(
                     f"Optional ScanSpec field '{s_field}' is not set."
                     f"Description: {description}. "
@@ -1223,11 +1223,21 @@ class Subject(Spec):
 
         if self.id is not None and not self.id.strip():
             raise ValueError("Subject ID cannot be an empty string")
-        if self.id is None:
-            log.warning(
-                "Subject ID is not provided; please consider adding an ID for "
-                "better traceability and to enable subject-wise splits."
-            )
+
+        _optional_subject_fields = {
+            "id": "subject identifier for traceability and subject-wise splits",
+            "type": "subject type (e.g. 'human', 'phantom', 'animal')",
+            "age": "subject age in years",
+            "sex": "subject sex",
+            "fat_percentage": "subject fat percentage",
+        }
+        for s_field, description in _optional_subject_fields.items():
+            if getattr(self, s_field) is None:
+                log.warning(
+                    f"Optional Subject field '{s_field}' is not set. "
+                    f"Description: {description}. "
+                    "Defaulted to None."
+                )
 
         if self.fat_percentage is not None and (
             self.fat_percentage < 0 or self.fat_percentage > 100
@@ -1526,6 +1536,22 @@ class MetadataSpec(Spec):
                 "If your signal matches an existing type, prefer one of the supported "
                 f"signal fields: {suggested_signal_keys}."
             )
+
+        _optional_metadata_fields = {
+            "credit": "credit or attribution for the dataset",
+            "probe_pose": "sampled probe pose at the transducer tip",
+            "voice_narration": "voice narration signal",
+            "ecg": "electrocardiogram signal",
+            "text_report": "free-text report associated with the study",
+            "annotations": "frame-level annotations",
+        }
+        for s_field, description in _optional_metadata_fields.items():
+            if getattr(self, s_field) is None:
+                log.warning(
+                    f"Optional MetadataSpec field '{s_field}' is not set. "
+                    f"Description: {description}. "
+                    "Defaulted to None."
+                )
 
 
 @dataclass

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -149,6 +149,22 @@ class Spec:
         """Return the names of fields that have a default value."""
         return tuple(f.name for f in fields(cls) if cls._is_optional_dataclass_field(f))
 
+    def warn_missing_optional_fields(self):
+        """Warn about optional fields that were not provided."""
+        _optional_fields = self.optional_fields()
+        for field_name in self.SCHEMA.keys():
+            if field_name in _optional_fields and getattr(self, field_name) is None:
+                if hasattr(self, "FIELD_METADATA"):
+                    meta = self.FIELD_METADATA.get(field_name, {})
+                    description = meta.get("description", _DEFAULT_FIELD_DESCRIPTION)
+                else:
+                    description = _DEFAULT_FIELD_DESCRIPTION
+                log.warning(
+                    f"Optional {self.__class__.__name__} field '{field_name}' is not set. "
+                    f"Description: {description} "
+                    "Defaulted to None."
+                )
+
     @staticmethod
     def _expected_shapes(shape_spec: Any) -> tuple[tuple, ...]:
         if shape_spec and isinstance(shape_spec[0], tuple):
@@ -1174,15 +1190,7 @@ class ScanSpec(Spec):
             if np.all(self.demodulation_frequency == self.demodulation_frequency[0]):
                 self.demodulation_frequency = self.demodulation_frequency[0]
 
-        # Warn about optional fields that were not provided
-        _optional_names = {f.name for f in fields(self) if f.default is None}
-        for field_name, meta in self.FIELD_METADATA.items():
-            if field_name in _optional_names and getattr(self, field_name) is None:
-                log.warning(
-                    f"Optional ScanSpec field '{field_name}' is not set. "
-                    f"Description: {meta['description']} "
-                    "Defaulted to None."
-                )
+        self.warn_missing_optional_fields()
 
 
 @dataclass
@@ -1190,6 +1198,7 @@ class Subject(Spec):
     """Subject metadata associated with the study.
 
     Args:
+        id: Subject ID.
         type: Subject type, e.g. human, phantom, animal.
         age: Subject age in years.
         sex: Subject sex.
@@ -1216,9 +1225,7 @@ class Subject(Spec):
         if self.id is not None and not self.id.strip():
             raise ValueError("Subject ID cannot be an empty string")
 
-        for field_name in self.SCHEMA:
-            if getattr(self, field_name) is None:
-                log.warning(f"Optional Subject field '{field_name}' is not set. Defaulted to None.")
+        self.warn_missing_optional_fields()
 
         if self.fat_percentage is not None and (
             self.fat_percentage < 0 or self.fat_percentage > 100
@@ -1518,14 +1525,7 @@ class MetadataSpec(Spec):
                 f"signal fields: {suggested_signal_keys}."
             )
 
-        _optional_names = {f.name for f in fields(type(self)) if f.default is None}
-        for field_name, meta in type(self).FIELD_METADATA.items():
-            if field_name in _optional_names and getattr(self, field_name, None) is None:
-                log.warning(
-                    f"Optional MetadataSpec field '{field_name}' is not set. "
-                    f"Description: {meta['description']} "
-                    "Defaulted to None."
-                )
+        self.warn_missing_optional_fields()
 
 
 @dataclass

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import defaultdict
 from dataclasses import MISSING, dataclass, field, fields
 from importlib.metadata import PackageNotFoundError
@@ -973,13 +972,11 @@ class DataSpec(Spec):
 
         if getattr(self, "_extra_map_keys", ()):
             custom_keys = ", ".join(sorted(self._extra_map_keys))
-            warnings.warn(
-                log.warning(
-                    f"Custom spatial map key(s) added to 'data': {custom_keys}. "
-                    "These are validated as generic Map specs. "
-                    "If your data matches an existing type, prefer one of the supported "
-                    f"spatial maps: {suggested_map_keys}."
-                )
+            log.warning(
+                f"Custom spatial map key(s) added to 'data': {custom_keys}. "
+                "These are validated as generic Map specs. "
+                "If your data matches an existing type, prefer one of the supported "
+                f"spatial maps: {suggested_map_keys}."
             )
 
 
@@ -1177,6 +1174,24 @@ class ScanSpec(Spec):
             if np.all(self.demodulation_frequency == self.demodulation_frequency[0]):
                 self.demodulation_frequency = self.demodulation_frequency[0]
 
+        # Warn about optional fields that were not provided
+        _optional_scan_fields = {
+            "time_to_next_transmit": "time between transmit events (n_frames, n_tx)",
+            "azimuth_angles": "azimuthal angles of transmit beams (n_tx,) in radians",
+            "sound_speed": "speed of sound in m/s",
+            "tgc_gain_curve": "time-gain-compensation curve (n_ax,)",
+            "element_width": "element width of the probe in meters",
+            "waveforms_one_way": "one-way transmit waveforms (n_tx, n_samples)",
+            "waveforms_two_way": "two-way transmit waveforms (n_tx, n_samples)",
+        }
+        for s_field, description in _optional_scan_fields.items():
+            if getattr(self, field) is None:
+                log.warning(
+                    f"Optional ScanSpec field '{s_field}' is not set."
+                    f"Description: {description}. "
+                    f"Defaulted to None."
+                )
+
 
 @dataclass
 class Subject(Spec):
@@ -1209,11 +1224,9 @@ class Subject(Spec):
         if self.id is not None and not self.id.strip():
             raise ValueError("Subject ID cannot be an empty string")
         if self.id is None:
-            warnings.warn(
-                log.warning(
-                    "Subject ID is not provided; please consider adding an ID for "
-                    "better traceability and to enable subject-wise splits."
-                )
+            log.warning(
+                "Subject ID is not provided; please consider adding an ID for "
+                "better traceability and to enable subject-wise splits."
             )
 
         if self.fat_percentage is not None and (
@@ -1507,13 +1520,11 @@ class MetadataSpec(Spec):
 
         if getattr(self, "_extra_signal_keys", ()):
             custom_keys = ", ".join(sorted(self._extra_signal_keys))
-            warnings.warn(
-                log.warning(
-                    f"Custom signal key(s) added to 'metadata': {custom_keys}. "
-                    "These are validated as generic SignalND specs. "
-                    "If your signal matches an existing type, prefer one of the supported "
-                    f"signal fields: {suggested_signal_keys}."
-                )
+            log.warning(
+                f"Custom signal key(s) added to 'metadata': {custom_keys}. "
+                "These are validated as generic SignalND specs. "
+                "If your signal matches an existing type, prefer one of the supported "
+                f"signal fields: {suggested_signal_keys}."
             )
 
 


### PR DESCRIPTION
See #328 

Most warnings were already done during file creation and during initialization of the dataloader.

For the dataloader, missing field warnings will be raised during initialization but they do not spam the user.
The only way this is possible is if `File.scan()` is called manually in a loop, such that `ScanSpec` is constructed in a loop. 
I think this would be inefficient user-behaviour rather than something we need to account for.

---
I added warnings for all optional scan parameters [as given here](https://zea--358.org.readthedocs.build/en/358/data-acquisition.html#group-reference)
- time_to_next_transmit
- azimuth_angles
- sound_speed
- tgc_gain_curve
- element_width
- waveforms_one_way
- waveforms_two_way

and optional metadata fields
- credit
- probe_pose
- voice_narration
- ecg
- text_report
- annotations

They all default to None and this will be logged as well.

---

Additionally there are now tests for the warnings (saving, loading, subject, metadata), and i fixed some of the older tests/implementations for warnings that used a nested 
```
warnings.warn(log.warning(...))
```

---

What is still missing is the backwards compatibility of datasets warning, but this should be added with the legacy file support in #351 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Warnings standardized to use the app logger and improved for clarity and consistency.
  * Missing optional fields now emit descriptive warnings (including subject id) and extra custom data/metadata keys trigger warnings.
  * Loading legacy/HDF5 files now emits clearer warnings for missing or legacy-formatted scan parameters.

* **Tests**
  * Added extensive tests covering specification warnings, subject/metadata field messages, custom key warnings, and legacy/HDF5 load warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tue-bmd/zea/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->