### PR TITLE
Move `Map`s from `extent` -> `coordinates`

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -129,12 +129,6 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
            - –
            - 
            - |badge-opt|
-         * - ``image_sc``
-           - :class:`~zea.data.spec.ImageSc`
-           - group
-           - –
-           - 
-           - |badge-opt|
          * - ``image``
            - :class:`~zea.data.spec.Image`
            - group
@@ -207,9 +201,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_ch) or (n_frames, z, x, n_ch)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -256,58 +250,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
-              - –
-              - |badge-opt|
-            * - ``labels``
-              - ``str``
-              - (n_spatial_ch)
-              - –
-              - |badge-opt|
-            * - ``description``
-              - ``str``
-              - scalar
-              - –
-              - |badge-opt|
-            * - ``unit``
-              - ``str``
-              - scalar
-              - –
-              - |badge-opt|
-            * - ``min``
-              - ``float32``
-              - scalar
-              - –
-              - |badge-opt|
-            * - ``max``
-              - ``float32``
-              - scalar
-              - –
-              - |badge-opt|
-
-      .. dropdown:: ``image_sc``
-
-         Scan-converted image. Values are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).
-
-         .. list-table::
-            :header-rows: 1
-            :widths: 22 20 28 10 10
-         
-            * - Field
-              - Type
-              - Shape
-              - Unit
-              - 
-            * - ``values``
-              - ``float32`` | ``uint8``
-              - (n_frames, x, z, y) or (n_frames, x, z)
-              - –
-              - |badge-req|
-            * - ``extent``
-              - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -354,9 +299,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, x, z, y) or (n_frames, x, z)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -403,9 +348,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -452,9 +397,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -501,9 +446,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -550,9 +495,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -599,9 +544,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``
@@ -648,9 +593,9 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
-            * - ``extent``
+            * - ``coordinates``
               - ``float32``
-              - (n_frames, 6) or (6)
+              - (..., 3)
               - –
               - |badge-opt|
             * - ``labels``

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -106,25 +106,35 @@ Beyond the standard data types (``raw_data``, ``beamformed_data``, …), you can
 
 **Custom spatial maps** (``data`` group)
 
-A custom map is a named entry in the ``data`` group that associates a pixel array with a physical
-extent.  Pass it as a sub-dict under the key you want:
+A custom map is a named entry in the ``data`` group that associates a pixel array with a
+per-pixel Cartesian coordinate grid.  Each map is a then function from Cartesian space to
+some real values.  Pass it as a sub-dict under the key you want:
 
 .. code-block:: python
 
     import numpy as np
     from zea import File
+    from zea.beamform.pixelgrid import cartesian_pixel_grid
 
     n_frames = 2
     values = np.zeros((n_frames, 64, 64, 1), dtype=np.uint8)   # (frames, z, x[, channels])
