### PR TITLE
Replace zeahub link in 3D notebook

### DIFF
--- a/docs/source/notebooks/pipeline/3d_beamforming_example.ipynb
+++ b/docs/source/notebooks/pipeline/3d_beamforming_example.ipynb
@@ -17,7 +17,7 @@
     "&nbsp;\n",
     "[![View on GitHub](https://img.shields.io/badge/GitHub-View%20Source-blue?logo=github)](https://github.com/tue-bmd/zea/blob/main/docs/source/notebooks/pipeline/3d_beamforming_example.ipynb)\n",
     "&nbsp;\n",
-    "[![Hugging Face dataset](https://img.shields.io/badge/Hugging%20Face-Dataset-yellow?logo=huggingface)](https://huggingface.co/datasets/zeahub/CIRS_3d_focused)"
+    "[![Hugging Face dataset](https://img.shields.io/badge/Hugging%20Face-Dataset-yellow?logo=huggingface)](https://huggingface.co/datasets/zeahub/phantoms)"
    ]
   },
   {


### PR DESCRIPTION
We want to deprecate https://huggingface.co/datasets/zeahub/CIRS_3d_focused in favor of https://huggingface.co/datasets/zeahub/phantoms

The hf hub badge in the 3D beamforming exmaple notebook still pointed to `zeahub/CIRS_3d_focused` -- I think once it's swapped we can remove the repo. This will lead to a broken link for anyone who hasn't pulled main, but hopefully that shouldn't be a big issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the dataset reference in the 3D beamforming example notebook to point to the current dataset source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->