### PR TITLE
Tissue suppression

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -977,8 +977,9 @@ def test_tissue_suppression():
     shape = (n_frames, n_transmits, n_samples, n_channels)
 
     # Stationary tissue: same signal repeated across all frames
-    tissue = rng.standard_normal((1, n_transmits, n_samples, n_channels)).astype(np.float32)
-    tissue = np.repeat(tissue, n_frames, axis=0)
+
+    gradient = np.linspace(0, 1, n_samples).reshape(1, 1, n_samples, 1)
+    tissue = np.ones(shape) * gradient
 
     # Blood component: random per frame
     blood = rng.standard_normal(shape).astype(np.float32) * 0.1
@@ -995,5 +996,12 @@ def test_tissue_suppression():
 
     # After suppression, energy should be lower than the original tissue-dominated signal
     assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
+
+    correlation_accross_frames = np.corrcoef(output.reshape(n_frames, -1))
+    # The correlation across frames should be reduced after tissue suppression
+    assert np.mean(correlation_accross_frames) < 0.5, (
+        "Tissue suppression should reduce correlation across frames, got mean correlation: "
+        f"{np.mean(correlation_accross_frames)}"
+    )
 
     return output

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -962,3 +962,38 @@ def test_common_midpoint_phase_error_coherent_data():
     assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
 
     return phase_error
+
+
+@backend_equality_check(decimal=4)
+def test_tissue_suppression():
+    """Test that TissueSuppression reduces stationary tissue component."""
+    import keras
+
+    from zea import ops
+
+    rng = np.random.default_rng(DEFAULT_TEST_SEED)
+
+    n_frames, n_transmits, n_samples, n_channels = 10, 4, 32, 8
+    shape = (n_frames, n_transmits, n_samples, n_channels)
+
+    # Stationary tissue: same signal repeated across all frames
+    tissue = rng.standard_normal((1, n_transmits, n_samples, n_channels)).astype(np.float32)
+    tissue = np.repeat(tissue, n_frames, axis=0)
+
+    # Blood component: random per frame
+    blood = rng.standard_normal(shape).astype(np.float32) * 0.1
+
+    data = tissue + blood
+
+    cutoff = 3
+    op = ops.TissueSuppression(cutoff=cutoff)
+    data_tensor = keras.ops.convert_to_tensor(data)
+    output = keras.ops.convert_to_numpy(op(data=data_tensor)["data"])
+
+    assert output.shape == shape, f"Expected shape {shape}, got {output.shape}"
+    assert output.dtype == data.dtype, f"Expected dtype {data.dtype}, got {output.dtype}"
+
+    # After suppression, energy should be lower than the original tissue-dominated signal
+    assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
+
+    return output

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -982,9 +982,9 @@ def test_tissue_suppression():
     tissue = np.ones(shape) * gradient
 
     # Blood component: random per frame
-    blood = rng.standard_normal(shape).astype(np.float32) * 0.1
+    blood = rng.standard_normal(shape) * 0.1
 
-    data = tissue + blood
+    data = (tissue + blood).astype(np.float32)
 
     cutoff = 3
     op = ops.TissueSuppression(cutoff=cutoff)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -973,12 +973,12 @@ def test_tissue_suppression():
 
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
 
-    n_frames, n_transmits, n_samples, n_channels = 10, 4, 32, 8
-    shape = (n_frames, n_transmits, n_samples, n_channels)
+    n_frames, n_tx, n_ax, n_ch = 10, 4, 32, 8
+    shape = (n_frames, n_tx, n_ax, n_ch)
 
     # Stationary tissue: same signal repeated across all frames
 
-    gradient = np.linspace(0, 1, n_samples).reshape(1, 1, n_samples, 1)
+    gradient = np.linspace(0, 1, n_ax).reshape(1, 1, n_ax, 1)
     tissue = np.ones(shape) * gradient
 
     # Blood component: random per frame

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -997,11 +997,11 @@ def test_tissue_suppression():
     # After suppression, energy should be lower than the original tissue-dominated signal
     assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
 
-    correlation_accross_frames = np.corrcoef(output.reshape(n_frames, -1))
+    correlation_across_frames = np.corrcoef(output.reshape(n_frames, -1))
     # The correlation across frames should be reduced after tissue suppression