-    extent = np.array([x_min, x_max, y_min, y_max, z_min, z_max], dtype=np.float32)  # metres
+
+    # Build a coordinate grid matching the values spatial shape.
+    # cartesian_pixel_grid returns shape (nz, nx, 3); broadcast to add the frame dimension.
+    coords_2d = cartesian_pixel_grid(
+        xlims=(-0.02, 0.02), zlims=(-0.03, 0.0), grid_size_x=64, grid_size_z=64
+    )  # shape (64, 64, 3), last axis = [x, y, z] in metres
+    coordinates = np.broadcast_to(coords_2d, (n_frames, 64, 64, 3)).copy()
+    # For a simple placeholder without a real grid:
+    # coordinates = np.zeros((n_frames, 64, 64, 3), dtype=np.float32)
 
     f = File.create(
         "my_acquisition.hdf5",
         data={
             "raw_data": raw,
             "my_overlay": {          # <-- Example of a custom field not in the zea spec
-                "values":  values,
-                "extent":  extent,
+                "values":      values,
+                "coordinates": coordinates,  # shape (*spatial_dims, 3)
                 # optional: "labels", "description", "unit"
             },
         },
@@ -134,8 +144,15 @@ extent.  Pass it as a sub-dict under the key you want:
 
     # Reading back
     with File("my_acquisition.hdf5") as f:
-        overlay_values = f.data.my_overlay.values[:]
-        overlay_extent = f.data.my_overlay.extent[:]
+        overlay_values      = f.data.my_overlay.values[:]
+        overlay_coordinates = f.data.my_overlay.coordinates[:]
+
+.. note::
+
+   :func:`~zea.beamform.pixelgrid.cartesian_pixel_grid` and
+   :func:`~zea.beamform.pixelgrid.polar_pixel_grid` are convenient helpers for
+   constructing coordinate grids that match typical beamformed images.  See their
+   docstrings for full details.
 
 
 **Custom metadata** (``metadata`` group)

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -107,7 +107,7 @@ Beyond the standard data types (``raw_data``, ``beamformed_data``, …), you can
 **Custom spatial maps** (``data`` group)
 
 A custom map is a named entry in the ``data`` group that associates a pixel array with a
-per-pixel Cartesian coordinate grid.  Each map is a then function from Cartesian space to
+per-pixel Cartesian coordinate grid.  Each map is then a function from Cartesian space to
 some real values.  Pass it as a sub-dict under the key you want:
 
 .. code-block:: python

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -289,7 +289,6 @@ ROOT_ATTRS_TABLE = """\
 MAP_DESCRIPTIONS = {
     "beamformed_data": "Beamformed (beamsummed) data. Values are ``float32`` in (n_frames, z, x, n_ch) or (n_frames, z, x, y, n_ch); ``labels`` names each channel (RF or I/Q).",  # noqa: E501
     "envelope_data": "Envelope-detected data. Values are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
-    "image_sc": "Scan-converted image. Values are ``float32`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
     "image": "Reconstructed (log-compressed) image. Values are ``uint8`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
     "segmentation": "Semantic segmentation mask. Values are ``bool`` in (n_frames, z, x, y, n_labels); ``labels`` names each channel.",  # noqa: E501
     "sos_map": "Speed-of-sound map in m/s. Values are ``float32``.",

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -23,7 +23,6 @@ from zea.data.spec import (
     DataSpec,
     EnvelopeData,
     Image,
-    ImageSc,
     MetadataSpec,
     MetricsSpec,
     ProbePose,
@@ -372,7 +371,6 @@ def generate() -> str:
     map_classes = [
         ("beamformed_data", BeamformedData),
         ("envelope_data", EnvelopeData),
-        ("image_sc", ImageSc),
         ("image", Image),
         ("segmentation", Segmentation),
         ("sos_map", SosMap),

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -50,24 +50,19 @@ def generate_dummy_data_dict(
         "raw_data": np.ones((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
     }
 
-    _coordinates_3d = np.zeros((n_frames, grid_size_z, grid_size_x, 3), dtype=np.float32)
     if add_optional_dtypes:
         data_dict["aligned_data"] = np.ones((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)
         data_dict["envelope_data"] = {
             "values": np.ones((n_frames, grid_size_z, grid_size_x), dtype=np.float32),
-            "coordinates": _coordinates_3d,
         }
         data_dict["beamformed_data"] = {
             "values": np.ones((n_frames, grid_size_z, grid_size_x, n_ch), dtype=np.float32),
-            "coordinates": _coordinates_3d,
         }
         data_dict["image"] = {
             "values": np.zeros((n_frames, grid_size_z, grid_size_x), dtype=image_dtype),
-            "coordinates": _coordinates_3d,
         }
         data_dict["image_sc"] = {
             "values": np.zeros((n_frames, grid_size_z, grid_size_x), dtype=image_dtype),
-            "coordinates": _coordinates_3d,
         }
 
     return data_dict

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -50,24 +50,24 @@ def generate_dummy_data_dict(
         "raw_data": np.ones((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
     }
 
-    _extent = np.array([-0.02, 0.02, 0, 0, -0.03, 0], dtype=np.float32)
+    _coordinates_3d = np.zeros((n_frames, grid_size_z, grid_size_x, 3), dtype=np.float32)
     if add_optional_dtypes:
         data_dict["aligned_data"] = np.ones((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)
         data_dict["envelope_data"] = {
             "values": np.ones((n_frames, grid_size_z, grid_size_x), dtype=np.float32),
-            "extent": _extent,
+            "coordinates": _coordinates_3d,
         }
         data_dict["beamformed_data"] = {
             "values": np.ones((n_frames, grid_size_z, grid_size_x, n_ch), dtype=np.float32),
-            "extent": _extent,
+            "coordinates": _coordinates_3d,
         }
         data_dict["image"] = {
             "values": np.zeros((n_frames, grid_size_z, grid_size_x), dtype=image_dtype),
-            "extent": _extent,
+            "coordinates": _coordinates_3d,
         }
         data_dict["image_sc"] = {
             "values": np.zeros((n_frames, grid_size_z, grid_size_x), dtype=image_dtype),
-            "extent": _extent,
+            "coordinates": _coordinates_3d,
         }
 
     return data_dict

--- a/tests/data/test_data_format.py
+++ b/tests/data/test_data_format.py
@@ -183,7 +183,7 @@ def test_image_only(tmp_hdf5_path):
     """Tests creating a file with only image_sc data (no scan)."""
     image_sc = {
         "values": np.zeros((n_frames, 256, 256), dtype=np.uint8),
-        "extent": np.array([-0.02, 0.02, 0, 0, -0.03, 0], dtype=np.float32),
+        "coordinates": np.zeros((n_frames, 256, 256, 3), dtype=np.float32),
     }
     f = File.create(
         tmp_hdf5_path,
@@ -203,7 +203,7 @@ def test_custom_map(tmp_hdf5_path):
     import warnings
 
     custom_values = np.zeros((n_frames, 64, 64, 1), dtype=np.uint8)
-    custom_extent = np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32)
+    custom_coordinates = np.zeros((n_frames, 64, 64, 3), dtype=np.float32)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -213,7 +213,7 @@ def test_custom_map(tmp_hdf5_path):
                 "raw_data": DATA["raw_data"],
                 "my_custom_overlay": {
                     "values": custom_values,
-                    "extent": custom_extent,
+                    "coordinates": custom_coordinates,
                     "description": "custom overlay map",
                     "unit": "a.u.",
                 },
@@ -226,7 +226,7 @@ def test_custom_map(tmp_hdf5_path):
     with File(tmp_hdf5_path) as f:
         assert "my_custom_overlay" in f["data"]
         np.testing.assert_array_equal(f.data.my_custom_overlay.values[:], custom_values)
-        np.testing.assert_array_equal(f.data.my_custom_overlay.extent[:], custom_extent)
+        np.testing.assert_array_equal(f.data.my_custom_overlay.coordinates[:], custom_coordinates)
 
 
 @pytest.fixture
@@ -246,7 +246,7 @@ def test_save_file_custom_maps(tmp_hdf5_path, _scan_and_probe):
 
     scan, probe = _scan_and_probe
     custom_values = np.zeros((n_frames, 32, 32, 1), dtype=np.uint8)
-    custom_extent = np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32)
+    custom_coordinates = np.zeros((n_frames, 32, 32, 3), dtype=np.float32)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -258,7 +258,7 @@ def test_save_file_custom_maps(tmp_hdf5_path, _scan_and_probe):
             custom_maps={
                 "my_overlay": {
                     "values": custom_values,
-                    "extent": custom_extent,
+                    "coordinates": custom_coordinates,
                 }
             },
         )
@@ -266,7 +266,7 @@ def test_save_file_custom_maps(tmp_hdf5_path, _scan_and_probe):
     with File(tmp_hdf5_path) as f:
         assert "my_overlay" in f["data"]
         np.testing.assert_array_equal(f.data.my_overlay.values[:], custom_values)
-        np.testing.assert_array_equal(f.data.my_overlay.extent[:], custom_extent)
+        np.testing.assert_array_equal(f.data.my_overlay.coordinates[:], custom_coordinates)
 
 
 def test_save_file_custom_metadata(tmp_hdf5_path, _scan_and_probe):

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -10,13 +10,10 @@ from zea.scan import Scan
 
 from . import generate_example_dataset
 
-# Dummy extent for map-based data types in tests
-_TEST_EXTENT = np.array([-0.02, 0.02, 0, 0, -0.03, 0], dtype=np.float32)
-
 
 def _make_map(values):
     """Wrap values into a Map-compatible dict."""
-    return {"values": values, "extent": _TEST_EXTENT}
+    return {"values": values, "coordinates": np.zeros((*values.shape, 3), dtype=np.float32)}
 
 
 @pytest.fixture
@@ -198,7 +195,7 @@ class TestGroupProxy:
                 "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
                 "image": {
                     "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
-                    "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+                    "coordinates": np.zeros((n_frames, 16, 12, 3), dtype=np.float32),
                 },
             },
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
@@ -357,7 +354,7 @@ class TestValidateSpec:
                     "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
                     "custom_map": {
                         "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
-                        "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+                        "coordinates": np.zeros((n_frames, 16, 12, 3), dtype=np.float32),
                     },
                 },
                 scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
@@ -417,7 +414,7 @@ class TestImageOnlyFile:
             data={
                 "image": {
                     "values": np.zeros((n_frames, 32, 24, 1), dtype=np.uint8),
-                    "extent": np.array([0, 0.05, 0, 0.04, -0.04, -0.01], dtype=np.float32),
+                    "coordinates": np.zeros((n_frames, 32, 24, 3), dtype=np.float32),
                 },
             },
             scan=_scan_minimal(n_frames=n_frames),
@@ -531,31 +528,31 @@ class TestSlicing:
 
 
 class TestSpatialData:
-    """Test saving + reading spatial maps that include values + extent."""
+    """Test saving + reading spatial maps that include values + coordinates."""
 
     @pytest.fixture
     def spatial_file(self, tmp_path):
         n_frames = 3
         img_values = np.random.randint(0, 255, (n_frames, 64, 48, 1), dtype=np.uint8)
-        img_extent = np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32)
+        img_coordinates = np.zeros((n_frames, 64, 48, 3), dtype=np.float32)
         seg_values = np.random.choice([True, False], (n_frames, 64, 48, 1, 2)).astype(np.bool_)
         seg_labels = np.array(["background", "lumen"], dtype=np.str_)
-        seg_extent = np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32)
+        seg_coordinates = np.zeros((n_frames, 64, 48, 1, 3), dtype=np.float32)
         sos_values = np.full((n_frames, 64, 48, 1), 1540.0, dtype=np.float32)
-        sos_extent = np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32)
+        sos_coordinates = np.zeros((n_frames, 64, 48, 3), dtype=np.float32)
 
         path = tmp_path / "spatial.hdf5"
         f = File.create(
             path,
             data={
                 "envelope_data": _make_map(np.ones((n_frames, 32, 24), dtype=np.float32)),
-                "image": {"values": img_values, "extent": img_extent},
+                "image": {"values": img_values, "coordinates": img_coordinates},
                 "segmentation": {
                     "values": seg_values,
                     "labels": seg_labels,
-                    "extent": seg_extent,
+                    "coordinates": seg_coordinates,
                 },
-                "sos_map": {"values": sos_values, "extent": sos_extent},
+                "sos_map": {"values": sos_values, "coordinates": sos_coordinates},
             },
             scan=_scan_minimal(n_frames=n_frames),
             probe_name="spatial_test",
@@ -564,19 +561,19 @@ class TestSpatialData:
         return (
             str(path),
             img_values,
-            img_extent,
+            img_coordinates,
             seg_values,
             seg_labels,
             sos_values,
         )
 
     def test_image_group_structure(self, spatial_file):
-        path, img_values, img_extent, *_ = spatial_file
+        path, img_values, img_coordinates, *_ = spatial_file
         with File(path) as f:
             proxy = f.data.image
             assert isinstance(proxy, GroupProxy)
             assert "values" in proxy
-            assert "extent" in proxy
+            assert "coordinates" in proxy
 
     def test_image_values_read(self, spatial_file):
         path, img_values, *_ = spatial_file
@@ -602,13 +599,13 @@ class TestSpatialData:
             np.testing.assert_allclose(f.data.sos_map.values[()], sos_values, atol=1e-6)
 
     def test_spatial_round_trip_via_validate_spec(self, spatial_file):
-        path, img_values, img_extent, seg_values, seg_labels, sos_values = spatial_file
+        path, img_values, img_coordinates, seg_values, seg_labels, sos_values = spatial_file
         with File(path) as f:
             spec = f.validate_spec()
 
         assert isinstance(spec.data.image, Image)
         np.testing.assert_array_equal(spec.data.image.values, img_values)
-        np.testing.assert_array_equal(spec.data.image.extent, img_extent)
+        np.testing.assert_array_equal(spec.data.image.coordinates, img_coordinates)
         assert isinstance(spec.data.segmentation, Segmentation)
         np.testing.assert_array_equal(spec.data.segmentation.values, seg_values)
         np.testing.assert_array_equal(spec.data.segmentation.labels, seg_labels)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -503,21 +503,21 @@ class TestDataValidationErrors:
 
     def test_map_wrong_pixel_dtype_raises(self):
         """SosMap inherits FloatMap – values must be float32, not uint8."""
-        with pytest.raises(TypeError, match="values"):
+        with pytest.raises(TypeError, match="SosMap: field 'values'"):
             SosMap(
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
             )
 
     def test_image_wrong_pixel_dtype_raises(self):
         """Image is UnsignedIntMap – values must be float32 or uint8, not complex128."""
-        with pytest.raises(TypeError, match="values"):
+        with pytest.raises(TypeError, match="Image: field 'values'"):
             Image(
                 values=np.zeros((2, 16, 12, 1), dtype=np.complex128),
             )
 
     def test_segmentation_wrong_pixel_dtype_raises(self):
         """Segmentation is BooleanMap – values must be bool_, not float32."""
-        with pytest.raises(TypeError, match="values"):
+        with pytest.raises(TypeError, match="Segmentation: field 'values'"):
             Segmentation(
                 values=np.zeros((2, 16, 12, 1, 2), dtype=np.float32),
                 labels=np.array(["a", "b"], dtype=np.str_),
@@ -525,14 +525,14 @@ class TestDataValidationErrors:
 
     def test_map_coordinates_wrong_shape_raises(self):
         """coordinates must have final dim 3 and spatial dims matching values."""
-        # Final dim is not 3
+        # Final dim is not 3 — caught by SCHEMA shape check
         with pytest.raises(ValueError, match="coordinates"):
             Image(
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
                 coordinates=np.zeros((2, 16, 12, 4), dtype=np.float32),
             )
-        # Spatial dims don't match values (wrong z size)
-        with pytest.raises(ValueError, match="coordinates"):
+        # Spatial dims don't match values — caught by Map.__post_init__
+        with pytest.raises(ValueError, match="Image: coordinates shape"):
             Image(
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
                 coordinates=np.zeros((2, 99, 12, 3), dtype=np.float32),

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -26,7 +26,8 @@ def test_segmentation_spec():
     # Correct usage
     values = np.zeros((10, 256, 256, 1, 4), dtype=np.bool_)
     labels = np.array(["background", "label1", "label2", "label3"], dtype=np.str_)
-    # values shape (10, 256, 256, 1, 4): spatial dims = (10, 256, 256, 1), n_labels treated as channel
+    # values shape (10, 256, 256, 1, 4): spatial dims = (10, 256, 256, 1),
+    # n_labels treated as channel
     coordinates = np.zeros((10, 256, 256, 1, 3), dtype=np.float32)
     segmentation = Segmentation(values=values, labels=labels, coordinates=coordinates)
     assert segmentation.values.shape == (10, 256, 256, 1, 4)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -557,6 +557,25 @@ class TestDataValidationErrors:
             )
             assert m2.coordinates.shape == (2, 16, 12, 3)
 
+    def test_map_coordinates_millimetre_range_warns(self):
+        """Coordinates with |value| > 1 m should trigger a units warning."""
+        # Values of 50 mm look fine in mm but are 0.05 m — no warning expected.
+        coords_metres = np.zeros((2, 8, 8, 3), dtype=np.float32)
+        coords_metres[..., 2] = 0.05  # 5 cm depth — valid
+        Map(
+            values=np.zeros((2, 8, 8), dtype=np.uint8),
+            coordinates=coords_metres,
+        )  # should not warn
+
+        # Coordinates in millimetres: max absolute value = 50 mm > 1 m threshold.
+        coords_mm = np.zeros((2, 8, 8, 3), dtype=np.float32)
+        coords_mm[..., 2] = 50.0  # 50 mm — looks like mm, not metres
+        with pytest.warns(match="metres"):
+            Map(
+                values=np.zeros((2, 8, 8), dtype=np.uint8),
+                coordinates=coords_mm,
+            )
+
     def test_n_ch_3_raises_for_raw_data(self):
         """raw_data n_ch must be 1 or 2, 3 channels should be rejected."""
         with pytest.raises(ValueError, match="n_ch"):

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -26,17 +26,16 @@ def test_segmentation_spec():
     # Correct usage
     values = np.zeros((10, 256, 256, 1, 4), dtype=np.bool_)
     labels = np.array(["background", "label1", "label2", "label3"], dtype=np.str_)
-    extent = np.array([0.0, 1.0, 0.0, 1.0, -1.0, 0.0], dtype=np.float32)
-    segmentation = Segmentation(values=values, labels=labels, extent=extent)
+    # values shape (10, 256, 256, 1, 4): spatial dims = (10, 256, 256, 1), n_labels treated as channel
+    coordinates = np.zeros((10, 256, 256, 1, 3), dtype=np.float32)
+    segmentation = Segmentation(values=values, labels=labels, coordinates=coordinates)
     assert segmentation.values.shape == (10, 256, 256, 1, 4)
     assert segmentation.labels.shape == (4,)
-    assert segmentation.extent.shape == (6,)
+    assert segmentation.coordinates.shape == (10, 256, 256, 1, 3)
 
     # Incorrect usage: labels shape mismatch
     with pytest.raises(ValueError):
-        Segmentation(
-            values=values, labels=np.array(["background", "label1"], dtype=np.str_), extent=extent
-        )
+        Segmentation(values=values, labels=np.array(["background", "label1"], dtype=np.str_))
 
 
 def _scan_minimal(n_frames: int = 3, n_tx: int = 2, n_el: int = 4):
@@ -92,33 +91,46 @@ def _example_metadata():
     }
 
 
+def _make_coordinates(values_shape):
+    """Build a zero-filled coordinates array compatible with the given values shape.
+
+    For unchanneled values (values_shape has no trailing channel dim) the
+    coordinates shape is ``(*values_shape, 3)``; callers that know their values
+    are channeled should pass ``values_shape[:-1]`` as *values_shape* explicitly.
+    """
+    return np.zeros((*values_shape, 3), dtype=np.float32)
+
+
 def _example_data(n_frames, n_tx, n_el, n_ax, n_ch):
+    # For channeled values (last dim = channel), coordinates use values.shape[:-1].
+    coords_3d = _make_coordinates((n_frames, 16, 12))  # spatial grid, no channel
+    coords_segm = _make_coordinates((n_frames, 16, 12, 1))  # spatial grid for seg (y dim = 1)
     return {
         "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
         "image": {
             "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
-            "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            "coordinates": coords_3d,
         },
         "segmentation": {
             "values": np.zeros((n_frames, 16, 12, 1, 2), dtype=np.bool_),
             "labels": np.array(["background", "tissue"], dtype=np.str_),
-            "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            "coordinates": coords_segm,
         },
         "sos_map": {
             "values": np.full((n_frames, 16, 12, 1), 1540.0, dtype=np.float32),
-            "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            "coordinates": coords_3d,
         },
         "strain": {
             "values": np.zeros((n_frames, 16, 12, 1), dtype=np.float32),
-            "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            "coordinates": coords_3d,
         },
         "swe": {
             "values": np.zeros((n_frames, 16, 12, 1), dtype=np.float32),
-            "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            "coordinates": coords_3d,
         },
         "tissue_doppler": {
             "values": np.zeros((n_frames, 16, 12, 1), dtype=np.float32),
-            "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+            "coordinates": coords_3d,
         },
     }
 
@@ -349,7 +361,7 @@ def test_data_accepts_custom_map_keys_and_warns():
                 "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
                 "custom_map": {
                     "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
-                    "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
+                    "coordinates": np.zeros((n_frames, 16, 12, 3), dtype=np.float32),
                     "description": "This is a custom map",
                     "unit": "mm",
                 },
@@ -384,7 +396,6 @@ def test_data_custom_map_dtype_error_includes_map_key_context():
                 "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
                 "custom_map": {
                     "values": np.zeros((n_frames, 16, 12, 1), dtype=np.bool_),
-                    "extent": np.array([0.0, 0.05, 0.0, 0.04, -0.04, -0.01], dtype=np.float32),
                 },
             },
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
@@ -494,7 +505,6 @@ class TestDataValidationErrors:
         with pytest.raises(TypeError, match="values"):
             SosMap(
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
-                extent=np.zeros(6, dtype=np.float32),
             )
 
     def test_image_wrong_pixel_dtype_raises(self):
@@ -502,7 +512,6 @@ class TestDataValidationErrors:
         with pytest.raises(TypeError, match="values"):
             Image(
                 values=np.zeros((2, 16, 12, 1), dtype=np.complex128),
-                extent=np.zeros(6, dtype=np.float32),
             )
 
     def test_segmentation_wrong_pixel_dtype_raises(self):
@@ -511,16 +520,42 @@ class TestDataValidationErrors:
             Segmentation(
                 values=np.zeros((2, 16, 12, 1, 2), dtype=np.float32),
                 labels=np.array(["a", "b"], dtype=np.str_),
-                extent=np.zeros(6, dtype=np.float32),
             )
 
-    def test_map_extent_wrong_shape_raises(self):
-        """extent must be (6,) or (n_frames, 6) — (3,) should fail."""
-        with pytest.raises(ValueError, match="extent"):
+    def test_map_coordinates_wrong_shape_raises(self):
+        """coordinates must have final dim 3 and spatial dims matching values."""
+        # Final dim is not 3
+        with pytest.raises(ValueError, match="coordinates"):
             Image(
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
-                extent=np.zeros(3, dtype=np.float32),
+                coordinates=np.zeros((2, 16, 12, 4), dtype=np.float32),
             )
+        # Spatial dims don't match values (wrong z size)
+        with pytest.raises(ValueError, match="coordinates"):
+            Image(
+                values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
+                coordinates=np.zeros((2, 99, 12, 3), dtype=np.float32),
+            )
+
+    def test_map_coordinates_valid_channeled_and_unchanneled(self):
+        """Valid coordinates shapes for channeled and unchanneled values."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            # Unchanneled: coordinates.shape == (*values.shape, 3)
+            m1 = Map(
+                values=np.zeros((2, 16, 12), dtype=np.uint8),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+            )
+            assert m1.coordinates.shape == (2, 16, 12, 3)
+
+            # Channeled: coordinates.shape == (*values.shape[:-1], 3)
+            m2 = Map(
+                values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+            )
+            assert m2.coordinates.shape == (2, 16, 12, 3)
 
     def test_n_ch_3_raises_for_raw_data(self):
         """raw_data n_ch must be 1 or 2, 3 channels should be rejected."""
@@ -536,7 +571,6 @@ class TestDataValidationErrors:
             DataSpec(
                 beamformed_data={
                     "values": np.zeros((2, 8, 6, 3), dtype=np.float32),
-                    "extent": np.array([-0.02, 0.02, 0, 0, -0.03, 0], dtype=np.float32),
                 }
             )
 
@@ -688,19 +722,19 @@ class TestProbePoseValidation:
 def test_image_spec_accepts_neginf():
     """Image spec validation must allow -inf in float32 arrays (represents
     complete silence in dB domain) but still reject +inf and values above 0."""
-    extent = np.array([-0.02, 0.02, 0, 0, -0.03, 0], dtype=np.float32)
+    coordinates = np.zeros((2, 8, 8, 3), dtype=np.float32)
 
     values_with_neginf = np.full((2, 8, 8), -30.0, dtype=np.float32)
     values_with_neginf[0, 0, 0] = -np.inf
 
-    img = Image(values=values_with_neginf, extent=extent)
+    img = Image(values=values_with_neginf, coordinates=coordinates)
     assert img is not None
 
     values_with_posinf = np.full((2, 8, 8), -30.0, dtype=np.float32)
     values_with_posinf[0, 0, 0] = np.inf
     with pytest.raises(ValueError, match="finite or -inf"):
-        Image(values=values_with_posinf, extent=extent)
+        Image(values=values_with_posinf, coordinates=coordinates)
 
     values_positive = np.full((2, 8, 8), 0.1, dtype=np.float32)
     with pytest.raises(ValueError, match="dB scale"):
-        Image(values=values_positive, extent=extent)
+        Image(values=values_positive, coordinates=coordinates)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -36,7 +36,11 @@ def test_segmentation_spec():
 
     # Incorrect usage: labels shape mismatch
     with pytest.raises(ValueError):
-        Segmentation(values=values, labels=np.array(["background", "label1"], dtype=np.str_))
+        Segmentation(
+            values=values,
+            labels=np.array(["background", "label1"], dtype=np.str_),
+            coordinates=coordinates,
+        )
 
 
 def _scan_minimal(n_frames: int = 3, n_tx: int = 2, n_el: int = 4):
@@ -506,6 +510,7 @@ class TestDataValidationErrors:
         with pytest.raises(TypeError, match="SosMap: field 'values'"):
             SosMap(
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
             )
 
     def test_image_wrong_pixel_dtype_raises(self):
@@ -513,6 +518,7 @@ class TestDataValidationErrors:
         with pytest.raises(TypeError, match="Image: field 'values'"):
             Image(
                 values=np.zeros((2, 16, 12, 1), dtype=np.complex128),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
             )
 
     def test_segmentation_wrong_pixel_dtype_raises(self):
@@ -521,6 +527,7 @@ class TestDataValidationErrors:
             Segmentation(
                 values=np.zeros((2, 16, 12, 1, 2), dtype=np.float32),
                 labels=np.array(["a", "b"], dtype=np.str_),
+                coordinates=np.zeros((2, 16, 12, 1, 3), dtype=np.float32),
             )
 
     def test_map_coordinates_wrong_shape_raises(self):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -29,7 +29,7 @@ def test_interface_initialization():
 
 
 def test_interface_reads_map_backed_dataset(tmp_path):
-    """For map-backed types (image, image_sc) the read must descend into the
+    """For map-backed types (e.g. image) the read must descend into the
     'values' sub-dataset rather than indexing the group directly."""
     path = tmp_path / "with_image.hdf5"
     generate_example_dataset(

--- a/zea/data/convert/cetus.py
+++ b/zea/data/convert/cetus.py
@@ -109,8 +109,9 @@ def process_cetus(source_path, output_path, overwrite=False):
 
     Each file stores the 3D B-mode volume as ``image_sc`` (scan-converted image).
     If a corresponding ground truth segmentation file exists, it is stored as a
-    ``Segmentation`` map under ``data/segmentation`` with spatial extent derived
-    from the NIfTI voxel spacing.
+    ``Segmentation`` map under ``data/segmentation``. Both maps include a
+    per-voxel coordinate grid (shape ``(1, D, H, W, 3)``) derived from the NIfTI
+    voxel spacing.
 
     Patient ID and citation are stored in the ``metadata`` group.
     License information is embedded in the file description.
@@ -165,16 +166,20 @@ def process_cetus(source_path, output_path, overwrite=False):
     patient_name = stem.split("_")[0]  # e.g. "patient01"
 
     # Build data dict
-    # Compute spatial extent from voxel spacing: (xmin, xmax, ymin, ymax, zmax, zmin)
     D, H, W = volume.shape
-    image_sc_extent = np.array(
-        [0, D * voxel_spacing[0], 0, W * voxel_spacing[2], 0, H * voxel_spacing[1]],
-        dtype=np.float32,
-    )
+
+    # Build per-voxel coordinate grid from voxel spacing.
+    # Shape: (1, D, H, W, 3) — valid for both image_sc (1,D,H,W) and segmentation (1,D,H,W,1).
+    d_range = np.arange(D, dtype=np.float32) * voxel_spacing[0]
+    h_range = np.arange(H, dtype=np.float32) * voxel_spacing[1]
+    w_range = np.arange(W, dtype=np.float32) * voxel_spacing[2]
+    d_grid, h_grid, w_grid = np.meshgrid(d_range, h_range, w_range, indexing="ij")
+    coordinates = np.stack([d_grid, h_grid, w_grid], axis=-1)[np.newaxis]  # (1, D, H, W, 3)
+
     data = {
         "image_sc": {
             "values": image_sc.astype(np.float32),
-            "extent": image_sc_extent,
+            "coordinates": coordinates,
         }
     }
 
@@ -183,15 +188,9 @@ def process_cetus(source_path, output_path, overwrite=False):
         # GT is binary: 0 or 255 -> bool mask, shape (1, D, H, W, 1)
         seg_mask = (gt_volume > 0)[np.newaxis, ..., np.newaxis]
 
-        # Compute spatial extent from voxel spacing: (xmin, xmax, ymin, ymax, zmax, zmin)
-        extent = np.array(
-            [0, D * voxel_spacing[0], 0, W * voxel_spacing[2], 0, H * voxel_spacing[1]],
-            dtype=np.float32,
-        )
-
         data["segmentation"] = {
             "values": seg_mask,
-            "extent": extent,
+            "coordinates": coordinates,
             "labels": np.array(["endocardium"]),
         }
 

--- a/zea/data/file_operations.py
+++ b/zea/data/file_operations.py
@@ -65,8 +65,6 @@ def save_file(
             ``"extent"`` keys (validated as :class:`~zea.data.spec.BeamformedData`).
         envelope_data (dict, optional): Envelope-detected data as a dict with ``"values"``
             and ``"extent"`` keys (validated as :class:`~zea.data.spec.EnvelopeData`).
-        image_sc (dict, optional): Scan-converted image data as a dict with ``"values"``
-            and ``"extent"`` keys (validated as :class:`~zea.data.spec.ImageSc`).
         image (dict, optional): Reconstructed (log-compressed) image data as a dict with
             ``"values"`` and ``"extent"`` keys (validated as :class:`~zea.data.spec.Image`).
         custom_maps (dict, optional): Custom spatial map entries to include in the ``data`` group.

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -272,7 +272,7 @@ class Spec:
         try:
             check_dtype(field_value, expected_dtype)
         except TypeError as e:
-            raise TypeError(f"Field '{field_name}' has invalid dtype: {e}")
+            raise TypeError(f"{type(self).__name__}: field '{field_name}' has invalid dtype: {e}")
 
         matched_shape = find_matched_shape(field_value, expected_shapes)
         if matched_shape is None:

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -471,28 +471,37 @@ class Spec:
 
 @dataclass
 class Map(Spec):
-    """Map data and spatial extent metadata.
+    """Map data with per-pixel Cartesian coordinates.
+
+    A map is a function from Cartesian space to some real values: every pixel at
+    spatial index ``[f, i, j, ...]`` is assigned a 3-D position ``coordinates[f, i, j, ..., :]``
+    = ``[x, y, z]`` in metres.
 
     The most flexible map spec, which can be used for any spatially aligned data product.
+    See, for example, :func:`~zea.beamform.pixelgrid.cartesian_pixel_grid` or
+    :func:`~zea.beamform.pixelgrid.polar_pixel_grid` to create a suitable coordinate array
+    from your scan geometry.
 
     Args:
-        values: The map values of shape (n_frames, z, x, y, n_ch) or (n_frames, z, x, y)
-            or (n_frames, z, x, n_ch) or (n_frames, z, x) and type uint8 or float32 or int16.
-        extent: The map extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
-        labels: The labels corresponding to the `n_ch` channels in the values.
+        values: The map values of shape ``(n_frames, z, x, y, n_ch)`` or ``(n_frames, z, x, y)``
+            or ``(n_frames, z, x, n_ch)`` or ``(n_frames, z, x)`` and type uint8, float32,
+            int16, or complex64.
+        coordinates: Per-pixel Cartesian positions in metres, shape ``(*spatial_dims, 3)``
+            where ``spatial_dims`` matches the spatial (non-channel) dimensions of ``values``.
+            For non-channeled values the shape is ``(*values.shape, 3)``; for channeled values
+            the shape is ``(*values.shape[:-1], 3)``.  The last axis holds ``[x, y, z]``.
+        labels: The labels corresponding to the ``n_ch`` channels in the values.
             This is required when values have an n_ch dimension, and should be None otherwise.
-            For IQ data, this would typically be ["I", "Q"].
+            For IQ data, this would typically be ``["I", "Q"]``.
         description: An optional free-text description of the map.
         unit: An optional string specifying the physical unit of the map values,
-            e.g. "m/s", "%", etc.
+            e.g. ``"m/s"``, ``"%"``, etc.
         min: The minimum value of the map.
         max: The maximum value of the map.
     """
 
     values: np.ndarray
-    extent: np.ndarray | None = None
+    coordinates: np.ndarray | None = None
     labels: np.ndarray | None = None
     description: str | None = None
     unit: str | None = None
@@ -508,7 +517,7 @@ class Map(Spec):
                 ("n_frames", "z", "x"),
             ),
         },
