### PR TITLE
Add preset for 12ch flowmatching model

### DIFF
--- a/zea/models/presets.py
+++ b/zea/models/presets.py
@@ -183,6 +183,18 @@ flow_matching_presets = {
         },
         "hf_handle": "hf://zeahub/flowmatching-echonetlvh/3ch",
     },
+    "flowmatching-echonetlvh-12ch": {
+        "metadata": {
+            "description": (
+                "Flow matching model trained on EchoNetLVH dataset. "
+                "12-frame model, input shape (256, 256, 12), "
+                "input range [0, 1]."
+            ),
+            "params": 7_692_177,
+            "path": "flow_matching",
+        },
+        "hf_handle": "hf://zeahub/flowmatching-echonetlvh/12ch",
+    },
 }
 
 carotid_segmenter_presets = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new flow matching preset for EchoNet LVH with 12-channel support, providing an additional model configuration option for flow matching applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->