### PR TITLE
Split heavy tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -137,7 +137,7 @@ jobs:
             -v "${{ github.workspace }}:/zea" \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest --cov --cov-branch --cov-report=xml -p no:cacheprovider -m 'heavy' ./tests/test_ops_infra.py ./tests/test_transmit_schemes.py ./tests/data/test_conversion_scripts.py"
+            sh -lc "pytest --cov --cov-branch --cov-report=xml -p no:cacheprovider -m 'heavy' ./tests"
 
       - name: Upload heavy test results to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,10 @@ env:
   REGISTRY: ghcr.io
   BASE_IMAGE: ghcr.io/tue-bmd/zea/all-cpu
   MAIN_REPO: tue-bmd/zea
-  HF_CACHE_MOUNT: /opt/hf-cache:/root/.cache/huggingface
-  ZEA_CACHE_MOUNT: /opt/zea-cache:/root/.cache/zea
+  HF_CACHE_HOST: /cache/huggingface
+  HF_CACHE_CONTAINER: /cache/huggingface
+  ZEA_CACHE_HOST: /cache/zea
+  ZEA_CACHE_CONTAINER: /cache/zea
 
 jobs:
   tag:
@@ -137,10 +139,11 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_MOUNT }} \
-            -v ${{ env.ZEA_CACHE_MOUNT }} \
-            -e HF_HOME=/root/.cache/huggingface \
-            -e ZEA_CACHE_DIR=/root/.cache/zea \
+            -v $HF_CACHE_HOST:$HF_CACHE_CONTAINER \
+            -v $ZEA_CACHE_HOST:$ZEA_CACHE_CONTAINER \
+            -e HF_HOME=$HF_CACHE_CONTAINER \
+            -e HUGGINGFACE_HUB_CACHE=$HF_CACHE_CONTAINER \
+            -e ZEA_CACHE_DIR=$ZEA_CACHE_CONTAINER \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest --cov --cov-branch --cov-report=xml -p no:cacheprovider -m 'heavy' ./tests"
@@ -167,10 +170,11 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_MOUNT }} \
-            -v ${{ env.ZEA_CACHE_MOUNT }} \
-            -e HF_HOME=/root/.cache/huggingface \
-            -e ZEA_CACHE_DIR=/root/.cache/zea \
+            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
+            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
+            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
+            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
+            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir agent"
@@ -190,10 +194,11 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_MOUNT }} \
-            -v ${{ env.ZEA_CACHE_MOUNT }} \
-            -e HF_HOME=/root/.cache/huggingface \
-            -e ZEA_CACHE_DIR=/root/.cache/zea \
+            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
+            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
+            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
+            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
+            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir models"
@@ -213,10 +218,11 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_MOUNT }} \
-            -v ${{ env.ZEA_CACHE_MOUNT }} \
-            -e HF_HOME=/root/.cache/huggingface \
-            -e ZEA_CACHE_DIR=/root/.cache/zea \
+            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
+            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
+            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
+            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
+            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir pipeline"
@@ -236,10 +242,11 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_MOUNT }} \
-            -v ${{ env.ZEA_CACHE_MOUNT }} \
-            -e HF_HOME=/root/.cache/huggingface \
-            -e ZEA_CACHE_DIR=/root/.cache/zea \
+            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
+            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
+            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
+            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
+            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir data --notebook-dir metrics"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -131,13 +131,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Run heavy Pytest
+      - name: Run heavy tests
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest --cov --cov-branch --cov-report=xml -p no:cacheprovider -m 'heavy' ./tests"
+            sh -lc "pytest --cov --cov-branch --cov-report=xml -p no:cacheprovider -m 'heavy' ./tests/test_ops_infra.py ./tests/test_transmit_schemes.py ./tests/data/test_conversion_scripts.py"
 
       - name: Upload heavy test results to Codecov
         uses: codecov/codecov-action@v6
@@ -146,13 +146,81 @@ jobs:
           slug: ${{ env.MAIN_REPO }}
           flags: heavy
 