-        "extent": {"dtype": np.float32, "shape": (("n_frames", 6), (6,))},
+        "coordinates": {"dtype": np.float32, "shape": ("...", 3)},
         "labels": {"dtype": np.str_, "shape": ("n_spatial_ch",)},
         "description": {"dtype": str, "shape": ()},
         "unit": {"dtype": str, "shape": ()},
@@ -524,31 +533,29 @@ class Map(Spec):
                 "labels must be provided when values have n_ch dimension"
             )
 
-        if self.extent is not None:
-            # Check sensible values
-            if np.any(self.extent[..., 0] > self.extent[..., 1]):
-                raise ValueError("Map extent xlims must have xmin <= xmax")
-            if np.any(self.extent[..., 2] > self.extent[..., 3]):
-                raise ValueError("Map extent ylims must have ymin <= ymax")
-            if np.any(self.extent[..., 4] > self.extent[..., 5]):
-                raise ValueError("Map extent zlims must have zmin <= zmax")
-
-            # Ultrasound specific warning: if extent values are unusually large, log a warning
-            if np.any(self.extent >= 1.0) or np.any(self.extent <= -1.0):
-                log.warning(
-                    "Map extent values are unusually large, extending beyond +/- 1.0 meters. "
-                    "Please verify that the extent values are correct and in meters."
+        if self.coordinates is not None:
+            # coordinates.shape[-1] is guaranteed == 3 by the SCHEMA check above.
+            # Validate that the spatial axes match values (with or without a trailing channel axis).
+            coords_spatial = self.coordinates.shape[:-1]
+            valid_spatial_shapes = {self.values.shape, self.values.shape[:-1]}
+            if coords_spatial not in valid_spatial_shapes:
+                raise ValueError(
+                    f"coordinates shape {self.coordinates.shape} is incompatible with "
+                    f"values shape {self.values.shape}. "
+                    f"coordinates.shape[:-1] must equal values.shape "
+                    f"({self.values.shape}) for non-channeled data, or "
+                    f"values.shape[:-1] ({self.values.shape[:-1]}) for channeled data."
                 )
         else:
             log.warning(
-                "Map extent is not provided, please consider adding an extent field to "
-                "ensure the map can be correctly displayed."
+                "Map coordinates are not provided, please consider adding a coordinates field "
+                "to ensure the map can be correctly displayed."
             )
 
 
 @dataclass
 class FloatMap(Map):
-    """Map data with float32 pixel values and spatial extent metadata."""
+    """Map data with float32 pixel values and per-pixel Cartesian coordinates."""
 
     SCHEMA = {
         **Map.SCHEMA,
@@ -561,7 +568,7 @@ class FloatMap(Map):
 
 @dataclass
 class BooleanMap(Map):
-    """Map data with bool pixel values and spatial extent metadata."""
+    """Map data with bool pixel values and per-pixel Cartesian coordinates."""
 
     SCHEMA = {
         **Map.SCHEMA,
@@ -574,7 +581,7 @@ class BooleanMap(Map):
 
 @dataclass
 class UnsignedIntMap(Map):
-    """Map data with uint8 pixel values and spatial extent metadata."""
+    """Map data with uint8 pixel values and per-pixel Cartesian coordinates."""
 
     SCHEMA = {
         **Map.SCHEMA,
@@ -587,15 +594,13 @@ class UnsignedIntMap(Map):
 
 @dataclass
 class Segmentation(BooleanMap):
-    """Segmentation data and spatial extent metadata.
+    """Segmentation data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The segmentation values of shape (n_frames, z, x, y, n_labels) and type bool.
-        extent: The segmentation extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
+        values: The segmentation values of shape ``(n_frames, z, x, y, n_labels)`` and type bool.
+        coordinates: Per-pixel Cartesian positions in metres, shape ``(n_frames, z, x, y, 3)``.
         labels: The labels corresponding to the segmentation values, where each unique value
-            in the values corresponds to a label in this list of shape (n_labels,) and type str.
+            in the values corresponds to a label in this list of shape ``(n_labels,)`` and type str.
     """
 
     def __post_init__(self):
@@ -607,15 +612,13 @@ class Segmentation(BooleanMap):
 
 @dataclass
 class Image(Map):
-    """Reconstructed (log-compressed) image data and spatial extent metadata.
+    """Reconstructed (log-compressed) image data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The image values of shape (n_frames, z, x, y) or (n_frames, z, x)
+        values: The image values of shape ``(n_frames, z, x, y)`` or ``(n_frames, z, x)``
             and type uint8 or float32. For float32 values, the values should be in dB
             (between -inf and 0).
-        extent: The image extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (radius_min, radius_max, theta_min, theta_max, phi_min, phi_max) and stored as float32.
+        coordinates: Per-pixel Cartesian positions in metres, shape ``(*values.shape, 3)``.
     """
 
     SCHEMA = {
@@ -642,16 +645,15 @@ class Image(Map):
 
 @dataclass
 class BeamformedData(FloatMap):
-    """Beamformed (beamsummed) data and spatial extent metadata.
+    """Beamformed (beamsummed) data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The beamformed data of shape (n_frames, z, x, n_ch) or
-            (n_frames, z, x, y, n_ch) and type float32.
+        values: The beamformed data of shape ``(n_frames, z, x, n_ch)`` or
+            ``(n_frames, z, x, y, n_ch)`` and type float32.
             n_ch is 1 for RF data or 2 for IQ data.
-        extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
-        labels: The labels for the channel dimension, e.g. ["RF"] or ["I", "Q"].
+        coordinates: Per-pixel Cartesian positions in metres, shape
+            ``(n_frames, z, x, 3)`` or ``(n_frames, z, x, y, 3)``.
+        labels: The labels for the channel dimension, e.g. ``["RF"]`` or ``["I", "Q"]``.
             Auto-generated from n_ch if not provided.
     """
 
@@ -685,14 +687,12 @@ class BeamformedData(FloatMap):
 
 @dataclass
 class EnvelopeData(FloatMap):
-    """Envelope-detected data and spatial extent metadata.
+    """Envelope-detected data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The envelope data of shape (n_frames, x, z) or
-            (n_frames, z, x, y) and type float32.
-        extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
+        values: The envelope data of shape ``(n_frames, x, z)`` or
+            ``(n_frames, z, x, y)`` and type float32.
+        coordinates: Per-pixel Cartesian positions in metres, shape ``(*values.shape, 3)``.
     """
 
     SCHEMA = {
@@ -709,14 +709,13 @@ class EnvelopeData(FloatMap):
 
 @dataclass
 class SosMap(FloatMap):
-    """Speed-of-sound map data and spatial extent metadata.
+    """Speed-of-sound map data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The speed-of-sound map values in m/s of shape (n_frames, z, x, y)
+        values: The speed-of-sound map values in m/s of shape ``(n_frames, z, x, y)``
             and type float32.
-        extent: The speed-of-sound map extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
+        coordinates: Per-pixel Cartesian positions in metres, shape
+            ``(n_frames, z, x, 3)`` or ``(n_frames, z, x, y, 3)``.
     """
 
     def __post_init__(self):
@@ -735,13 +734,11 @@ class SosMap(FloatMap):
 
 @dataclass
 class StrainPercentageMap(FloatMap):
-    """Strain map data and spatial extent metadata.
+    """Strain map data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The strain values in % of shape (n_frames, z, x, y) and type float32.
-        extent: The strain extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
+        values: The strain values in % of shape ``(n_frames, z, x, y)`` and type float32.
+        coordinates: Per-pixel Cartesian positions in metres.
     """
 
     def __post_init__(self):
@@ -753,12 +750,12 @@ class StrainPercentageMap(FloatMap):
 
 @dataclass
 class ShearWaveElastographyMap(FloatMap):
-    """Shear-wave elastography data and spatial extent metadata.
+    """Shear-wave elastography data with per-pixel Cartesian coordinates.
 
     Args:
         values: The shear-wave elastography values in m/s of shape
-            (n_frames, z, x, y) and type float32.
-        extent: The SWE extent in meters of shape (n_frames, 6) or (6,).
+            ``(n_frames, z, x, y)`` and type float32.
+        coordinates: Per-pixel Cartesian positions in metres.
     """
 
     def __post_init__(self):
@@ -770,12 +767,12 @@ class ShearWaveElastographyMap(FloatMap):
 
 @dataclass
 class TissueDopplerMap(FloatMap):
-    """Tissue Doppler data and spatial extent metadata.
+    """Tissue Doppler data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The tissue Doppler values in m/s of shape (n_frames, z, x, y)
+        values: The tissue Doppler values in m/s of shape ``(n_frames, z, x, y)``
             and type float32.
-        extent: The tissue Doppler extent in meters of shape (n_frames, 6) or (6,).
+        coordinates: Per-pixel Cartesian positions in metres.
     """
 
     def __post_init__(self):
@@ -787,14 +784,14 @@ class TissueDopplerMap(FloatMap):
 
 @dataclass
 class ColorDopplerMap(FloatMap):
-    """Color Doppler (velocity) data and spatial extent metadata.
+    """Color Doppler (velocity) data with per-pixel Cartesian coordinates.
 
     Args:
         values: The color Doppler velocity values in m/s of shape
-            (n_frames, z, x, y) and type float32. Positive values
+            ``(n_frames, z, x, y)`` and type float32. Positive values
             indicate flow towards the transducer, negative values
             indicate flow away from the transducer.
-        extent: The color Doppler extent in meters of shape (n_frames, 6) or (6,).
+        coordinates: Per-pixel Cartesian positions in metres.
     """
 
     def __post_init__(self):
@@ -814,18 +811,18 @@ class DataSpec(Spec):
         aligned_data: Time-of-flight corrected data of shape
             (n_frames, n_tx, n_ax, n_el, n_ch) and type float32 or int16.
 
-    Spatial map data products (with extent metadata):
-        - beamformed_data: Beamformed (beamsummed) data and extent metadata.
-        - envelope_data: Envelope-detected data and extent metadata.
-        - image_sc: Scan-converted image data and extent metadata.
-        - image: Reconstructed image data and extent metadata.
-        - segmentation: Segmentation data and extent metadata.
-        - sos_map: Speed-of-sound map data and extent metadata.
-        - strain_percentage_map: Strain map data and extent metadata.
-        - shear_wave_elastography_map: Shear-wave elastography data and extent metadata.
-        - tissue_doppler: Tissue Doppler data and extent metadata.
-        - color_doppler: Color Doppler velocity data and extent metadata.
-        - \\*\\*kwargs: Any other spatially aligned map data and extent metadata.
+    Spatial map data products (values + per-pixel coordinates):
+        - beamformed_data: Beamformed (beamsummed) data and per-pixel coordinates.
+        - envelope_data: Envelope-detected data and per-pixel coordinates.
+        - image_sc: Scan-converted image data and per-pixel coordinates.
+        - image: Reconstructed image data and per-pixel coordinates.
+        - segmentation: Segmentation data and per-pixel coordinates.
+        - sos_map: Speed-of-sound map data and per-pixel coordinates.
+        - strain_percentage_map: Strain map data and per-pixel coordinates.
+        - shear_wave_elastography_map: Shear-wave elastography data and per-pixel coordinates.
+        - tissue_doppler: Tissue Doppler data and per-pixel coordinates.
+        - color_doppler: Color Doppler velocity data and per-pixel coordinates.
+        - \\*\\*kwargs: Any other spatially aligned map data and per-pixel coordinates.
 
     At least one data field (pipeline or spatial map) must be provided.
     """

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -827,7 +827,6 @@ class DataSpec(Spec):
     Spatial map data products (values + per-pixel coordinates):
         - beamformed_data: Beamformed (beamsummed) data and per-pixel coordinates.
         - envelope_data: Envelope-detected data and per-pixel coordinates.
-        - image_sc: Scan-converted image data and per-pixel coordinates.
         - image: Reconstructed image data and per-pixel coordinates.
         - segmentation: Segmentation data and per-pixel coordinates.
         - sos_map: Speed-of-sound map data and per-pixel coordinates.
@@ -1640,8 +1639,7 @@ class FileSpec(Spec):
         This reads all groups into memory and runs the full spec validation
         (dtype, shape, dimension consistency).  Legacy files are handled
         transparently: extra scalar fields in the scan group (``n_frames``,
-        ``n_tx``, etc.) are ignored, flat ``data/image`` datasets are loaded
-        as ``image_sc`` when ``image_sc`` is absent, and the ``probe`` root
+        ``n_tx``, etc.) are ignored, and the ``probe`` root
         attribute is mapped to ``probe_name``.
 
         Args:

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -641,20 +641,6 @@ class Image(Map):
 
 
 @dataclass
-class ImageSc(Image):
-    """Scan-converted image data and spatial extent metadata.
-
-    Args:
-        values: The scan-converted values of shape (n_frames, z, x, y) or (n_frames, z, x)
-            and type uint8 or float32. For float32 values, the values should be in dB
-            (between -inf and 0).
-        extent: Spatial extent in meters of shape (n_frames, 6) or (6,).
-            A shape of (6,) is broadcast to all frames. Values are ordered as
-            (xmin, xmax, ymin, ymax, zmin, zmax) and stored as float32.
-    """
-
-
-@dataclass
 class BeamformedData(FloatMap):
     """Beamformed (beamsummed) data and spatial extent metadata.
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -836,7 +836,6 @@ class DataSpec(Spec):
     # Spatial map data products (with extent metadata)
     beamformed_data: BeamformedData | dict | None = None
     envelope_data: EnvelopeData | dict | None = None
-    image_sc: ImageSc | dict | None = None
     image: Image | dict | None = None
     segmentation: Segmentation | dict | None = None
     sos_map: SosMap | dict | None = None
@@ -858,7 +857,6 @@ class DataSpec(Spec):
         # Spatial map data products
         "beamformed_data": {"spec": BeamformedData},
         "envelope_data": {"spec": EnvelopeData},
-        "image_sc": {"spec": ImageSc},
         "image": {"spec": Image},
         "segmentation": {"spec": Segmentation},
         "sos_map": {"spec": SosMap},
@@ -879,7 +877,6 @@ class DataSpec(Spec):
         aligned_data: np.ndarray | None = None,
         beamformed_data: BeamformedData | dict | None = None,
         envelope_data: EnvelopeData | dict | None = None,
-        image_sc: ImageSc | dict | None = None,
         image: Image | dict | None = None,
         segmentation: Segmentation | dict | None = None,
         sos_map: SosMap | dict | None = None,
@@ -893,7 +890,6 @@ class DataSpec(Spec):
         self.aligned_data = aligned_data
         self.beamformed_data = beamformed_data
         self.envelope_data = envelope_data
-        self.image_sc = image_sc
         self.image = image
         self.segmentation = segmentation
         self.sos_map = sos_map

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -546,6 +546,18 @@ class Map(Spec):
                     f"({self.values.shape}) for non-channeled data, or "
                     f"values.shape[:-1] ({self.values.shape[:-1]}) for channeled data."
                 )
+            # Sanity-check units: clinical ultrasound scan regions are at most a few tens of
+            # centimetres across, so any finite coordinate magnitude above 1 m almost certainly
+            # indicates the array was supplied in millimetres rather than metres.
+            max_abs = np.max(np.abs(self.coordinates[np.isfinite(self.coordinates)]), initial=0.0)
+            if max_abs > 1.0:
+                warnings.warn(
+                    log.warning(
+                        f"Map coordinates have a maximum absolute value of {max_abs:.4g}, which "
+                        "exceeds 1 m.  Ultrasound scan regions are typically a few centimetres "
+                        "across.  Please verify that coordinates are in metres, not millimetres."
+                    )
+                )
         else:
             log.warning(
                 "Map coordinates are not provided, please consider adding a coordinates field "

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -540,8 +540,8 @@ class Map(Spec):
             valid_spatial_shapes = {self.values.shape, self.values.shape[:-1]}
             if coords_spatial not in valid_spatial_shapes:
                 raise ValueError(
-                    f"coordinates shape {self.coordinates.shape} is incompatible with "
-                    f"values shape {self.values.shape}. "
+                    f"{type(self).__name__}: coordinates shape {self.coordinates.shape} is "
+                    f"incompatible with values shape {self.values.shape}. "
                     f"coordinates.shape[:-1] must equal values.shape "
                     f"({self.values.shape}) for non-channeled data, or "
                     f"values.shape[:-1] ({self.values.shape[:-1]}) for channeled data."
@@ -553,15 +553,16 @@ class Map(Spec):
             if max_abs > 1.0:
                 warnings.warn(
                     log.warning(
-                        f"Map coordinates have a maximum absolute value of {max_abs:.4g}, which "
-                        "exceeds 1 m.  Ultrasound scan regions are typically a few centimetres "
-                        "across.  Please verify that coordinates are in metres, not millimetres."
+                        f"{type(self).__name__}: coordinates have a maximum absolute value of "
+                        f"{max_abs:.4g}, which exceeds 1 m.  Ultrasound scan regions are "
+                        "typically a few centimetres across.  Please verify that coordinates "
+                        "are in metres, not millimetres."
                     )
                 )
         else:
             log.warning(
-                "Map coordinates are not provided, please consider adding a coordinates field "
-                "to ensure the map can be correctly displayed."
+                f"{type(self).__name__}: coordinates are not provided, please consider adding "
+                "a coordinates field to ensure the map can be correctly displayed."
             )
 
 


### PR DESCRIPTION
**The problem**
- Currently, our `Map` spec requires specifying an `extent`, but this is ambiguous without specifying the units & sampling grid.
 
**This PR** 
- Updates `Map` from `extent` to requiring Cartesian `coordinates`. Now `Map` defines a straightforward mapping from Cartesian space to some Real numbers (the `values`).
  - This should enable users to specify maps sampled on grids in arbitrary coordinate systems, as long as they can convert them to Cartesian. We already have some functions that can help with this, e.g. [`polar_pixel_grid`](https://zea.readthedocs.io/en/latest/_autosummary/zea.beamform.pixelgrid.html#zea.beamform.pixelgrid.polar_pixel_grid), which I've linked in the docs.
- Removes `ImageSc`, no longer distinguishing a priori between polar / Cartesian images. The user can still save images sampled on multiple grids if they'd like, saving them as custom maps.
- Adds `type(self).__name__` to some error messages printed by abstract classes like `Spec` and `Map` to print the name of the child class to help with debugging. E.g.:

Instead of:
```
TypeError: Field 'values' has invalid dtype: Expected dtype compatible with one of (<class 'numpy.float32'>), got dtype uint8. Hint: wrap the value with the appropriate numpy type, e.g. np.float32(...), np.str_(...), np.uint8(...).
```
We now get (see SosMap):
```
TypeError: SosMap: field 'values' has invalid dtype: Expected dtype compatible with one of (<class 'numpy.float32'>), got dtype uint8. Hint: wrap the value with the appropriate numpy type, e.g. np.float32(...), np.str_(...), np.uint8(...).
```


**Potential downside to consider**
- This may make it harder to aggregate images in their native coordinates systems afterwards, since we would need to detect in some way which grid system was used. We could consider, e.g. having a small set of common grid systems that users could choose from to label their Map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Spatial map data model updated: applications must now provide per-pixel Cartesian `coordinates` instead of `extent` bounds.
  * Removed `image_sc` from available map types.

* **Documentation**
  * Updated spatial map examples to demonstrate the new coordinate-based approach.
  * Documented helper functions for generating coordinate grids matching typical image shapes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tue-bmd/zea/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->