### PR TITLE
🚨 Less warnings file and scan loading

### DIFF
--- a/docs/source/notebooks/pipeline/zea_sequence_example.ipynb
+++ b/docs/source/notebooks/pipeline/zea_sequence_example.ipynb
@@ -168,7 +168,6 @@
     "\n",
     "scan.set_transmits(n_tx)  # reduce number of transmits for faster processing\n",
     "scan.zlims = (0, 0.04)  # reduce z-limits a bit for better visualizations\n",
-    "scan.n_ch = data.shape[-1]  # rf data\n",
     "\n",
     "config = zea.Config(dynamic_range=(-40, 0))"
    ]
@@ -191,10 +190,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
       "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'element_height', 'element_width', 'type', 'center_frequency', 'bandwidth_percent'}. Make sure this is intended. This warning will only be shown once.\n",
-      "\u001b[1m15/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m3s\u001b[0m 139ms/step\n"
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
+      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[33mDEBUG\u001b[0m [zea.Pipeline] The following input keys are not used by the pipeline: {'element_height', 'element_width', 'center_frequency', 'bandwidth_percent', 'type'}. Make sure this is intended. This warning will only be shown once.\n",
+      "\u001b[1m15/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m4s\u001b[0m 142ms/step\n"
      ]
     }
    ],