-      - name: Run notebook tests with Pytest
+  notebook-tests-agent:
+    needs: [image]
+    runs-on: self-hosted
+    timeout-minutes: 100
+    concurrency:
+      group: notebook-tests-agent-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run agent notebook tests
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest -p no:cacheprovider -s -m 'notebook'"
+            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir agent"
+
+  notebook-tests-models:
+    needs: [image]
+    runs-on: self-hosted
+    timeout-minutes: 100
+    concurrency:
+      group: notebook-tests-models-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run models notebook tests
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/zea" \
+            -w /zea \
+            ${{ needs.image.outputs.docker_image }} \
+            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir models"
+
+  notebook-tests-pipeline:
+    needs: [image]
+    runs-on: self-hosted
+    timeout-minutes: 100
+    concurrency:
+      group: notebook-tests-pipeline-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run pipeline notebook tests
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/zea" \
+            -w /zea \
+            ${{ needs.image.outputs.docker_image }} \
+            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir pipeline"
+
+  notebook-tests-data-metrics:
+    needs: [image]
+    runs-on: self-hosted
+    timeout-minutes: 100
+    concurrency:
+      group: notebook-tests-data-metrics-${{ github.ref }}
+      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run data and metrics notebook tests
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/zea" \
+            -w /zea \
+            ${{ needs.image.outputs.docker_image }} \
+            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir data --notebook-dir metrics"
 
   test-docs-build:
     needs: [image]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -154,20 +154,32 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ${{ env.MAIN_REPO }}
           flags: heavy
-
-  notebook-tests-agent:
+  notebook-tests:
     needs: [image]
     runs-on: self-hosted
     timeout-minutes: 100
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: agent
+            dirs: agent
+          - name: models
+            dirs: models
+          - name: pipeline
+            dirs: pipeline
+          - name: data-metrics
+            dirs: "data metrics"
     concurrency:
-      group: notebook-tests-agent-${{ github.ref }}
+      group: notebook-tests-${{ matrix.name }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Run agent notebook tests
+      - name: Run ${{ matrix.name }} notebook tests
         run: |
+          DIRS_ARGS=$(echo "${{ matrix.dirs }}" | tr ' ' '\n' | sed 's/^/--notebook-dir /' | tr '\n' ' ')
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
             -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
@@ -177,79 +189,7 @@ jobs:
             -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir agent"
-
-  notebook-tests-models:
-    needs: [image]
-    runs-on: self-hosted
-    timeout-minutes: 100
-    concurrency:
-      group: notebook-tests-models-${{ github.ref }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Run models notebook tests
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
-            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
-            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
-            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
-            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
-            -w /zea \
-            ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir models"
-
-  notebook-tests-pipeline:
-    needs: [image]
-    runs-on: self-hosted
-    timeout-minutes: 100
-    concurrency:
-      group: notebook-tests-pipeline-${{ github.ref }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Run pipeline notebook tests
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
-            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
-            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
-            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
-            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
-            -w /zea \
-            ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir pipeline"
-
-  notebook-tests-data-metrics:
-    needs: [image]
-    runs-on: self-hosted
-    timeout-minutes: 100
-    concurrency:
-      group: notebook-tests-data-metrics-${{ github.ref }}
-      cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Run data and metrics notebook tests
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/zea" \
-            -v ${{ env.HF_CACHE_HOST }}:${{ env.HF_CACHE_CONTAINER }} \
-            -v ${{ env.ZEA_CACHE_HOST }}:${{ env.ZEA_CACHE_CONTAINER }} \
-            -e HF_HOME=${{ env.HF_CACHE_CONTAINER }} \
-            -e HUGGINGFACE_HUB_CACHE=${{ env.HF_CACHE_CONTAINER }} \
-            -e ZEA_CACHE_DIR=${{ env.ZEA_CACHE_CONTAINER }} \
-            -w /zea \
-            ${{ needs.image.outputs.docker_image }} \
-            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir data --notebook-dir metrics"
+            sh -lc "pytest -p no:cacheprovider -s -m 'notebook' $DIRS_ARGS"
 
   test-docs-build:
     needs: [image]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,6 +10,8 @@ env:
   REGISTRY: ghcr.io
   BASE_IMAGE: ghcr.io/tue-bmd/zea/all-cpu
   MAIN_REPO: tue-bmd/zea
+  HF_CACHE_MOUNT: /opt/hf-cache:/root/.cache/huggingface
+  ZEA_CACHE_MOUNT: /opt/zea-cache:/root/.cache/zea
 
 jobs:
   tag:
@@ -135,6 +137,10 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
+            -v ${{ env.HF_CACHE_MOUNT }} \
+            -v ${{ env.ZEA_CACHE_MOUNT }} \
+            -e HF_HOME=/root/.cache/huggingface \
+            -e ZEA_CACHE_DIR=/root/.cache/zea \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest --cov --cov-branch --cov-report=xml -p no:cacheprovider -m 'heavy' ./tests"
@@ -161,6 +167,10 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
+            -v ${{ env.HF_CACHE_MOUNT }} \
+            -v ${{ env.ZEA_CACHE_MOUNT }} \
+            -e HF_HOME=/root/.cache/huggingface \
+            -e ZEA_CACHE_DIR=/root/.cache/zea \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir agent"
@@ -180,6 +190,10 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
+            -v ${{ env.HF_CACHE_MOUNT }} \
+            -v ${{ env.ZEA_CACHE_MOUNT }} \
+            -e HF_HOME=/root/.cache/huggingface \
+            -e ZEA_CACHE_DIR=/root/.cache/zea \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir models"
@@ -199,6 +213,10 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
+            -v ${{ env.HF_CACHE_MOUNT }} \
+            -v ${{ env.ZEA_CACHE_MOUNT }} \
+            -e HF_HOME=/root/.cache/huggingface \
+            -e ZEA_CACHE_DIR=/root/.cache/zea \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir pipeline"
@@ -218,6 +236,10 @@ jobs:
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
+            -v ${{ env.HF_CACHE_MOUNT }} \
+            -v ${{ env.ZEA_CACHE_MOUNT }} \
+            -e HF_HOME=/root/.cache/huggingface \
+            -e ZEA_CACHE_DIR=/root/.cache/zea \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
             sh -lc "pytest -p no:cacheprovider -s -m 'notebook' --notebook-dir data --notebook-dir metrics"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,6 +155,7 @@ jobs:
           slug: ${{ env.MAIN_REPO }}
           flags: heavy
   notebook-tests:
+    name: notebook-tests (${{ matrix.label }})
     needs: [image]
     runs-on: self-hosted
     timeout-minutes: 100
@@ -164,12 +165,16 @@ jobs:
         include:
           - name: agent
             dirs: agent
+            label: agent
           - name: models
             dirs: models
+            label: models
           - name: pipeline
             dirs: pipeline
+            label: pipeline
           - name: data-metrics
             dirs: "data metrics"
+            label: data+metrics
     concurrency:
       group: notebook-tests-${{ matrix.name }}-${{ github.ref }}
       cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,3 +26,6 @@ DUMMY_DATASET_GRID_SIZE_Z = 256
 DUMMY_DATASET_GRID_SIZE_X = 256
 
 DEFAULT_TEST_SEED = 42
+
+# Populated during notebook test runs: {notebook_name: (folder, duration_seconds)}
+_notebook_timings: dict[str, tuple[str, float]] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import os
 import tempfile
+from collections import defaultdict
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pytest
@@ -45,8 +47,6 @@ def pytest_addoption(parser):
 
 
 def pytest_sessionstart(session):
-    from pathlib import Path
-
     notebooks_dir = Path("docs/source/notebooks")
     notebooks = list(notebooks_dir.rglob("*.ipynb"))
     if notebooks:
@@ -56,8 +56,6 @@ def pytest_sessionstart(session):
 def pytest_sessionfinish(session, exitstatus):
     if not _notebook_timings:
         return
-
-    from collections import defaultdict
 
     by_folder: dict[str, list[tuple[str, float]]] = defaultdict(list)
     for name, (folder, duration) in sorted(_notebook_timings.items()):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,13 @@ def pytest_addoption(parser):
         default=None,
         help="Run only the notebook matching this name (e.g. --notebook dbua_example.ipynb)",
     )
+    parser.addoption(
+        "--notebook-dir",
+        action="append",
+        default=None,
+        help="Run only notebooks under this subfolder (e.g. --notebook-dir models)."
+        " Can be repeated.",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,10 @@
 """This file contains fixtures that are used by all tests in the tests directory."""
 
-import os
-import tempfile
 from collections import defaultdict
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pytest
-
-_tmp_cache_dir = tempfile.TemporaryDirectory(prefix="zea_test_cache_")
-
-os.environ["ZEA_CACHE_DIR"] = _tmp_cache_dir.name  # set before importing zea
 
 from zea.data.data_format import generate_example_dataset  # noqa: E402
 from zea.internal.device import backend_cuda_available  # noqa: E402
@@ -100,14 +94,6 @@ def run_once_after_all_tests():
     yield
     print("Stopping workers")
     backend_workers.stop_workers()
-
-
-@pytest.fixture(scope="session", autouse=True)
-def clean_cache_dir():
-    """Fixture to clean the cache directory after all tests."""
-    yield
-    print("Cleaning cache directory")
-    _tmp_cache_dir.cleanup()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from . import (  # noqa: E402
     DUMMY_DATASET_GRID_SIZE_X,
     DUMMY_DATASET_GRID_SIZE_Z,
     DUMMY_DATASET_N_FRAMES,
+    _notebook_timings,
     backend_workers,
 )
 
@@ -41,6 +42,48 @@ def pytest_addoption(parser):
         help="Run only notebooks under this subfolder (e.g. --notebook-dir models)."
         " Can be repeated.",
     )
+
+
+def pytest_sessionstart(session):
+    from pathlib import Path
+
+    notebooks_dir = Path("docs/source/notebooks")
+    notebooks = list(notebooks_dir.rglob("*.ipynb"))
+    if notebooks:
+        print(f"📚 Preparing to test {len(notebooks)} notebooks from {notebooks_dir}")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if not _notebook_timings:
+        return
+
+    from collections import defaultdict
+
+    by_folder: dict[str, list[tuple[str, float]]] = defaultdict(list)
+    for name, (folder, duration) in sorted(_notebook_timings.items()):
+        by_folder[folder].append((name, duration))
+
+    col_w = max(len(name) for name, _ in _notebook_timings.items()) + 2
+    print("\n" + "=" * (col_w + 20))
+    print("📊 Notebook run-time summary")
+    print("=" * (col_w + 20))
+
+    grand_total = 0.0
+    for folder in sorted(by_folder):
+        entries = sorted(by_folder[folder], key=lambda x: -x[1])
+        folder_total = sum(d for _, d in entries)
+        grand_total += folder_total
+        print(f"\n  📁 {folder}  ({folder_total:.1f}s total)")
+        for name, duration in entries:
+            mins, secs = divmod(duration, 60)
+            time_str = f"{int(mins)}m {secs:.1f}s" if mins else f"{secs:.1f}s"
+            print(f"    {name:<{col_w}}  {time_str:>8}")
+
+    print("\n" + "-" * (col_w + 20))
+    grand_mins, grand_secs = divmod(grand_total, 60)
+    grand_str = f"{int(grand_mins)}m {grand_secs:.1f}s" if grand_mins else f"{grand_secs:.1f}s"
+    print(f"  {'TOTAL':<{col_w}}  {grand_str:>8}")
+    print("=" * (col_w + 20) + "\n")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,13 +1,17 @@
 """Tests for the caching utility."""
 
+import os
 import time
+from pathlib import Path
 
 import keras
 import numpy as np
 import pytest
 
+import zea.internal.cache as cache_mod
 from zea.internal.cache import cache_output, cache_summary, clear_cache, get_function_source
 from zea.internal.core import Object
+
 from . import DEFAULT_TEST_SEED
 
 # Global variable for the expected duration of the expensive operation
@@ -76,11 +80,29 @@ class CustomObject(Object):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def clean_cache():
-    """Fixture to clean up the cache directory before and after tests."""
+def clean_cache(tmp_path_factory):
+    """Run cache tests against an isolated temp cache directory."""
+    tmp_cache_root = tmp_path_factory.mktemp("zea_test_cache")
+    tmp_cache_dir = Path(tmp_cache_root) / "cached_funcs"
+    tmp_cache_dir.mkdir(parents=True, exist_ok=True)
+
+    prev_cache_env = os.environ.get("ZEA_CACHE_DIR")
+    prev_zea_cache_dir = cache_mod.ZEA_CACHE_DIR
+    prev_cache_dir = cache_mod._CACHE_DIR
+    os.environ["ZEA_CACHE_DIR"] = str(tmp_cache_root)
+    cache_mod.ZEA_CACHE_DIR = Path(tmp_cache_root)
+    cache_mod._CACHE_DIR = tmp_cache_dir
+
     clear_cache()
     yield
     clear_cache()
+
+    cache_mod.ZEA_CACHE_DIR = prev_zea_cache_dir
+    cache_mod._CACHE_DIR = prev_cache_dir
+    if prev_cache_env is None:
+        os.environ.pop("ZEA_CACHE_DIR", None)
+    else:
+        os.environ["ZEA_CACHE_DIR"] = prev_cache_env
 
 
 def test_get_function_source():

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -126,10 +126,47 @@ for nbp_name in NOTEBOOK_PARAMETERS.keys():
         "Wrong definition in NOTEBOOK_PARAMETERS?"
     )
 
+# Populated during the test run: {notebook_name: (folder, duration_seconds)}
+_timings: dict[str, tuple[str, float]] = {}
+
 
 def pytest_sessionstart(session):
     print(f"📚 Preparing to test {len(NOTEBOOKS)} notebooks from {NOTEBOOKS_DIR}")
     print(f"📝 Using custom parameters for {len(NOTEBOOK_PARAMETERS)} notebooks")
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if not _timings:
+        return
+
+    # Group by folder
+    from collections import defaultdict
+
+    by_folder: dict[str, list[tuple[str, float]]] = defaultdict(list)
+    for name, (folder, duration) in sorted(_timings.items()):
+        by_folder[folder].append((name, duration))
+
+    col_w = max(len(name) for name, _ in _timings.items()) + 2
+    print("\n" + "=" * (col_w + 20))
+    print("📊 Notebook run-time summary")
+    print("=" * (col_w + 20))
+
+    grand_total = 0.0
+    for folder in sorted(by_folder):
+        entries = sorted(by_folder[folder], key=lambda x: -x[1])
+        folder_total = sum(d for _, d in entries)
+        grand_total += folder_total
+        print(f"\n  📁 {folder}  ({folder_total:.1f}s total)")
+        for name, duration in entries:
+            mins, secs = divmod(duration, 60)
+            time_str = f"{int(mins)}m {secs:.1f}s" if mins else f"{secs:.1f}s"
+            print(f"    {name:<{col_w}}  {time_str:>8}")
+
+    print("\n" + "-" * (col_w + 20))
+    grand_mins, grand_secs = divmod(grand_total, 60)
+    grand_str = f"{int(grand_mins)}m {grand_secs:.1f}s" if grand_mins else f"{grand_secs:.1f}s"
+    print(f"  {'TOTAL':<{col_w}}  {grand_str:>8}")
+    print("=" * (col_w + 20) + "\n")
 
 
 @pytest.mark.notebook
@@ -163,4 +200,5 @@ def test_notebook_runs(notebook, tmp_path, request):
     )
 
     duration = time.time() - start
