### PR TITLE
Improve repr / str across zea objects

### DIFF
--- a/tests/data/test_dataloader.py
+++ b/tests/data/test_dataloader.py
@@ -653,9 +653,11 @@ def test_dataloader_repr(dummy_hdf5):
         batch_size=4,
     )
     repr_str = repr(loader)
-    assert "<Dataloader:" in repr_str
+    assert "Dataloader(" in repr_str
+    assert "n_samples=" in repr_str
     assert "batch_size=4" in repr_str
     assert "key='data'" in repr_str
+    assert "threads=" in repr_str
 
 
 def test_assert_image_range_below():

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -204,8 +204,7 @@ def test_dataset_properties(dummy_dataset_path):
     with Dataset(dummy_dataset_path, validate=False) as dataset:
         assert dataset.n_files == 2
         assert len(dataset) == 2
-        assert repr(dataset).startswith("<zea.data.datasets.Dataset at 0x")
-        assert "2 files" in repr(dataset)
+        assert repr(dataset) == "Dataset(n_files=2)"
         assert str(dataset) == "Dataset with 2 files"
 
 

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -193,8 +193,7 @@ def test_folder_properties(dummy_dataset_path):
 
     assert folder.n_files == 2
     assert len(folder) == 2
-    assert repr(folder).startswith("<zea.data.datasets.Folder at 0x")
-    assert "2 files" in repr(folder)
+    assert repr(folder) == f"Folder(n_files=2, folder='{dummy_dataset_path}')"
     assert str(dummy_dataset_path) in repr(folder)
     assert str(folder) == f"Folder with 2 files in '{dummy_dataset_path}'"
 

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -1152,14 +1152,15 @@ class TestMultiTrackFile:
         path, *_ = _make_two_track_spec(tmp_path)
         with File(path) as f:
             r = repr(f.tracks[1])
-        assert "index=1" in r
+        assert r.startswith("<Track[1]")
+        assert "data=" in r
 
     def test_track_repr_includes_label(self, tmp_path):
         """repr(track) includes the label when one is set."""
         path, *_ = _make_two_track_spec(tmp_path)
         with File(path) as f:
             r = repr(f.tracks[0])
-        assert "label='track_a'" in r
+        assert '"track_a"' in r
 
     # ------------------------------------------------------------------
     # Track.label, File.track_labels, File.get_track

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -318,6 +318,14 @@ class TestGroupProxy:
             assert "raw_data" in d
             assert "envelope_data" in d
 
+    def test_repr_delegates_to_h5py(self, spec_file):
+        """_GroupProxy repr shows the underlying HDF5 group path."""
+        path, *_ = spec_file
+        with File(path) as f:
+            r = repr(f.data)
+        assert "HDF5 group" in r
+        assert "data" in r
+
 
 class TestFileDataProperty:
     def test_data_property_returns_group_proxy(self, spec_file):
@@ -990,6 +998,81 @@ def _make_two_track_spec(tmp_path, n_frames=2, n_tx=3, n_el=4, n_ax=8, n_ch=1):
     )
     f.close()
     return path, raw_a, raw_b
