### PR TITLE
Speed up simulation notebook pytest

### DIFF
--- a/docs/source/notebooks/data/zea_simulation_example.ipynb
+++ b/docs/source/notebooks/data/zea_simulation_example.ipynb
@@ -89,15 +89,7 @@
    "execution_count": 4,
    "id": "bd7f70ad",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m nvidia-smi is not available. Please install nvidia-utils. Cannot retrieve GPU memory. Falling back to CPU.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "init_device(verbose=False)\n",
     "set_mpl_style()"
@@ -366,7 +358,7 @@
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No azimuth angles provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'zlims', 'xlims', 'n_el', 'center_frequency'}. Make sure this is intended. This warning will only be shown once.\n"
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'center_frequency', 'zlims', 'n_el', 'xlims'}. Make sure this is intended. This warning will only be shown once.\n"
      ]
     }
    ],
@@ -452,7 +444,20 @@
    "execution_count": 14,
    "id": "83453631",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1mFunction Timing Statistics\u001b[0m\n",
+      "=====================================================================================================\n",
+      "\u001b[36mFunction\u001b[0m              \u001b[32mMean\u001b[0m          \u001b[32mMedian\u001b[0m        \u001b[32mStd Dev\u001b[0m       \u001b[33mMin\u001b[0m           \u001b[33mMax\u001b[0m           \u001b[35mCount\u001b[0m    \n",
+      "-----------------------------------------------------------------------------------------------------\n",
+      "\u001b[36msimulate_rf\u001b[0m           \u001b[32m0.214892\u001b[0m      \u001b[32m0.216736\u001b[0m      \u001b[32m0.008426\u001b[0m      \u001b[33m0.189968\u001b[0m      \u001b[33m0.229841\u001b[0m      \u001b[35m30\u001b[0m       \n",
+      "\u001b[36msimulate_rf (JIT)\u001b[0m     \u001b[32m0.003745\u001b[0m      \u001b[32m0.003770\u001b[0m      \u001b[32m0.000183\u001b[0m      \u001b[33m0.003239\u001b[0m      \u001b[33m0.004098\u001b[0m      \u001b[35m30\u001b[0m       \n"
+     ]
+    }
+   ],
    "source": [
     "from zea.utils import FunctionTimer\n",
     "\n",
@@ -498,7 +503,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "zea-env",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -512,7 +517,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/docs/source/notebooks/data/zea_simulation_example.ipynb
+++ b/docs/source/notebooks/data/zea_simulation_example.ipynb
@@ -89,10 +89,32 @@
    "execution_count": 4,
    "id": "bd7f70ad",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m nvidia-smi is not available. Please install nvidia-utils. Cannot retrieve GPU memory. Falling back to CPU.\n"
+     ]
+    }
+   ],
    "source": [
     "init_device(verbose=False)\n",
     "set_mpl_style()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "params_cell_sim",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "n_repeats = 30  # number of timing repetitions"
    ]
   },
   {
@@ -105,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "cc4d7097",
    "metadata": {},
    "outputs": [],
@@ -140,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "9bd4100a",
    "metadata": {},
    "outputs": [],
@@ -149,7 +171,12 @@
     "n_el = 64\n",
     "aperture = 20e-3\n",
     "probe_geometry = np.stack(\n",
-    "    [np.linspace(-aperture / 2, aperture / 2, n_el), np.zeros(n_el), np.zeros(n_el)], axis=1\n",
+    "    [\n",
+    "        np.linspace(-aperture / 2, aperture / 2, n_el),\n",
+    "        np.zeros(n_el),\n",
+    "        np.zeros(n_el),\n",
+    "    ],\n",
+    "    axis=1,\n",
     ")\n",
     "\n",
     "probe = Probe(\n",
@@ -169,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ee300172",
    "metadata": {},
    "outputs": [],
@@ -205,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "2382cfb2",
    "metadata": {},
    "outputs": [],
@@ -249,7 +276,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "09a3db57",
    "metadata": {},
    "outputs": [
@@ -300,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "19435040",
    "metadata": {},
    "outputs": [],
@@ -328,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "aef498ed",
    "metadata": {},
    "outputs": [
@@ -336,9 +363,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No azimuth angles provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'center_frequency', 'xlims', 'n_el', 'zlims'}. Make sure this is intended. This warning will only be shown once.\n"
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'zlims', 'xlims', 'n_el', 'center_frequency'}. Make sure this is intended. This warning will only be shown once.\n"
      ]
     }
    ],
@@ -401,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "8aa8873d",
    "metadata": {},
    "outputs": [],
@@ -421,23 +449,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "83453631",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[1mFunction Timing Statistics\u001b[0m\n",
-      "=====================================================================================================\n",
-      "\u001b[36mFunction\u001b[0m              \u001b[32mMean\u001b[0m          \u001b[32mMedian\u001b[0m        \u001b[32mStd Dev\u001b[0m       \u001b[33mMin\u001b[0m           \u001b[33mMax\u001b[0m           \u001b[35mCount\u001b[0m    \n",
-      "-----------------------------------------------------------------------------------------------------\n",
-      "\u001b[36msimulate_rf\u001b[0m           \u001b[32m0.220066\u001b[0m      \u001b[32m0.218923\u001b[0m      \u001b[32m0.021850\u001b[0m      \u001b[33m0.189399\u001b[0m      \u001b[33m0.255911\u001b[0m      \u001b[35m30\u001b[0m       \n",
-      "\u001b[36msimulate_rf (JIT)\u001b[0m     \u001b[32m0.004081\u001b[0m      \u001b[32m0.003444\u001b[0m      \u001b[32m0.003207\u001b[0m      \u001b[33m0.003159\u001b[0m      \u001b[33m0.020947\u001b[0m      \u001b[35m30\u001b[0m       \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from zea.utils import FunctionTimer\n",
     "\n",
@@ -448,7 +463,7 @@
     "timed_rf = timer(simulate_rf, name=\"simulate_rf\")\n",
     "timed_rf_jit = timer(simulate_rf_jit, name=\"simulate_rf (JIT)\")\n",
     "\n",
-    "for _ in range(30):\n",
+    "for _ in range(n_repeats):\n",
     "    timed_rf_jit(**simulation_args)\n",
     "    timed_rf(**simulation_args)\n",
     "\n",
@@ -483,7 +498,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "zea-env",
    "language": "python",
    "name": "python3"
   },
@@ -497,7 +512,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -109,6 +109,9 @@ NOTEBOOK_PARAMETERS = {
         "grid_size_x": 16,
         "grid_size_z": 16,
     },
+    "zea_simulation_example.ipynb": {
+        "n_repeats": 2,
+    },
     # Add more notebooks and their parameters here as needed
     # "other_notebook.ipynb": {
     #     "param1": value1,


### PR DESCRIPTION
See #364. I saw consistency between slow pytest heavy runs where the simulation notebook stalled. Since addition of the benchmark (last cell) in this notebook I think it has been quite slow. Might not solve #364 entirely but partly maybe. There was an easy win by reducing the num of iterations in the last cell with parameter injection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the simulation example notebook with improved code structure for better readability and refreshed benchmark performance data.

* **Tests**
  * Added continuous integration configuration to automatically validate the example notebook as part of the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tue-bmd/zea/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->