-    assert np.mean(correlation_accross_frames) < 0.5, (
+    assert np.mean(correlation_across_frames) < 0.5, (
         "Tissue suppression should reduce correlation across frames, got mean correlation: "
-        f"{np.mean(correlation_accross_frames)}"
+        f"{np.mean(correlation_across_frames)}"
     )
 
     return output

--- a/zea/func/__init__.py
+++ b/zea/func/__init__.py
@@ -58,6 +58,7 @@ from .ultrasound import (
     hilbert,
     log_compress,
     make_tgc_curve,
+    suppress_tissue,
     upmix,
 )
 
@@ -116,4 +117,5 @@ __all__ = [
     "upmix",
     "log_compress",
     "make_tgc_curve",
+    "suppress_tissue",
 ]

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -930,7 +930,7 @@ def dehaze_nuclear_diffusion(
     return tissue_frames, haze_frames
 
 
-def suppress_tissue(data, cutoff: int = 5) -> np.ndarray:
+def suppress_tissue(data, cutoff: int = 5):
     """
     Suppresses tissue using Direct SVD.
 
@@ -940,6 +940,8 @@ def suppress_tissue(data, cutoff: int = 5) -> np.ndarray:
     """
     if cutoff <= 0:
         return data
+    if cutoff >= data.shape[0]:
+        raise ValueError(f"Cutoff must be between 0 and n_frames-1, got {cutoff}.")
 
     original_shape = data.shape
     n_frames = original_shape[0]

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -935,7 +935,7 @@ def suppress_tissue(data, cutoff: int = 5) -> np.ndarray:
     Suppresses tissue using Direct SVD.
 
     Args:
-        data (np.ndarray): Shape (Frames, ...)
+        data (ops.Tensor): Shape (n_frames, ...)
         cutoff (int): Number of principal components (tissue) to reject.
     """
     if cutoff <= 0:

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -946,9 +946,9 @@ def suppress_tissue(data: np.ndarray, cutoff: int = 5) -> np.ndarray:
 
     original_shape = data.shape
     n_frames = original_shape[0]
-    data_2d = data.reshape(n_frames, -1)
+    data_2d = ops.reshape(data, (n_frames, -1))
 
-    casorati_matrix = data_2d @ data_2d.T
+    casorati_matrix = ops.matmul(data_2d, ops.transpose(data_2d))
 
     # We call the data X
     # X = U @ S @ Vh
@@ -958,9 +958,9 @@ def suppress_tissue(data: np.ndarray, cutoff: int = 5) -> np.ndarray:
     V, S, _ = ops.linalg.svd(casorati_matrix)
 
     # Remove the right singular vectors
-    reconstructed = data_2d.T @ V
+    reconstructed = ops.matmul(ops.transpose(data_2d), V)
 
     # Reconstruct with only part of the vectors
-    reconstructed = reconstructed[:, cutoff:] @ V[:, cutoff:].T
+    reconstructed = ops.matmul(reconstructed[:, cutoff:], ops.transpose(V[:, cutoff:]))
 
-    return reconstructed.T.reshape(data.shape)
+    return ops.reshape(ops.transpose(reconstructed), original_shape)

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -928,3 +928,39 @@ def dehaze_nuclear_diffusion(
         haze_frames = hazy_np - haze_frames - 1
 
     return tissue_frames, haze_frames
+
+
+def suppress_tissue(data: np.ndarray, cutoff: int = 5) -> np.ndarray:
+    """
+    Suppresses tissue using Direct SVD.
+
+    Parameters
+    ----------
+    data : np.ndarray
+        Shape (Frames, ...)
+    cutoff : int
+        Number of principal components (tissue) to reject.
+    """
+    if cutoff <= 0:
+        return data
+
+    original_shape = data.shape
+    n_frames = original_shape[0]
+    data_2d = data.reshape(n_frames, -1)
+
+    casorati_matrix = data_2d @ data_2d.T
+
+    # We call the data X
+    # X = U @ S @ Vh
+    # Xh@X =  Vh @ Sh @ Uh @ U @ S @ Vh = V @ Sh @ S @ Vh
+
+    # Compute the SVD of the grammian
+    V, S, _ = ops.linalg.svd(casorati_matrix)
+
+    # Remove the right singular vectors
+    reconstructed = data_2d.T @ V
+
+    # Reconstruct with only part of the vectors
+    reconstructed = reconstructed[:, cutoff:] @ V[:, cutoff:].T
+
+    return reconstructed.T.reshape(data.shape)

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -930,16 +930,13 @@ def dehaze_nuclear_diffusion(
     return tissue_frames, haze_frames
 
 
-def suppress_tissue(data: np.ndarray, cutoff: int = 5) -> np.ndarray:
+def suppress_tissue(data, cutoff: int = 5) -> np.ndarray:
     """
     Suppresses tissue using Direct SVD.
 
-    Parameters
-    ----------
-    data : np.ndarray
-        Shape (Frames, ...)
-    cutoff : int
-        Number of principal components (tissue) to reject.
+    Args:
+        data (np.ndarray): Shape (Frames, ...)
+        cutoff (int): Number of principal components (tissue) to reject.
     """
     if cutoff <= 0:
         return data

--- a/zea/ops/__init__.py
+++ b/zea/ops/__init__.py
@@ -261,6 +261,7 @@ from .ultrasound import (
     ScanConvert,
     Simulate,
     TOFCorrection,
+    TissueSuppression,
     UpMix,
 )
 
@@ -308,6 +309,7 @@ __all__ = [
     "ScanConvert",
     "Simulate",
     "TOFCorrection",
+    "TissueSuppression",
     "UpMix",
     "CommonMidpointPhaseError",
     # Keras operations

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1184,3 +1184,55 @@ class CommonMidpointPhaseError(Operation):
                 data,
             )
         return {self.output_key: pemap}
+
+
+@ops_registry("tissue_suppression")
+class TissueSuppression(Operation):
+    """Tissue suppression using SVD-based clutter filtering.
+
+    Removes stationary tissue components from multi-frame ultrasound data
+    by zeroing the dominant singular values of the Casorati matrix.
+    """
+
+    def __init__(self, cutoff: int = 5, **kwargs):
+        super().__init__(**kwargs)
+        self.cutoff = cutoff
+
+    @staticmethod
+    def suppress_tissue(data: np.ndarray, cutoff: int = 5) -> np.ndarray:
+        """
+        Suppresses tissue using Direct SVD (Reduced).
+
+        Parameters
+        ----------
+        data : np.ndarray
+            Shape (Frames, Transmits, Samples, Channels)
+        cutoff : int
+            Number of principal components (tissue) to reject.
+        """
+        if cutoff <= 0:
+            return data
+
+        # 1. Reshape to Casorati Matrix: (Frames, Space)
+        original_shape = data.shape
+        n_frames = original_shape[0]
+        data_2d = data.reshape(n_frames, -1)
+
+        # 2. Reduced SVD directly on the Casorati matrix
+        U, s, Vh = ops.linalg.svd(data_2d, full_matrices=False)
+
+        # 3. Suppress tissue by zeroing the first 'cutoff' singular values
+        s_filtered = s.copy()
+        mask = ops.arange(s.shape[0]) > cutoff
+        s_filtered = s_filtered * mask
+
+        # 4. Reconstruct: U @ diag(s_filtered) @ Vh, optimised as (U * s_filtered) @ Vh
+        reconstructed = (U * s_filtered) @ Vh
+
+        # 5. Restore original shape
+        return reconstructed.reshape(original_shape)
+
+    def call(self, **kwargs):
+        data = kwargs[self.key]
+        filtered = self.suppress_tissue(ops.array(data), self.cutoff)
+        return {self.output_key: ops.cast(ops.array(filtered), data.dtype)}

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1199,7 +1199,7 @@ class TissueSuppression(Operation):
         super().__init__(**kwargs)
         self.cutoff = cutoff
 
-    def suppress_tissue(self, data) -> np.ndarray:
+    def suppress_tissue(self, data):
         """
         Suppresses tissue using Direct SVD.
 

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1201,10 +1201,10 @@ class TissueSuppression(Operation):
 
     def suppress_tissue(self, data) -> np.ndarray:
         """
-        Suppresses tissue using Direct SVD (Reduced).
+        Suppresses tissue using Direct SVD.
 
         Args:
-            data (ops.Tensor): Shape (n_frames, n_tx, n_ax, n_el, n_ch)
+            data (ops.Tensor): Shape (n_frames, ...)
 
         """
         return suppress_tissue(data, self.cutoff)

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -22,6 +22,7 @@ from zea.func.ultrasound import (
     get_band_pass_filter,
     get_low_pass_iq_filter,
     log_compress,
+    suppress_tissue,
     upmix,
 )
 from zea.internal.core import (
@@ -1210,27 +1211,7 @@ class TissueSuppression(Operation):
         cutoff : int
             Number of principal components (tissue) to reject.
         """
-        if cutoff <= 0:
-            return data
-
-        # 1. Reshape to Casorati Matrix: (Frames, Space)
-        original_shape = data.shape
-        n_frames = original_shape[0]
-        data_2d = data.reshape(n_frames, -1)
-
-        # 2. Reduced SVD directly on the Casorati matrix
-        U, s, Vh = ops.linalg.svd(data_2d, full_matrices=False)
-
-        # 3. Suppress tissue by zeroing the first 'cutoff' singular values
-        s_filtered = s.copy()
-        mask = ops.arange(s.shape[0]) > cutoff
-        s_filtered = s_filtered * mask
-
-        # 4. Reconstruct: U @ diag(s_filtered) @ Vh, optimised as (U * s_filtered) @ Vh
-        reconstructed = (U * s_filtered) @ Vh
-
-        # 5. Restore original shape
-        return reconstructed.reshape(original_shape)
+        return suppress_tissue(data, cutoff)
 
     def call(self, **kwargs):
         data = kwargs[self.key]

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1199,21 +1199,17 @@ class TissueSuppression(Operation):
         super().__init__(**kwargs)
         self.cutoff = cutoff
 
-    @staticmethod
-    def suppress_tissue(data: np.ndarray, cutoff: int = 5) -> np.ndarray:
+    def suppress_tissue(self, data) -> np.ndarray:
         """
         Suppresses tissue using Direct SVD (Reduced).
 
-        Parameters
-        ----------
-        data : np.ndarray
-            Shape (Frames, Transmits, Samples, Channels)
-        cutoff : int
-            Number of principal components (tissue) to reject.
+        Args:
+            data (ops.Tensor): Shape (n_frames, n_tx, n_ax, n_el, n_ch)
+
         """
-        return suppress_tissue(data, cutoff)
+        return suppress_tissue(data, self.cutoff)
 
     def call(self, **kwargs):
         data = kwargs[self.key]
-        filtered = self.suppress_tissue(ops.array(data), self.cutoff)
+        filtered = self.suppress_tissue(ops.array(data))
         return {self.output_key: ops.cast(ops.array(filtered), data.dtype)}


### PR DESCRIPTION
This PR implements singular value decomposition based tissue suppression. It implements the function `tissue_suppression`, which is used in a new operation: `TissueSuppression`.

# Result
## Without tissue suppression

<img width="464" height="438" alt="verasonics_bmode" src="https://github.com/user-attachments/assets/3a5c5375-972c-41f6-b5aa-a6d8bf5e2faf" />

## With tissue suppression
<img width="464" height="438" alt="verasonics_bmode copy" src="https://github.com/user-attachments/assets/b42fa1d3-0236-4461-96a2-d091d7acc5e1" />

# How to test
- I placed the source data for this example (from the PALA dataset) on the NAS `USBMD-NAS/Ultrasound-BMd/data/vincent/RF_003.hdf5`
- This is the pipeline I used
```yaml
parameters:
  grid_size_x: 400
  grid_size_z: 600
  dynamic_range: [-60, 0]
  zlims: [0.001, 0.013]
  apply_lens_correction: false
  lens_sound_speed: 1000
  lens_thickness: 0.002

pipeline:
  operations:
    - name: keras.ops.cast
      params:
        dtype: float32
    - name: beamform
      params:
        beamformer: delay_and_sum
        num_patches: 200
    - name: tissue_suppression
    - name: envelope_detect
    - name: normalize
    - name: log_compress
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tissue suppression functionality available as both a functional API (`suppress_tissue`) and an operation (`TissueSuppression`) for ultrasound signal processing.
  * Both implementations include a configurable cutoff parameter (default: 5).

* **Tests**
  * Added comprehensive test coverage for tissue suppression, verifying output shape/dtype preservation and signal reduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->