+
+
+class TestRepr:
+    """Tests for __repr__ / __str__ of File, Track, _StringDataset."""
+
+    def test_file_repr_single_track(self, tmp_path):
+        """Single-track file repr shows filename, mode and '1 track'."""
+        path = tmp_path / "single.hdf5"
+        File.create(
+            path,
+            data={"raw_data": np.zeros((1, 2, 8, 4, 1), dtype=np.float32)},
+            scan=_scan_minimal(n_frames=1, n_tx=2, n_el=4),
+        ).close()
+        with File(path) as f:
+            r = repr(f)
+        assert r.startswith('<File "')
+        assert "single.hdf5" in r
+        assert "mode r" in r
+        assert "1 track" in r
+
+    def test_file_repr_multi_track_with_labels(self, tmp_path):
+        """Multi-track repr includes track count and label names."""
+        path, *_ = _make_two_track_spec(tmp_path)
+        with File(path) as f:
+            r = repr(f)
+        assert "2 tracks" in r
+        assert '"track_a"' in r
+        assert '"track_b"' in r
+
+    def test_file_str_equals_repr(self, tmp_path):
+        path = tmp_path / "s.hdf5"
+        File.create(
+            path,
+            data={"raw_data": np.zeros((1, 2, 8, 4, 1), dtype=np.float32)},
+            scan=_scan_minimal(n_frames=1, n_tx=2, n_el=4),
+        ).close()
+        with File(path) as f:
+            assert repr(f) == str(f)
+
+    def test_track_repr_with_label(self, tmp_path):
+        """Track repr shows index, label, and data keys."""
+        path, *_ = _make_two_track_spec(tmp_path)
+        with File(path) as f:
+            r = repr(f.tracks[0])
+        assert r.startswith("<Track[0]")
+        assert '"track_a"' in r
+        assert "data=" in r
+        assert "raw_data" in r
+
+    def test_track_repr_without_label(self, tmp_path):
+        """Track repr omits label part when track has no label."""
+        path = tmp_path / "nolabel.hdf5"
+        File.create(
+            path,
+            data={"raw_data": np.zeros((1, 2, 8, 4, 1), dtype=np.float32)},
+            scan=_scan_minimal(n_frames=1, n_tx=2, n_el=4),
+        ).close()
+        with File(path) as f:
+            r = repr(f.tracks[0])
+        assert "<Track[0]" in r
+        assert "data=" in r
+        # no spurious quote from a missing label
+        assert r.count('"') == 0 or r.startswith("<Track[0] data=")
+
+    def test_string_dataset_repr(self, tmp_path):
+        """_StringDataset repr mentions shape and str dtype."""
+        path = tmp_path / "sd.hdf5"
+        with h5py.File(path, "w") as f:
+            f.create_dataset("labels", data=np.array([b"a", b"b"]))
+        with h5py.File(path, "r") as f:
+            ds = _StringDataset(f["labels"])
+            r = repr(ds)
+        assert "StringDataset" in r
+        assert "shape" in r
+        assert "str" in r
 
 
 class TestMultiTrackFile:

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -207,7 +207,7 @@ class TestStringDataset:
         with h5py.File(path, "r") as f:
             ds = _StringDataset(f["labels"])
             assert len(ds) == 2
-            assert "_StringDataset" in repr(ds)
+            assert "StringDataset" in repr(ds)
 
     def test_getattr_delegates_to_dataset(self, tmp_path):
         path = tmp_path / "str_attr.hdf5"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -312,6 +312,15 @@ def test_config_recursive():
     config_check_equal_recursive(config, expected_config)
 
 
+def test_config_repr():
+    """Config repr is Config({...}) with no angle brackets."""
+    config = Config(simple_dict)
+    r = repr(config)
+    assert r.startswith("Config(")
+    assert r.endswith(")")
+    assert "<" not in r
+
+
 def test_config_pickle():
     """Tests if the config can be pickled and unpickled without changing its contents."""
     import pickle

--- a/tests/test_ops_infra.py
+++ b/tests/test_ops_infra.py
@@ -1057,16 +1057,23 @@ def test_all_functions_exported():
 
 
 def test_pipeline_repr():
-    """Test Pipeline.__repr__ output format."""
+    """Pipeline repr is constructor-style with no angle brackets."""
     pipeline = ops.Pipeline([MultiplyOperation(), AddOperation()], name="test_pipe")
     r = repr(pipeline)
-    assert r == "<Pipeline test_pipe=(MultiplyOperation, AddOperation)>"
+    assert r.startswith("Pipeline(")
+    assert r.endswith(")")
+    assert "<" not in r
+    assert "name='test_pipe'" in r
+    assert "operations=[" in r
+    assert "MultiplyOperation" in r
+    assert "AddOperation" in r
 
     # Nested pipeline repr
     inner = ops.Pipeline([AddOperation()], name="inner")
     outer = ops.Pipeline([MultiplyOperation(), inner], name="outer")
     r2 = repr(outer)