+    _timings[notebook.name] = (notebook.parent.name, duration)
     print(f"✅ Finished {notebook.name} in {duration:.1f}s")

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -26,6 +26,8 @@ from pathlib import Path
 import papermill as pm
 import pytest
 
+from . import _notebook_timings
+
 CONFIG_DIR = Path("configs")
 
 # Automatically discover notebooks
@@ -126,48 +128,6 @@ for nbp_name in NOTEBOOK_PARAMETERS.keys():
         "Wrong definition in NOTEBOOK_PARAMETERS?"
     )
 
-# Populated during the test run: {notebook_name: (folder, duration_seconds)}
-_timings: dict[str, tuple[str, float]] = {}
-
-
-def pytest_sessionstart(session):
-    print(f"📚 Preparing to test {len(NOTEBOOKS)} notebooks from {NOTEBOOKS_DIR}")
-    print(f"📝 Using custom parameters for {len(NOTEBOOK_PARAMETERS)} notebooks")
-
-
-def pytest_sessionfinish(session, exitstatus):
-    if not _timings:
-        return
-
-    # Group by folder
-    from collections import defaultdict
-
-    by_folder: dict[str, list[tuple[str, float]]] = defaultdict(list)
-    for name, (folder, duration) in sorted(_timings.items()):
-        by_folder[folder].append((name, duration))
-
-    col_w = max(len(name) for name, _ in _timings.items()) + 2
-    print("\n" + "=" * (col_w + 20))
-    print("📊 Notebook run-time summary")
-    print("=" * (col_w + 20))
-
-    grand_total = 0.0
-    for folder in sorted(by_folder):
-        entries = sorted(by_folder[folder], key=lambda x: -x[1])
-        folder_total = sum(d for _, d in entries)
-        grand_total += folder_total
-        print(f"\n  📁 {folder}  ({folder_total:.1f}s total)")
-        for name, duration in entries:
-            mins, secs = divmod(duration, 60)
-            time_str = f"{int(mins)}m {secs:.1f}s" if mins else f"{secs:.1f}s"
-            print(f"    {name:<{col_w}}  {time_str:>8}")
-
-    print("\n" + "-" * (col_w + 20))
-    grand_mins, grand_secs = divmod(grand_total, 60)
-    grand_str = f"{int(grand_mins)}m {grand_secs:.1f}s" if grand_mins else f"{grand_secs:.1f}s"
-    print(f"  {'TOTAL':<{col_w}}  {grand_str:>8}")
-    print("=" * (col_w + 20) + "\n")
-
 
 @pytest.mark.notebook
 @pytest.mark.parametrize("notebook", NOTEBOOKS, ids=lambda x: x.name)