@@ -249,37 +248,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 1/15\u001b[0m \u001b[32m━\u001b[0m\u001b[37m━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[1m2s\u001b[0m 171ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 2/15\u001b[0m \u001b[32m━━\u001b[0m\u001b[37m━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[1m1s\u001b[0m 131ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 3/15\u001b[0m \u001b[32m━━━━\u001b[0m\u001b[37m━━━━━━━━━━━━━━━━\u001b[0m \u001b[1m1s\u001b[0m 131ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 4/15\u001b[0m \u001b[32m━━━━━\u001b[0m\u001b[37m━━━━━━━━━━━━━━━\u001b[0m \u001b[1m1s\u001b[0m 131ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 5/15\u001b[0m \u001b[32m━━━━━━\u001b[0m\u001b[37m━━━━━━━━━━━━━━\u001b[0m \u001b[1m1s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 6/15\u001b[0m \u001b[32m━━━━━━━━\u001b[0m\u001b[37m━━━━━━━━━━━━\u001b[0m \u001b[1m1s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 7/15\u001b[0m \u001b[32m━━━━━━━━━\u001b[0m\u001b[37m━━━━━━━━━━━\u001b[0m \u001b[1m1s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 8/15\u001b[0m \u001b[32m━━━━━━━━━━\u001b[0m\u001b[37m━━━━━━━━━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m 9/15\u001b[0m \u001b[32m━━━━━━━━━━━━\u001b[0m\u001b[37m━━━━━━━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m10/15\u001b[0m \u001b[32m━━━━━━━━━━━━━\u001b[0m\u001b[37m━━━━━━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m11/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━\u001b[0m\u001b[37m━━━━━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m12/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m━━━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m13/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m━━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m14/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m━━\u001b[0m \u001b[1m0s\u001b[0m 132ms/step\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit waveform indices provided, using zeros\n",
-      "\u001b[1m\u001b[38;5;36mzea\u001b[0m\u001b[0m: \u001b[38;5;214mWARNING\u001b[0m No transmit origins provided, using zeros\n",
-      "\u001b[1m15/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m2s\u001b[0m 132ms/step\n"
+      "\u001b[1m15/15\u001b[0m \u001b[32m━━━━━━━━━━━━━━━━━━━━\u001b[0m\u001b[37m\u001b[0m \u001b[1m3s\u001b[0m 163ms/step\n"
      ]
     }
    ],

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -513,11 +513,13 @@ def test_field_metadata_keys_are_subset_of_schema_for_all_specs():
             )
 
 
-def test_subject_id_warning_for_missing_id():
+def test_subject_id_warning_for_missing_id(tmp_path):
     n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
 
+    path = tmp_path / "subject_id_missing_warns_on_save.hdf5"
     with patch("zea.log.warning") as mock_warn:
-        FileSpec(
+        File.create(
+            path,
             data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
             metadata={
@@ -532,16 +534,19 @@ def test_subject_id_warning_for_missing_id():
                 "common_midpoint_phase_error": np.zeros((n_frames,), dtype=np.float32),
                 "coherence_factor": np.ones((n_frames,), dtype=np.float32),
             },
+            overwrite=True,
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
     assert any("Optional Subject field 'id' is not set" in m for m in messages)
 
 
-def test_subject_id_warning_includes_field_metadata_description():
+def test_subject_id_warning_includes_field_metadata_description(tmp_path):
     n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
 
+    path = tmp_path / "subject_id_description_warns_on_save.hdf5"
     with patch("zea.log.warning") as mock_warn:
-        FileSpec(
+        File.create(
+            path,
             data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
             scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
             metadata={
@@ -552,6 +557,7 @@ def test_subject_id_warning_includes_field_metadata_description():
                     "fat_percentage": np.float32(17.5),
                 }
             },
+            overwrite=True,
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
     assert any("subject-wise splits" in m for m in messages)

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -900,7 +900,7 @@ def _scan_bare(n_tx: int = 2, n_el: int = 4):
 
 
 class TestScanSpecSaveWarnings:
-    """log.warning calls emitted during ScanSpec / FileSpec construction."""
+    """log.warning calls emitted during save/serialization."""
 
     @pytest.mark.parametrize(
         "field",
@@ -913,6 +913,25 @@ class TestScanSpecSaveWarnings:
     def test_optional_scan_field_missing_warns(self, field):
         with patch("zea.log.warning") as mock_warn:
             ScanSpec(**_scan_bare())
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert not any(f"ScanSpec field '{field}' is not set" in m for m in messages)
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            f.name
+            for f in fields(ScanSpec)
+            if f.default is None and f.name in ScanSpec.FIELD_METADATA
+        ],
+    )
+    def test_optional_scan_field_missing_warns_on_save(self, field, tmp_path):
+        path = tmp_path / "scan_save_warns.hdf5"
+        with patch("zea.log.warning") as mock_warn:
+            File.create(
+                path,
+                data={"raw_data": np.zeros((2, 2, 8, 4, 1), dtype=np.float32)},
+                scan=_scan_bare(n_tx=2, n_el=4),
+            )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any(f"ScanSpec field '{field}' is not set" in m for m in messages)
 
@@ -1008,16 +1027,29 @@ class TestScanSpecSaveWarnings:
                 metadata={"subject": {"type": "human"}},
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-        assert any("Optional Subject field 'id' is not set" in m for m in messages)
+        assert not any("Optional Subject field 'id' is not set" in m for m in messages)
 
 
 class TestSubjectFieldWarnings:
-    """log.warning calls emitted when Subject optional fields are None."""
+    """Subject optional-field warning behavior."""
 
     @pytest.mark.parametrize("field", list(Subject.SCHEMA))
     def test_optional_subject_field_missing_warns(self, field):
         with patch("zea.log.warning") as mock_warn:
             Subject()
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert not any(f"Optional Subject field '{field}' is not set" in m for m in messages)
+
+    @pytest.mark.parametrize("field", list(Subject.SCHEMA))
+    def test_optional_subject_field_missing_warns_on_save(self, field, tmp_path):
+        path = tmp_path / "subject_save_warns.hdf5"
+        with patch("zea.log.warning") as mock_warn:
+            File.create(
+                path,
+                data={"raw_data": np.zeros((2, 2, 8, 4, 1), dtype=np.float32)},
+                scan=_scan_minimal(n_frames=2, n_tx=2, n_el=4),
+                metadata={"subject": {}},
+            )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any(f"Optional Subject field '{field}' is not set" in m for m in messages)
 
@@ -1035,7 +1067,7 @@ class TestSubjectFieldWarnings:
 
 
 class TestMetadataSpecFieldWarnings:
-    """log.warning calls emitted when MetadataSpec optional fields are None."""
+    """MetadataSpec optional-field warning behavior."""
 
     @pytest.mark.parametrize(
         "field",
@@ -1044,6 +1076,22 @@ class TestMetadataSpecFieldWarnings:
     def test_optional_metadata_field_missing_warns(self, field):
         with patch("zea.log.warning") as mock_warn:
             MetadataSpec()
+        messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+        assert not any(f"Optional MetadataSpec field '{field}' is not set" in m for m in messages)
+
+    @pytest.mark.parametrize(
+        "field",
+        [f.name for f in fields(MetadataSpec) if f.default is None],
+    )
+    def test_optional_metadata_field_missing_warns_on_save(self, field, tmp_path):
+        path = tmp_path / "metadata_save_warns.hdf5"
+        with patch("zea.log.warning") as mock_warn:
+            File.create(
+                path,
+                data={"raw_data": np.zeros((2, 2, 8, 4, 1), dtype=np.float32)},
+                scan=_scan_minimal(n_frames=2, n_tx=2, n_el=4),
+                metadata={},
+            )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert any(f"Optional MetadataSpec field '{field}' is not set" in m for m in messages)
 

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pytest
 
+import zea
 from zea.scan import Scan
 
 scan_args = {
@@ -272,6 +273,82 @@ def test_accessing_valid_but_unset_attributes():
 
     scan = Scan(n_tx=5)
     scan.focus_distances
+
+
+def test_missing_transmit_defaults_warn_once_on_access(monkeypatch):
+    local_scan_args = scan_args.copy()
+    local_scan_args.pop("azimuth_angles", None)
+    local_scan_args.pop("t0_delays", None)
+    local_scan_args.pop("tx_apodizations", None)
+    local_scan_args.pop("focus_distances", None)
+    local_scan_args.pop("transmit_origins", None)
+    local_scan_args.pop("initial_times", None)
+    local_scan_args.pop("tgc_gain_curve", None)
+    local_scan_args.pop("tx_waveform_indices", None)
+
+    warnings = []
+
+    # Reset warning_once state to make this test deterministic.
+    zea.log._warned_locations.clear()
+
+    def _capture_warning(message, *args, **kwargs):
+        warnings.append(message)
+        return message
+
+    monkeypatch.setattr("zea.scan.log.warning", _capture_warning)
+
+    # Nothing should be warned at initialization, only on-demand when fallback
+    # properties are actually accessed.
+    scan = Scan(**local_scan_args)
+    assert len(warnings) == 0
+
+    for i in range(5):
+        scan.selected_transmits = slice(0, i + 1)
+        _ = scan.azimuth_angles
+        _ = scan.t0_delays
+        _ = scan.tx_apodizations
+        _ = scan.focus_distances
+        _ = scan.transmit_origins
+        _ = scan.initial_times
+        _ = scan.tgc_gain_curve
+        _ = scan.tx_waveform_indices
+
+    assert warnings.count("No ``azimuth_angles`` provided, using zeros") == 1
+    assert warnings.count("No ``t0_delays`` provided, using zeros") == 1
+    assert warnings.count("No ``tx_apodizations`` provided, using ones") == 1
+    assert warnings.count("No ``focus_distances`` provided, using zeros") == 1
+    assert warnings.count("No ``transmit_origins`` provided, using zeros") == 1
+    assert warnings.count("No ``initial_times`` provided, using zeros") == 1
+    assert warnings.count("No ``tgc_gain_curve`` provided, using ones") == 1
+    assert warnings.count("No ``tx_waveform_indices`` provided, using zeros") == 1
+
+
+def test_missing_defaults_warn_once_per_scan_instance(monkeypatch):
+    local_scan_args = scan_args.copy()
+    local_scan_args.pop("tx_waveform_indices", None)
+
+    warnings = []
+
+    zea.log._warned_locations.clear()
+
+    def _capture_warning(message, *args, **kwargs):
+        warnings.append(message)
+        return message
+
+    monkeypatch.setattr("zea.scan.log.warning", _capture_warning)
+
+    scan1 = Scan(**local_scan_args)
+    scan2 = Scan(**local_scan_args)
+
+    # First access in each instance should warn.
+    _ = scan1.tx_waveform_indices
+    _ = scan2.tx_waveform_indices
+
+    # Repeated access in same instance should not warn again.
+    _ = scan1.tx_waveform_indices
+    _ = scan2.tx_waveform_indices
+
+    assert warnings.count("No ``tx_waveform_indices`` provided, using zeros") == 2
 
 
 def test_scan_pickle():

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -464,6 +464,9 @@ class Spec:
 
         assert isinstance(group, h5py.Group), "group must be an h5py Group"
 
+        # Optional fields should only warn when persisting to disk, not on load.
+        self.warn_missing_optional_fields()
+
         field_metadata = getattr(self, "FIELD_METADATA", {})
 
         for field_name, field_info in self.SCHEMA.items():
@@ -1286,8 +1289,6 @@ class ScanSpec(Spec):
             if np.all(self.demodulation_frequency == self.demodulation_frequency[0]):
                 self.demodulation_frequency = self.demodulation_frequency[0]
 
-        self.warn_missing_optional_fields()
-
 
 @dataclass
 class ProbeSpec(Spec):
@@ -1446,8 +1447,6 @@ class Subject(Spec):
 
         if self.id is not None and not self.id.strip():
             raise ValueError("Subject ID cannot be an empty string")
-
-        self.warn_missing_optional_fields()
 
         if self.fat_percentage is not None and (
             self.fat_percentage < 0 or self.fat_percentage > 100
@@ -1729,8 +1728,6 @@ class MetadataSpec(Spec):
 
     def __post_init__(self):
         super().__post_init__()
-
-        self.warn_missing_optional_fields()
 
 
 @dataclass

--- a/zea/log.py
+++ b/zea/log.py
@@ -254,12 +254,17 @@ def warning(message, *args, **kwargs):
     return message
 
 
-def warning_once(message, *args, **kwargs):
-    """Prints a warning message only once per call location."""
+def warning_once(message, *args, key=None, **kwargs):
+    """Prints a warning message only once for a dedupe key.
+
+    By default, deduplication is per call location. A custom ``key`` can be
+    provided to scope once-only behavior (for example, per object instance).
+    """
     frame = inspect.stack()[1]
-    key = f"{frame.filename}:{frame.lineno}"
-    if key not in _warned_locations:
-        _warned_locations.add(key)
+    location_key = f"{frame.filename}:{frame.lineno}"
+    dedupe_key = location_key if key is None else (location_key, key)
+    if dedupe_key not in _warned_locations:
+        _warned_locations.add(dedupe_key)
         warning(message, *args, **kwargs)
     return message
 

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -635,7 +635,7 @@ class Scan(Parameters):
         value = self._params.get("azimuth_angles")
         if value is None:
             log.warning_once(
-                "No azimuth angles provided, using zeros",
+                "No ``azimuth_angles`` provided, using zeros",
                 key=(id(self), "azimuth_angles"),
             )
             return np.zeros(self.n_tx)

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -634,7 +634,10 @@ class Scan(Parameters):
         of shape (n_tx,). These angles are often used in 3D imaging."""
         value = self._params.get("azimuth_angles")
         if value is None:
-            log.warning("No azimuth angles provided, using zeros")
+            log.warning_once(
+                "No azimuth angles provided, using zeros",
+                key=(id(self), "azimuth_angles"),
+            )
             return np.zeros(self.n_tx)
 
         return value[self.selected_transmits]
@@ -656,7 +659,10 @@ class Scan(Parameters):
         shape (n_tx, n_el), shifted such that the smallest delay is 0."""
         value = self._params.get("t0_delays")
         if value is None:
-            log.warning("No transmit delays provided, using zeros")
+            log.warning_once(
+                "No ``t0_delays`` provided, using zeros",
+                key=(id(self), "t0_delays"),
+            )
             return np.zeros((self.n_tx, self.n_el))
 
         return value[self.selected_transmits]
@@ -666,7 +672,10 @@ class Scan(Parameters):
         """Transmit apodizations of shape (n_tx, n_el)."""
         value = self._params.get("tx_apodizations")
         if value is None:
-            log.warning("No transmit apodizations provided, using ones")
+            log.warning_once(
+                "No ``tx_apodizations`` provided, using ones",
+                key=(id(self), "tx_apodizations"),
+            )
             return np.ones((self.n_tx, self.n_el))
 
         return value[self.selected_transmits]
@@ -676,7 +685,10 @@ class Scan(Parameters):
         """Focus distances in meters for each event of shape (n_tx,)."""
         value = self._params.get("focus_distances")
         if value is None:
-            log.warning("No focus distances provided, using zeros")
+            log.warning_once(
+                "No ``focus_distances`` provided, using zeros",
+                key=(id(self), "focus_distances"),
+            )
             return np.zeros(self.n_tx)
 
         return value[self.selected_transmits]
@@ -686,7 +698,10 @@ class Scan(Parameters):
         """Transmit origins of shape (n_tx, 3)."""
         value = self._params.get("transmit_origins")
         if value is None:
-            log.warning("No transmit origins provided, using zeros")
+            log.warning_once(
+                "No ``transmit_origins`` provided, using zeros",
+                key=(id(self), "transmit_origins"),
+            )
             return np.zeros((self.n_tx, 3))
 
         return value[self.selected_transmits]
@@ -696,7 +711,10 @@ class Scan(Parameters):
         """Initial times in seconds for each event of shape (n_tx,)."""
         value = self._params.get("initial_times")
         if value is None:
-            log.warning("No initial times provided, using zeros")
+            log.warning_once(
+                "No ``initial_times`` provided, using zeros",
+                key=(id(self), "initial_times"),
+            )
             return np.zeros(self.n_tx)
 
         return value[self.selected_transmits]
@@ -736,7 +754,10 @@ class Scan(Parameters):
         """Time gain compensation (TGC) curve of shape (n_ax,)."""
         value = self._params.get("tgc_gain_curve")
         if value is None:
-            log.warning("No TGC gain curve provided, using ones")
+            log.warning_once(
+                "No ``tgc_gain_curve`` provided, using ones",
+                key=(id(self), "tgc_gain_curve"),
+            )
             return np.ones(self.n_ax)
         return value[: self.n_ax]
 
@@ -745,7 +766,10 @@ class Scan(Parameters):
         """Indices of the waveform used for each transmit event of shape (n_tx,)."""
         value = self._params.get("tx_waveform_indices")
         if value is None:
-            log.warning("No transmit waveform indices provided, using zeros")
+            log.warning_once(
+                "No ``tx_waveform_indices`` provided, using zeros",
+                key=(id(self), "tx_waveform_indices"),
+            )
             return np.zeros(self.n_tx, dtype=int)
 
         return value[self.selected_transmits]


### PR DESCRIPTION
See #328 

### What changed
- Optional `Spec` fields no longer warn at construction/load time.
- Optional field warnings are emitted when serializing (saving) only.
- This reduces noise when reading files while still surfacing incomplete metadata when writing datasets.

### Why
- Loading older or partial datasets often leaves optional fields unset by design.
- Repeated warnings during read workflows are noisy and not actionable.
- Save-time warnings are the right moment to signal missing optional metadata.

You'll also see I reran one notebook and the warnings got reduced significantly.

<details closed>
<summary>Minimal snippet</summary>

from pathlib import Path
import numpy as np
import zea

def make_minimal_scan(n_frames=2, n_tx=2, n_el=4):
    return {
        "sampling_frequency": np.float32(30e6),
        "center_frequency": np.float32(5e6),
        "demodulation_frequency": np.float32(5e6),
        "initial_times": np.zeros((n_tx,), dtype=np.float32),
        "t0_delays": np.zeros((n_tx, n_el), dtype=np.float32),
        "tx_apodizations": np.ones((n_tx, n_el), dtype=np.float32),
        "focus_distances": np.zeros((n_tx,), dtype=np.float32),
        "transmit_origins": np.zeros((n_tx, 3), dtype=np.float32),
        "polar_angles": np.zeros((n_tx,), dtype=np.float32),
        "azimuth_angles": np.zeros((n_tx,), dtype=np.float32),
        # Intentionally omit optional fields like tgc_gain_curve, waveforms_*
    }

path = Path("temp/spec_warning_save_load_demo.hdf5")
data = {"raw_data": np.zeros((2, 2, 8, 4, 1), dtype=np.float32)}
scan = make_minimal_scan()
metadata = {}

print("\n--- SAVE PHASE (expect optional warnings) ---")
zea.File.create(path, data=data, scan=scan, metadata=metadata, overwrite=True)

print("\n--- LOAD PHASE (expect no optional warnings) ---")
with zea.File(path) as f:
    _ = f.data.raw_data.shape
    _ = f.metadata
    scan = f.scan
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Warnings for missing transmit parameters now emit only once per scan instance, reducing redundant notifications during multiple accesses.
  * Warnings about unset optional fields now appear when saving data to disk rather than during object initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->