-    assert "Pipeline inner" in r2
+    assert "Pipeline(" in r2
+    assert "inner" in r2
 
 
 def test_pipeline_eq():
@@ -1210,11 +1217,13 @@ def test_patched_grid_get_dict():
 
 
 def test_beamform_repr():
-    """Test Beamform.__repr__ returns the expected format."""
+    """Test Beamform.__repr__ returns constructor-style format."""
 
     b = Beamform(num_patches=1, jit_options=None)
     r = repr(b)
-    assert r.startswith("<Beamform")
+    assert r.startswith("Beamform(")
+    assert r.endswith(")")
+    assert "<" not in r
     assert "TOFCorrection" in r
 
 

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -69,6 +69,17 @@ def test_file_create_accepts_probe_object():
         os.unlink(path)
 
 
+def test_probe_repr():
+    """Probe repr is a single-line constructor-style string with key fields."""
+    probe = Probe.from_name("verasonics_l11_4v")
+    r = repr(probe)
+    assert r.startswith("Probe(")
+    assert r.endswith(")")
+    assert "\n" not in r
+    assert "name=" in r
+    assert "MHz" in r
+
+
 def test_file_create_probe_wrong_type():
     """File.create should raise TypeError when probe is an unsupported type."""
     n_frames, n_tx, n_el, n_ax = 1, 4, 128, 64

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -40,6 +40,27 @@ scan_args = {
 }
 
 
+def test_scan_repr():
+    """Scan repr is a single-line constructor-style string."""
+    scan = Scan(**scan_args)
+    r = repr(scan)
+    assert r.startswith("Scan(")
+    assert r.endswith(")")
+    assert "\n" not in r
+    assert "sampling_frequency=" in r
+    assert "MHz" in r
+
+
+def test_scan_str():
+    """Scan str is a multi-line constructor-style string."""
+    scan = Scan(**scan_args)
+    s = str(scan)
+    assert s.startswith("Scan(\n")
+    assert s.endswith("\n)")
+    assert "\n" in s
+    assert "sampling_frequency=" in s
+
+
 def test_scan_compare():
     """Test comparison of Scan objects."""
     scan = Scan(**scan_args)

--- a/zea/config.py
+++ b/zea/config.py
@@ -365,7 +365,7 @@ class Config(dict):
         del self[name]
 
     def __repr__(self):
-        return f"<Config {self.as_dict()}>"
+        return f"Config({self.as_dict()})"
 
     def to_json(self):
         """Return the config as a json string."""

--- a/zea/config.py
+++ b/zea/config.py
@@ -179,7 +179,7 @@ class Config(dict):
                 >>> config.update_recursive({"a": 4, "b": {"c": 5}})
                 >>> # Notice how "d" is kept and only "c" is updated.
                 >>> print(config)
-                <Config {'a': 4, 'b': {'c': 5, 'd': 3}}>
+                Config({'a': 4, 'b': {'c': 5, 'd': 3}})
 
         Args:
             dictionary (dict, optional): Dictionary to update from.

--- a/zea/data/dataloader.py
+++ b/zea/data/dataloader.py
@@ -684,10 +684,10 @@ class Dataloader:
 
     def __repr__(self):
         return (
-            f"<Dataloader: {len(self.source)} samples, "
+            f"Dataloader(n_samples={len(self.source)}, "
             f"batch_size={self.batch_size}, "
             f"key='{self.source.key}', "
-            f"threads={self.num_threads}>"
+            f"threads={self.num_threads})"
         )
 
     @staticmethod

--- a/zea/data/datasets.py
+++ b/zea/data/datasets.py
@@ -42,6 +42,9 @@ import tqdm
 
 from zea import log
 from zea.data.file import File