@@ -200,5 +160,5 @@ def test_notebook_runs(notebook, tmp_path, request):
     )
 
     duration = time.time() - start
-    _timings[notebook.name] = (notebook.parent.name, duration)
+    _notebook_timings[notebook.name] = (notebook.parent.name, duration)
     print(f"✅ Finished {notebook.name} in {duration:.1f}s")

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -140,6 +140,11 @@ def test_notebook_runs(notebook, tmp_path, request):
     if notebook_filter and notebook_filter not in notebook.name:
         pytest.skip(f"Skipped (--notebook={notebook_filter})")
 
+    # Filter by --notebook-dir CLI option if provided
+    notebook_dir_filter = request.config.getoption("--notebook-dir")
+    if notebook_dir_filter and notebook.parent.name not in notebook_dir_filter:
+        pytest.skip(f"Skipped (--notebook-dir={notebook_dir_filter})")
+
     print(f"\n📘 Starting notebook: {notebook.name}")
 
     output_path = tmp_path / notebook.name


### PR DESCRIPTION
Regarding #364 

Does not address the problem mentioned, but lowers the cost when tests fail. If a single test fails, we dont need to re-run the whole 30min+, this lowers the burden/bottlenecking on the runners.

Current proposed split:

- `heavy-tests` contains `ops_infra, transmit_schemes, conversion_scripts`
- `notebook-tests-agent` 2 notebooks
- `notebook-tests-models` 9 model notebooks
- `notebook-tests-pipeline` 7 notebooks
- `notebook-tests-data-metrics` 5 very cheap notebooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reorganized heavy test execution to target specific test sets for more focused runs
  * Split notebook tests into separate parallel jobs (agent, models, pipeline, data/metrics) to speed CI
  * Added per-notebook timing collection and grouped folder summaries to improve visibility into test performance and totals
  * Added option to run notebook tests filtered by directory for targeted runs
  * Improved test cache isolation by using per-test temporary cache handling

* **Chores**
  * CI updated to mount shared cache volumes, set in-container cache env vars, and renamed the heavy-tests step for clarity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->