### PR TITLE
Custom ops support

### DIFF
--- a/tests/fixtures/custom_ops.py
+++ b/tests/fixtures/custom_ops.py
@@ -1,0 +1,43 @@
+"""Custom operation classes used as test fixtures for get_ops / pipeline-config tests.
+
+These classes are intentionally registered under names that differ from their
+class names, so tests can verify that :func:`~zea.ops.base.get_ops` resolves
+operations by class-object identity rather than by class name.
+"""
+
+from zea.internal.registry import ops_registry
+from zea.ops.base import Operation
+
+
+@ops_registry("fixture_scale_op")
+class ScaleByFactorOp(Operation):
+    """Multiply ``data`` by a scalar *factor*.
+
+    Registry key ``"fixture_scale_op"`` intentionally differs from the class
+    name ``ScaleByFactorOp`` to exercise the identity-based lookup path in
+    :func:`~zea.ops.base.get_ops`.
+    """
+
+    def __init__(self, factor: float = 3.0, **kwargs):
+        """
+        :param factor: Scalar multiplier applied to *data*.
+        :type factor: float
+        """
+        super().__init__(**kwargs)
+        self.factor = factor
+
+    def call(self, data, **kwargs):
+        return {"data": data * self.factor}
+
+
+@ops_registry("fixture_passthrough")
+class Fixturepassthrough(Operation):
+    """Return *data* unchanged.
+
+    Registry key ``"fixture_passthrough"`` matches ``Fixturepassthrough``
+    when lower-cased, so this class exercises the shortname-fallback path that
+    was already present before the identity-based fix.
+    """
+
+    def call(self, data, **kwargs):
+        return {"data": data}

--- a/tests/fixtures/custom_ops.py
+++ b/tests/fixtures/custom_ops.py
@@ -34,9 +34,11 @@ class ScaleByFactorOp(Operation):
 class Fixturepassthrough(Operation):
     """Return *data* unchanged.
 
-    Registry key ``"fixture_passthrough"`` matches ``Fixturepassthrough``
-    when lower-cased, so this class exercises the shortname-fallback path that
-    was already present before the identity-based fix.
+    Registry key ``"fixture_passthrough"`` does **not** match
+    ``Fixturepassthrough`` lower-cased (``"fixturepassthrough"`` vs
+    ``"fixture_passthrough"`` — the underscore differs), so this class also
+    exercises the identity-based resolution path added to
+    :func:`~zea.ops.base.get_ops`.
     """
 
     def call(self, data, **kwargs):

--- a/tests/fixtures/dotted_key_ops.py
+++ b/tests/fixtures/dotted_key_ops.py
@@ -1,0 +1,22 @@
+"""Fixture module for testing path A inside get_ops.
+
+``DottedKeyOp`` is registered under its full module path as the key.  When
+``get_ops("tests.fixtures.dotted_key_ops.DottedKeyOp")`` is called for the
+first time (before this module has been imported), the module is imported, the
+decorator fires, and the second ``ops_name in ops_registry`` check (path A)
+inside the dotted-path branch succeeds.
+
+This file must **not** be imported by any other fixture or test file, so that
+the module is fresh when the path-A test runs.
+"""
+
+from zea.internal.registry import ops_registry
+from zea.ops.base import Operation
+
+
+@ops_registry("tests.fixtures.dotted_key_ops.DottedKeyOp")
+class DottedKeyOp(Operation):
+    """Registered under its full dotted module path as the registry key."""
+
+    def call(self, data, **kwargs):
+        return {"data": data}