+from zea.datapaths import format_data_path
+from zea.internal.cache import cache_output
+from zea.internal.core import hash_elements
 from zea.internal.preset_utils import (
     HF_DATASETS_DIR,
     HF_PREFIX,
@@ -49,9 +52,6 @@ from zea.internal.preset_utils import (
     _hf_parse_path,
     _hf_resolve_path,
 )
-from zea.datapaths import format_data_path
-from zea.internal.cache import cache_output
-from zea.internal.core import hash_elements
 from zea.internal.utils import calculate_file_hash, reduce_to_signature
 from zea.io_lib import search_file_tree
 from zea.tools.hf import HFPath
@@ -376,10 +376,7 @@ class Folder:
             log.warning(f"Unable to write validation flag: {e}")
 
     def __repr__(self):
-        return (
-            f"<zea.data.datasets.Folder at 0x{id(self):x}: "
-            f"{self.n_files} files, folder='{self.folder_path}'>"
-        )
+        return f"Folder(n_files={self.n_files}, folder='{self.folder_path}')"
 
     def __str__(self):
         return f"Folder with {self.n_files} files in '{self.folder_path}'"
@@ -549,7 +546,7 @@ class Dataset(H5FileHandleCache):
         return sum(self.get_file(file_path).n_frames for file_path in self.file_paths)
 
     def __repr__(self):
-        return f"<zea.data.datasets.Dataset at 0x{id(self):x}: {self.n_files} files>"
+        return f"Dataset(n_files={self.n_files})"
 
     def __str__(self):
         return f"Dataset with {self.n_files} files"

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -52,7 +52,7 @@ class _StringDataset:
         return len(self._ds)
 
     def __repr__(self):
-        return f"<_StringDataset wrapping {self._ds!r}>"
+        return f"<StringDataset shape={self._ds.shape} dtype=str>"
 
 
 class _GroupProxy:
@@ -98,7 +98,7 @@ class _GroupProxy:
         return list(self._group.keys())
 
     def __repr__(self):
-        return f"<GroupProxy '{self._group.name}' keys={list(self._group.keys())}>"
+        return repr(self._group)
 
     def keys(self):
         """Return the keys of the underlying group."""
@@ -227,8 +227,9 @@ class Track:
         return self._timestamps
 
     def __repr__(self) -> str:
-        label_part = f" label={self._label!r}" if self._label is not None else ""
-        return f"<Track index={self._index}{label_part} keys={list(self._group.keys())}>"
+        label_part = f' "{self._label}"' if self._label is not None else ""
+        keys = list(self._group.get("data", {}).keys())
+        return f"<Track[{self._index}]{label_part} data={keys}>"
 
 
 def load_dict_from_hdf5_group(group: "h5py.Group") -> dict:
@@ -612,7 +613,7 @@ class File(h5py.File):
             for track, ts in zip(tracks, all_timestamps):
                 object.__setattr__(track, "_timestamps", ts)
         else:
-            log.warning(
+            log.warning_once(
                 "`track_schedule` was not found in the file; cannot compute track timestamps."
             )
 
@@ -634,7 +635,20 @@ class File(h5py.File):
                 print(f.track_labels)  # ['focused', 'planewave']
                 focused, planewave = f.tracks  # safe — same order
         """
-        return [t.label for t in self.tracks]
+        if "tracks" not in self:
+            return []
+        tracks_group = self["tracks"]
+        labels = []
+        i = 0
+        while f"track_{i}" in tracks_group:
+            tg = tracks_group[f"track_{i}"]
+            if "label" in tg:
+                raw = tg["label"][()]
+                labels.append(raw.decode() if isinstance(raw, bytes) else str(raw))
+            else:
+                labels.append(None)
+            i += 1
+        return labels
 
     def get_track(self, label: str) -> "Track":
         """Return the track with the given label.
@@ -1363,10 +1377,21 @@ class File(h5py.File):
         return FileSpec.from_hdf5(self)
 
     def __repr__(self):
-        return f'<zea.File at 0x{id(self):x} ("{Path(self.filename).name}" mode={self.mode})>'
-
-    def __str__(self):
-        return f"zea HDF5 File: '{self.path.name}' (mode={self.mode})"
+        name = Path(self.filename).name
+        try:
+            n = self._n_tracks
+            if n > 1:
+                labels = self.track_labels
+                label_str = ", ".join(
+                    f'"{label}"' if label else str(i) for i, label in enumerate(labels)
+                )
+                track_info = f"{n} tracks: {label_str}"
+            else:
+                track_info = f"{n} track"
+        except Exception:
+            track_info = ""
+        mode_info = f"mode {self.mode}"
+        return f'<File "{name}" ({mode_info}, {track_info})>'
 
     def copy_key(self, key: str, dst: "File"):
         """Copy a specific key to another file.

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -522,6 +522,21 @@ class Spec:
         """Get the dtype of a field."""
         return cls.SCHEMA[field_name]["dtype"]
 
+    def __repr__(self) -> str:
+        parts = []
+        for field_name, field_info in self.SCHEMA.items():
+            value = getattr(self, field_name, None)
+            if value is None:
+                continue
+            nested_spec = field_info.get("spec")
+            if nested_spec is not None:
+                parts.append(f"{field_name}={value!r}")
+            elif isinstance(value, np.ndarray):
+                parts.append(f"{field_name}=array({value.dtype} {value.shape})")
+            else:
+                parts.append(f"{field_name}={value!r}")
+        return f"{self.__class__.__name__}({', '.join(parts)})"
+
 
 @dataclass
 class Map(Spec):

--- a/zea/internal/parameters.py
+++ b/zea/internal/parameters.py
@@ -593,18 +593,29 @@ class Parameters(ZeaObject):
 
         return tensor_dict
 
+    @staticmethod
+    def _fmt_value(k: str, v) -> str:
+        """Format a single parameter value for display."""
+        if isinstance(v, np.ndarray):
+            return f"array({v.dtype} {v.shape})"
+        if isinstance(v, list):
+            if len(v) > 8:
+                head = ", ".join(repr(x) for x in v[:4])
+                tail = ", ".join(repr(x) for x in v[-2:])
+                return f"[{head}, ..., {tail}] (len={len(v)})"
+            return repr(v)
+        # Show Hz-based fields in MHz for readability
+        _freq_keys = {"center_frequency", "sampling_frequency", "demodulation_frequency"}
+        if k in _freq_keys and isinstance(v, (int, float, np.floating, np.integer)):
+            return f"{float(v) / 1e6:.4g} MHz"
+        return repr(v)
+
     def __repr__(self):
         param_lines = []
         for k, v in self._params.items():
             if v is None:
                 continue
-
-            # Handle arrays by showing their shape instead of content
-            if isinstance(v, np.ndarray):
-                param_lines.append(f"{k}=array(shape={v.shape})")
-            else:
-                param_lines.append(f"{k}={repr(v)}")
-
+            param_lines.append(f"{k}={self._fmt_value(k, v)}")
         param_str = ", ".join(param_lines)
         return f"{self.__class__.__name__}({param_str})"
 
@@ -613,13 +624,7 @@ class Parameters(ZeaObject):
         for k, v in self._params.items():
             if v is None:
                 continue
-
-            # Handle arrays by showing their shape instead of content
-            if isinstance(v, np.ndarray):
-                param_lines.append(f"    {k}=array(shape={v.shape})")
-            else:
-                param_lines.append(f"    {k}={v}")
-
+            param_lines.append(f"    {k}={self._fmt_value(k, v)}")
         param_str = ",\n".join(param_lines)
         return f"{self.__class__.__name__}(\n{param_str}\n)"
 

--- a/zea/log.py
+++ b/zea/log.py
@@ -17,6 +17,7 @@ Example usage
 """
 
 import contextlib
+import inspect
 import logging
 import os
 import re
@@ -241,11 +242,25 @@ def success(message):
     return message
 
 
+# Track locations that have already emitted a once-only warning
+_warned_locations: set = set()
+
+
 def warning(message, *args, **kwargs):
     """Prints a message with log level warning."""
     logger.warning(message, *args, **kwargs)
     if file_logger:
         file_logger.warning(remove_color_escape_codes(message), *args, **kwargs)
+    return message
+
+
+def warning_once(message, *args, **kwargs):
+    """Prints a warning message only once per call location."""
+    frame = inspect.stack()[1]
+    key = f"{frame.filename}:{frame.lineno}"
+    if key not in _warned_locations:
+        _warned_locations.add(key)
+        warning(message, *args, **kwargs)
     return message
 
 

--- a/zea/ops/pipeline.py
+++ b/zea/ops/pipeline.py
@@ -520,7 +520,7 @@ class Pipeline:
                 operations.append(repr(operation))
             else:
                 operations.append(operation.__class__.__name__)
-        return f"<Pipeline {self.name}=({', '.join(operations)})>"
+        return f"Pipeline(name={self.name!r}, operations=[{', '.join(operations)}])"
 
     @classmethod
     def load(cls, file_path: str, **kwargs) -> "Pipeline":
@@ -1104,7 +1104,7 @@ class Beamform(Pipeline):
                 operations.append(repr(operation))
             else:
                 operations.append(operation.__class__.__name__)
-        return f"<Beamform {self.name}=({', '.join(operations)})>"
+        return f"Beamform(name={self.name!r}, operations=[{', '.join(operations)}])"
 
     def get_dict(self, compact=True) -> dict:
         """Convert the pipeline to a dictionary.

--- a/zea/probes.py
+++ b/zea/probes.py
@@ -152,6 +152,23 @@ class Probe(ProbeSpec):
     def get_parameters(self):
         return {key: getattr(self, key) for key in self.SCHEMA}
 
+    def __repr__(self) -> str:
+        parts = []
+        if self.name is not None:
+            parts.append(f"name='{self.name}'")
+        if self.type is not None:
+            parts.append(f"type='{self.type}'")
+        if self.probe_geometry is not None:
+            n_el = self.probe_geometry.shape[0]
+            parts.append(f"n_el={n_el}")
+        if self.center_frequency is not None:
+            parts.append(f"fc={float(self.center_frequency) / 1e6:.2f} MHz")
+        if self.bandwidth_percent is not None:
+            parts.append(f"bw={float(self.bandwidth_percent):.1f}%")
+        if self.element_width is not None:
+            parts.append(f"pitch={float(self.element_width) * 1e3:.3f} mm")
+        return f"Probe({', '.join(parts)})"
+
     @classmethod
     def from_name(cls, probe_name, **kwargs) -> "Probe":
         """Create a probe from its name.


### PR DESCRIPTION
**Motivation:** repr outputs were inconsistent (mix of angle-bracket resource handles and value objects, `zea.` module prefixes, wrong constructor arg names, hex object addresses) and warnings in `File.tracks` fired on every access.

**Changes:**
- Added `log.warning_once()` — suppresses duplicate warnings per call-site
- `track_labels` now reads HDF5 directly (no `Track` objects, no spurious warnings)
- Unified repr style: `<ClassName ...>` for resource handles (File, Track), `ClassName(...)` for value/config objects (Probe, Scan, Pipeline, Beamform, Config, Dataset, Folder, Dataloader)
- Removed `zea.` module prefixes; use real constructor arg names

**Examples:**
```python
repr(file)      # <File "patient.hdf5" (mode r, 2 tracks: "bmode", "doppler")>
repr(track)     # <Track[0] "4C" data=['raw_data']>
repr(probe)     # Probe(name='L7-4', fc=5.208 MHz, n_el=128)
repr(pipeline)  # Pipeline(name='bmode', operations=[Demodulate, TOFCorrection, LogCompress])
repr(dataset)   # Dataset(n_files=42)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `warning_once()` helper function for single-emission warnings.
  * Added `__repr__()` methods to `Spec` and `Probe` classes for improved object representation.

* **Improvements**
  * Updated string representations across multiple classes to use constructor-style formatting instead of memory-address-based format for improved readability.
  * Enhanced parameter and array value formatting for better diagnostics output.

* **Tests**
  * Added comprehensive test coverage for `repr()` behavior across `Config`, `File`, `Track`, `Dataloader`, `Pipeline`, `Beamform`, `Probe`, and `Scan` classes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tue-bmd/zea/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->