### PR TITLE
Fix keras import for `--help`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,7 @@ exclude_patterns = [
     "_autosummary/zea.tracking.lucas_kanade.rst",
     "_autosummary/zea.models.hvae.model.rst",
     "_autosummary/zea.models.hvae.utils.rst",
+    "_autosummary/zea.cli_args.rst",
 ]
 
 autodoc_default_options = {

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -3,6 +3,7 @@
 import importlib
 import importlib.util
 import os
+import sys
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING
 
@@ -47,6 +48,10 @@ except PackageNotFoundError:
 
 def _bootstrap_backend():
     """Setup function to initialize the zea package."""
+
+    # No printing when using --help flag
+    if "-h" in sys.argv[1:] or "--help" in sys.argv[1:]:
+        return
 
     def _check_backend_installed():
         """Verify that the required ML backend is installed.

--- a/zea/__main__.py
+++ b/zea/__main__.py
@@ -14,7 +14,7 @@ from typing import Annotated, Union
 
 import tyro
 
-from zea.data.process import ProcessArgs
+from zea.cli_args import ProcessArgs
 
 
 @dataclass

--- a/zea/cli_args.py
+++ b/zea/cli_args.py
@@ -1,0 +1,54 @@
+"""Lightweight CLI argument definitions for the ``zea`` command line tool.
+
+Kept free of heavy imports (keras, ``zea.data``, …) so that ``zea --help`` and
+``zea process --help`` can be rendered without loading an ML backend. This
+module lives at the top level of the package (rather than under ``zea.data``)
+because importing ``zea.data`` eagerly pulls in keras. The actual processing
+code lives in :mod:`zea.data.process`.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Annotated
+
+import tyro
+
+
+@dataclass
+class ProcessArgs:
+    """Arguments for beamforming a zea dataset."""
+
+    dataset: Annotated[
+        str,
+        tyro.conf.arg(
+            aliases=["-d"],
+            help="Path/URI to the zea dataset (folder of HDF5 files or a single HDF5 file).",
+        ),
+    ]
+    config: Annotated[
+        str,
+        tyro.conf.arg(
+            aliases=["-c"],
+            help="Path to config.yaml for the beamforming pipeline.",
+        ),
+    ]
+    save_dir: Path = Path("output")
+    key: str = "data/raw_data"
+    n_frames: int | None = None
+    save_as: str = "gif"
+    keep_keys: list[str] = field(default_factory=lambda: ["maxval"])
+    timings: bool = False
+    num_threads: int = 16
+    revision: str | None = None
+    config_revision: str | None = None
+    overwrite: bool = False
+    keep_dynamic_range: bool = False
+    device: Annotated[
+        str,
+        tyro.conf.arg(
+            help=(
+                "Compute device ('cuda:0', 'cpu', 'auto:1', …). "
+                "Only relevant when running the beamformer pipeline."
+            ),
+        ),
+    ] = "auto:1"

--- a/zea/data/process.py
+++ b/zea/data/process.py
@@ -7,9 +7,8 @@ Usage:
 import argparse
 import re
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass, field, fields as dataclass_fields
+from dataclasses import fields as dataclass_fields
 from pathlib import Path
-from typing import Annotated
 
 import keras
 import numpy as np
@@ -17,6 +16,7 @@ import tyro
 from keras import ops
 
 from zea import display, io_lib, log
+from zea.cli_args import ProcessArgs
 from zea.config import Config
 from zea.data.dataloader import Dataloader
 from zea.data.datasets import Dataset
@@ -34,46 +34,6 @@ try:
     SUPPORTED_FORMATS += ["nii.gz"]
 except ImportError:
     sitk = None
-
-
-@dataclass
-class ProcessArgs:
-    """Arguments for beamforming a zea dataset."""
-
-    dataset: Annotated[
-        str,
-        tyro.conf.arg(
-            aliases=["-d"],
-            help="Path/URI to the zea dataset (folder of HDF5 files or a single HDF5 file).",
-        ),
-    ]
-    config: Annotated[
-        str,
-        tyro.conf.arg(
-            aliases=["-c"],
-            help="Path to config.yaml for the beamforming pipeline.",
-        ),
-    ]
-    save_dir: Path = Path("output")
-    key: str = "data/raw_data"
-    n_frames: int | None = None
-    save_as: str = "gif"
-    keep_keys: list[str] = field(default_factory=lambda: ["maxval"])
-    timings: bool = False
-    num_threads: int = 16
-    revision: str | None = None
-    config_revision: str | None = None
-    overwrite: bool = False
-    keep_dynamic_range: bool = False
-    device: Annotated[
-        str,
-        tyro.conf.arg(
-            help=(
-                "Compute device ('cuda:0', 'cpu', 'auto:1', …). "
-                "Only relevant when running the beamformer pipeline."
-            ),
-        ),
-    ] = "auto:1"
 
 
 def get_parser(add_help: bool = True) -> argparse.ArgumentParser:


### PR DESCRIPTION
Regarding #416 

importing `ProcessArgs` from `zea.data.process` was causing the cascading keras import when using `zea --help`.

This is now moved to its own file. Its kind of an ugly fix, but its also the smallest possible fix.
Maybe we can think of something else, but for now, `zea --help` is clean and runs in ~1ms instead of ~1s