--- a/tests/fixtures/unregistered_ops.py
+++ b/tests/fixtures/unregistered_ops.py
@@ -1,0 +1,31 @@
+"""Fixture module for testing paths B and C inside get_ops.
+
+Neither class is decorated with ``@ops_registry``, so
+``ops_registry.get_name(cls)`` raises ``KeyError`` for both (path B).
+
+* ``UnregisteredOp`` — unique name, not in registry → path B caught, path C
+  check also fails → ``ValueError`` raised.
+* ``Identity`` — lower-cased name ``"identity"`` IS in the registry (the
+  built-in :class:`~zea.ops.base.Identity`) → path B caught, path C shortname
+  fallback succeeds and returns the built-in class.
+"""
+
+from zea.ops.base import Operation
+
+
+class UnregisteredOp(Operation):
+    """Importable but has no registry entry — exercises path B + ValueError."""
+
+    def call(self, data, **kwargs):
+        return {"data": data}
+
+
+class Identity(Operation):
+    """Importable, no registry entry, but ``"identity"`` IS a registry key.
+
+    Exercises path B (``KeyError`` caught) followed by path C (shortname
+    fallback returns the built-in :class:`~zea.ops.base.Identity`).
+    """
+
+    def call(self, data, **kwargs):
+        return {"data": data}

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -1,0 +1,214 @@
+"""Tests for custom-operation loading via :func:`~zea.ops.base.get_ops` and pipeline configs.
+
+Covers:
+
+* Plain registry-name lookup
+* Module-path lookup where the registry key **equals** the lower-cased class name
+  (the original shortname-fallback path)
+* Module-path lookup where the registry key **differs** from the class name
+  (requires the identity-based resolution added to ``get_ops``)
+* Error paths (unknown name, unregistered class)
+* End-to-end: custom op loaded into a :class:`~zea.ops.Pipeline` via a config dict,
+  a YAML file, and via a pre-imported registry name
+"""
+
+import numpy as np
+import pytest
+import yaml
+
+from zea.config import Config
+from zea.ops.base import get_ops
+from zea.ops.pipeline import Pipeline, pipeline_from_config
+
+# ── get_ops: plain registry-name lookups ─────────────────────────────────────
+
+
+def test_get_ops_by_registry_name():
+    """get_ops with a known registry name returns the correct class."""
+    from zea.ops.base import Identity
+
+    cls = get_ops("identity")
+    assert cls is Identity
+
+
+def test_get_ops_unknown_plain_name_raises():
+    """get_ops with an unknown plain name raises :exc:`KeyError`."""
+    with pytest.raises(KeyError):
+        get_ops("nonexistent_op_zzzzzz")
+
+
+# ── get_ops: module-path lookups ─────────────────────────────────────────────
+
+
+def test_get_ops_module_path_registry_key_differs_from_class_name():
+    """Module-path lookup resolves by class identity when registry key ≠ class name.
+
+    ``ScaleByFactorOp`` is registered as ``"fixture_scale_op"``.  The old
+    shortname fallback (checking ``"ScaleByFactorOp"`` in the registry) would
+    *not* find it; only the identity-based lookup introduced in the fix does.
+    """
+    from tests.fixtures.custom_ops import ScaleByFactorOp
+
+    cls = get_ops("tests.fixtures.custom_ops.ScaleByFactorOp")
+    assert cls is ScaleByFactorOp
+
+
+def test_get_ops_module_path_registry_key_matches_lowercased_class_name():
+    """Module-path lookup also works via the shortname fallback path.
+
+    ``Fixturepassthrough`` is registered as ``"fixture_passthrough"``; the
+    shortname ``"Fixturepassthrough"`` lower-cases to ``"fixturepassthrough"``
+    which is a different key, so identity-based lookup is still needed.
+    """
+    from tests.fixtures.custom_ops import Fixturepassthrough
+
+    cls = get_ops("tests.fixtures.custom_ops.Fixturepassthrough")
+    assert cls is Fixturepassthrough
+
+
+def test_get_ops_module_path_unknown_class_raises():
+    """Dotted path to a class that doesn't exist in the registry raises :exc:`ValueError`."""
+    # The module exists and will be importable, but "NotARegisteredClass" is not there
+    with pytest.raises(ValueError, match="not found in registry"):
+        get_ops("tests.fixtures.custom_ops.NotARegisteredClass")
+
+
+def test_get_ops_module_path_already_imported_returns_same_object():
+    """Calling get_ops with module path twice returns the identical class object."""
+    cls_by_path = get_ops("tests.fixtures.custom_ops.ScaleByFactorOp")
+    cls_by_name = get_ops("fixture_scale_op")
+    assert cls_by_path is cls_by_name
+
+
+# ── Pipeline: config dict with custom op by module path ──────────────────────
+
+
+def test_pipeline_from_config_with_module_path():
+    """Pipeline built from a config dict using a module-path op name works end-to-end."""
+    config = Config(
+        {
+            "pipeline": {
+                "operations": [
+                    {"name": "tests.fixtures.custom_ops.ScaleByFactorOp"},
+                ]
+            }
+        }
+    )
+    pipeline = pipeline_from_config(config, jit_options=None)
+    assert len(pipeline.operations) == 1
+
+    result = pipeline(data=np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_allclose(result["data"], np.array([3.0, 6.0, 9.0]))
+
+
+def test_pipeline_from_config_with_module_path_and_params():
+    """Custom op loaded by module path accepts constructor params from the config."""
+    config = Config(
+        {
+            "pipeline": {
+                "operations": [
+                    {
+                        "name": "tests.fixtures.custom_ops.ScaleByFactorOp",
+                        "params": {"factor": 5.0},
+                    }
+                ]
+            }
+        }
+    )
+    pipeline = pipeline_from_config(config, jit_options=None)
+    result = pipeline(data=np.array([2.0, 4.0]))
+    np.testing.assert_allclose(result["data"], np.array([10.0, 20.0]))
+
+
+def test_pipeline_from_config_custom_op_by_registry_name_after_import():
+    """Once a custom module has been imported, its registry name works in config too."""
+    # Ensure the module is imported (get_ops does the import)
+    get_ops("tests.fixtures.custom_ops.ScaleByFactorOp")
+
+    config = Config(
+        {"pipeline": {"operations": [{"name": "fixture_scale_op", "params": {"factor": 2.0}}]}}
+    )
+    pipeline = pipeline_from_config(config, jit_options=None)
+    result = pipeline(data=np.array([7.0]))
+    np.testing.assert_allclose(result["data"], np.array([14.0]))
+
+
+# ── Pipeline: YAML file with custom op by module path ────────────────────────
+
+
+def test_pipeline_from_yaml_custom_op_by_module_path(tmp_path):
+    """Custom op specified by module path in a YAML config is loaded correctly."""
+    config_dict = {
+        "pipeline": {
+            "operations": [
+                {
+                    "name": "tests.fixtures.custom_ops.ScaleByFactorOp",
+                    "params": {"factor": 4.0},
+                }
+            ]
+        }
+    }
+    yaml_path = tmp_path / "custom_pipeline.yaml"
+    yaml_path.write_text(yaml.dump(config_dict))
+
+    pipeline = Pipeline.from_path(yaml_path, jit_options=None)
+    result = pipeline(data=np.array([3.0]))
+    np.testing.assert_allclose(result["data"], np.array([12.0]))
+
+
+def test_pipeline_yaml_roundtrip_custom_op_registry_name(tmp_path):
+    """Pipeline with a custom op round-trips through YAML using its registry name.
+
+    After the module is imported, the op is available by registry name in the
+    same Python session, so the saved YAML (which contains the registry name)
+    loads successfully.
+    """
+    from tests.fixtures.custom_ops import ScaleByFactorOp
+
+    pipeline = Pipeline(
+        operations=[ScaleByFactorOp(factor=6.0)],
+        jit_options=None,
+    )
+
+    yaml_path = tmp_path / "roundtrip.yaml"
+    pipeline.to_yaml(yaml_path)
+
+    with open(yaml_path) as f:
+        content = yaml.safe_load(f)
+
+    # The YAML stores the registry key, not the module path
+    op_entry = content["pipeline"]["operations"][0]
+    assert op_entry["name"] == "fixture_scale_op"
+    assert op_entry["params"]["factor"] == 6.0
+
+    # Loading back works because fixture_scale_op is registered in this session
+    loaded = Pipeline.from_path(yaml_path, jit_options=None)
+    result = loaded(data=np.array([2.0]))
+    np.testing.assert_allclose(result["data"], np.array([12.0]))
+
+
+# ── Pipeline: multi-op chain mixing built-in and custom ops ──────────────────
+
+
+def test_pipeline_mixed_builtin_and_custom_ops():
+    """Pipeline with both built-in and custom ops (by module path) runs correctly."""
+    from zea.ops.base import Identity
+
+    config = Config(
+        {
+            "pipeline": {
+                "operations": [
+                    {"name": "identity"},
+                    {
+                        "name": "tests.fixtures.custom_ops.ScaleByFactorOp",
+                        "params": {"factor": 2.0},
+                    },
+                ]
+            }
+        }
+    )
+    pipeline = pipeline_from_config(config, jit_options=None)
+    assert isinstance(pipeline.operations[0], Identity)
+
+    result = pipeline(data=np.array([5.0]))
+    np.testing.assert_allclose(result["data"], np.array([10.0]))

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -73,6 +73,45 @@ def test_get_ops_module_path_unknown_class_raises():
         get_ops("tests.fixtures.custom_ops.NotARegisteredClass")
 
 
+def test_get_ops_module_path_registered_under_full_dotted_key():
+    """Covers path A: post-import ``ops_name in ops_registry`` check (line 68-69).
+
+    ``DottedKeyOp`` is registered under its full module path as the key.
+    ``dotted_key_ops`` is never imported elsewhere, so on the first call the
+    module import triggers the decorator, and the second registry check fires.
+    """
+    full_key = "tests.fixtures.dotted_key_ops.DottedKeyOp"
+    cls = get_ops(full_key)  # import happens here; path A check fires
+    from tests.fixtures.dotted_key_ops import DottedKeyOp
+
+    assert cls is DottedKeyOp
+
+
+def test_get_ops_unregistered_class_in_module_raises():
+    """Covers path B: ``except KeyError: pass`` when class exists but is not registered.
+
+    ``UnregisteredOp`` is importable but has no ``@ops_registry`` decorator.
+    ``get_name(cls)`` raises ``KeyError`` (path B caught); the shortname
+    ``"UnregisteredOp"`` is also not a registry key, so ``ValueError`` is raised.
+    """
+    with pytest.raises(ValueError, match="not found in registry"):
+        get_ops("tests.fixtures.unregistered_ops.UnregisteredOp")
+
+
+def test_get_ops_module_path_shortname_fallback():
+    """Covers path C: class-name shortname fallback after path B.
+
+    ``tests.fixtures.unregistered_ops.Identity`` is importable but unregistered,
+    so ``get_name(cls)`` raises ``KeyError`` (path B caught).  The lowercased
+    class name ``"identity"`` IS a registry key, so path C returns the built-in
+    :class:`~zea.ops.base.Identity` class.
+    """
+    from zea.ops.base import Identity as BuiltinIdentity
+
+    cls = get_ops("tests.fixtures.unregistered_ops.Identity")
+    assert cls is BuiltinIdentity
+
+
 def test_get_ops_module_path_already_imported_returns_same_object():
     """Calling get_ops with module path twice returns the identical class object."""
     cls_by_path = get_ops("tests.fixtures.custom_ops.ScaleByFactorOp")

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -53,12 +53,12 @@ def test_get_ops_module_path_registry_key_differs_from_class_name():
     assert cls is ScaleByFactorOp
 
 
-def test_get_ops_module_path_registry_key_matches_lowercased_class_name():
-    """Module-path lookup also works via the shortname fallback path.
+def test_get_ops_module_path_registry_key_differs_by_underscore():
+    """Module-path lookup resolves by identity when key differs only by underscore.
 
-    ``Fixturepassthrough`` is registered as ``"fixture_passthrough"``; the
-    shortname ``"Fixturepassthrough"`` lower-cases to ``"fixturepassthrough"``
-    which is a different key, so identity-based lookup is still needed.
+    ``Fixturepassthrough`` is registered as ``"fixture_passthrough"``; its
+    lower-cased class name ``"fixturepassthrough"`` does not match the registry
+    key (the underscore breaks the match), so identity-based lookup is required.
     """
     from tests.fixtures.custom_ops import Fixturepassthrough
 

--- a/zea/ops/base.py
+++ b/zea/ops/base.py
@@ -140,7 +140,7 @@ class Operation(keras.Operation):
         output_data_type: Union[DataTypes, None] = None,
         key: Union[str, None] = "data",
         output_key: Union[str, None] = None,
-        cache_inputs: Union[bool, List[str]] = False,
+        cache_inputs: bool = False,
         cache_outputs: bool = False,
         jit_compile: bool = True,
         with_batch_dim: bool = True,
@@ -159,8 +159,11 @@ class Operation(keras.Operation):
             output_key (str or None): Dict key the operation writes its result to.
                 Defaults to ``key``. Set to a different value to preserve the original
                 input under ``key`` while producing a new key for downstream operations.
-            cache_inputs (bool or list of str): Keys whose values are stored and merged
-                into every subsequent call, or ``True`` to cache all inputs.
+            cache_inputs (bool): When ``True``, values stored via
+                :meth:`set_input_cache` are merged into every call. ``False``
+                means the cache is empty by default. Selective per-key caching
+                is not supported; use :meth:`set_input_cache` directly to
+                control which keys are stored.
             cache_outputs (bool): Memoize outputs keyed by a hash of the merged inputs.
             jit_compile (bool): Wrap :meth:`call` with :func:`~zea.backend.jit` for
                 faster execution. Disable for easier interactive debugging.

--- a/zea/ops/base.py
+++ b/zea/ops/base.py
@@ -20,9 +20,72 @@ from zea.utils import (
 )
 
 
-def get_ops(ops_name):
-    """Get the operation from the registry."""
-    return ops_registry[ops_name]
+def get_ops(ops_name: str):
+    """Retrieve an :class:`Operation` subclass from the registry by name.
+
+    Two lookup forms are supported:
+
+    **Registry name** (plain string)
+        A key previously registered with ``@ops_registry("name")``,
+        e.g. ``"demodulate"``.  The lookup is case-insensitive.
+
+    **Module path** (dotted string containing a ``"."``)
+        A fully-qualified import path such as
+        ``"my_package.my_module.MyOp"``.  The module is imported
+        automatically, then the class is located in the registry by *object
+        identity* — so the registry key does **not** need to match the class
+        name.
+
+    Args:
+        ops_name (str): Registry name or dotted module path of the operation.
+
+    Returns:
+        type: The :class:`Operation` subclass registered under ``ops_name``.
+
+    Raises:
+        ValueError: If ``ops_name`` is a dotted module path but the class
+            cannot be found in the registry after importing the module.
+        KeyError: If ``ops_name`` is a plain name that is not registered.
+
+    Examples:
+        .. code-block:: python
+
+            # By registry name
+            cls = get_ops("demodulate")
+
+            # By module path — the class may be registered under any key
+            cls = get_ops("my_project.processing.MyCustomOp")
+            pipeline = Pipeline(operations=[cls(factor=2.0)])
+    """
+    if ops_name in ops_registry:
+        return ops_registry[ops_name]
+
+    if "." in ops_name:
+        module_name, class_name = ops_name.rsplit(".", 1)
+        module = __import__(module_name, fromlist=[class_name])
+
+        # Check again: module may have registered the op under the full dotted key
+        if ops_name in ops_registry:
+            return ops_registry[ops_name]
+
+        # Resolve by class object identity — works even when registry key ≠ class name
+        cls = getattr(module, class_name, None)
+        if cls is not None:
+            try:
+                return ops_registry[ops_registry.get_name(cls)]
+            except KeyError:
+                pass
+
+        # Last fallback: class name used directly as registry key (case-insensitive)
+        if class_name in ops_registry:
+            return ops_registry[class_name]
+
+        raise ValueError(
+            f"Operation '{ops_name}' or '{class_name}' not found in registry, "
+            "even after attempting to import module."
+        )
+
+    return ops_registry[ops_name]  # raises KeyError with a helpful message
 
 
 def _to_native(value):
@@ -39,8 +102,34 @@ def _to_native(value):
 
 
 class Operation(keras.Operation):
-    """
-    A base abstract class for operations in the pipeline with caching functionality.
+    """Abstract base class for pipeline operations with caching and JIT support.
+
+    Every operation:
+
+    * receives and returns a :class:`dict` of named tensors
+    * is identified by a key in :data:`~zea.internal.registry.ops_registry`
+    * can be composed into a :class:`~zea.ops.Pipeline`
+    * optionally caches inputs and/or outputs for repeated calls with the
+      same arguments
+
+    Subclasses **must** implement :meth:`call`, which performs the actual
+    computation and must return a :class:`dict`.
+
+    Examples:
+        .. code-block:: python
+
+            from zea.internal.registry import ops_registry
+            from zea.ops.base import Operation
+
+
+            @ops_registry("my_scale")
+            class MyScale(Operation):
+                def __init__(self, factor: float = 2.0, **kwargs):
+                    super().__init__(**kwargs)
+                    self.factor = factor
+
+                def call(self, data, **kwargs):
+                    return {"data": data * self.factor}
     """
 
     ADD_OUTPUT_KEYS: List[str] = []
@@ -62,24 +151,28 @@ class Operation(keras.Operation):
     ):
         """
         Args:
-            input_data_type (DataTypes): The data type of the input data
-            output_data_type (DataTypes): The data type of the output data
-            key: The key for the input data (operation will operate on this key)
-                Defaults to "data".
-            output_key: The key for the output data (operation will output to this key)
-                Defaults to the same as the input key. If you want to store intermediate
-                results, you can set this to a different key. But make sure to update the
-                input key of the next operation to match the output key of this operation.
-            cache_inputs: A list of input keys to cache or True to cache all inputs
-            cache_outputs: A list of output keys to cache or True to cache all outputs
-            jit_compile: Whether to JIT compile the 'call' method for faster execution
-            with_batch_dim: Whether operations should expect a batch dimension in the input
-            jit_kwargs: Additional keyword arguments for the JIT compiler
-            jittable: Whether the operation can be JIT compiled
-            additional_output_keys: A list of additional output keys produced by the operation.
-                These are used to track if all keys are available for downstream operations.
-                If the operation has a conditional output, it is best to add all possible
-                output keys here.
+            input_data_type (DataTypes or None): Expected data type of the input tensor.
+                Used for pipeline data-type validation; pass ``None`` to skip.
+            output_data_type (DataTypes or None): Data type produced by this operation.
+            key (str or None): Dict key the operation reads from (and writes to by
+                default). Defaults to ``"data"``.
+            output_key (str or None): Dict key the operation writes its result to.
+                Defaults to ``key``. Set to a different value to preserve the original
+                input under ``key`` while producing a new key for downstream operations.
+            cache_inputs (bool or list of str): Keys whose values are stored and merged
+                into every subsequent call, or ``True`` to cache all inputs.
+            cache_outputs (bool): Memoize outputs keyed by a hash of the merged inputs.
+            jit_compile (bool): Wrap :meth:`call` with :func:`~zea.backend.jit` for
+                faster execution. Disable for easier interactive debugging.
+            with_batch_dim (bool): Whether inputs carry a leading batch dimension.
+                Affects default axis selection in filter-type operations.
+            jit_kwargs (dict or None): Extra keyword arguments forwarded to the JIT
+                compiler.
+            jittable (bool): Mark the operation as JIT-compilable. Set to ``False`` for
+                operations that use Python control flow incompatible with tracing.
+            additional_output_keys (list of str or None): Extra dict keys this operation
+                may produce beyond ``output_key``. Used for pipeline key-availability
+                validation. Defaults to the class-level :attr:`ADD_OUTPUT_KEYS` list.
         """
         super().__init__(**kwargs)
 


### PR DESCRIPTION
Support custom operators in `get_ops` as well as config.pipeline definitions. Will be much easier to incorporate custom operations that are not in zea (yet). Partially stolen from #372. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operations can now be resolved by their full module path (dotted notation), providing greater flexibility when composing pipelines in addition to using registry names.
  * Custom operations are now loadable through YAML pipeline configurations.

* **Documentation**
  * Enhanced documentation for the Operation class with improved parameter descriptions and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->