### PR TITLE
`zea.Dataset` lazy loading

### DIFF
--- a/docs/source/_autosummary/zea.rst
+++ b/docs/source/_autosummary/zea.rst
@@ -17,7 +17,6 @@ zea
    Dataloader
    Dataset
    File
-   Folder
    Parameters
    Pipeline
    Probe

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -131,7 +131,6 @@ TOPLEVEL_API_ALIASES = {
     "zea.config.Config": "zea.Config",
     "zea.data.dataloader.Dataloader": "zea.Dataloader",
     "zea.data.datasets.Dataset": "zea.Dataset",
-    "zea.data.datasets.Folder": "zea.Folder",
     "zea.data.file.File": "zea.File",
     "zea.ops.pipeline.Pipeline": "zea.Pipeline",
     "zea.probes.Probe": "zea.Probe",

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -1,6 +1,7 @@
 """Testing for `zea.data.datasets` module."""
 
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -218,3 +219,46 @@ def test_folder_rejects_single_file(dummy_dataset_path):
     file_path = next(Path(dummy_dataset_path).glob("*.hdf5"))
     with pytest.raises(ValueError, match="Use File class instead"):
         Folder(file_path, validate=False)
+
+
+def test_dataset_lazy_hf_defers_download(tmp_path):
+    """lazy=True stores hf:// pointers at init and downloads each file on first access."""
+    f1 = tmp_path / "file1.hdf5"
+    f2 = tmp_path / "file2.hdf5"
+    generate_example_dataset(f1)
+    generate_example_dataset(f2)
+
+    hf_files = ["file1.hdf5", "file2.hdf5"]
+
+    with (
+        patch("zea.data.datasets._hf_list_h5_files", return_value=hf_files),
+        patch("zea.data.datasets._hf_resolve_path", return_value=f1) as mock_resolve,
+    ):
+        ds = Dataset("hf://org/myrepo", lazy=True)
+
+        # No download at init
+        mock_resolve.assert_not_called()
+        assert len(ds) == 2
+        assert ds.file_paths[0] == "hf://org/myrepo/file1.hdf5"
+        assert ds.file_paths[1] == "hf://org/myrepo/file2.hdf5"
+
+        # First access triggers download of that file only
+        _ = ds[0]
+        mock_resolve.assert_called_once_with("hf://org/myrepo/file1.hdf5")
+        assert ds.file_paths[0] == str(f1)  # pointer replaced with local path
+        assert ds.file_paths[1] == "hf://org/myrepo/file2.hdf5"  # untouched
+
+        # Second access to the same index does not re-download
+        mock_resolve.reset_mock()
+        _ = ds[0]
+        mock_resolve.assert_not_called()
+
+        ds.close()
+
+
+def test_dataloader_rejects_lazy():
+    """H5DataSource raises ValueError when lazy=True is passed."""
+    from zea.data.dataloader import H5DataSource
+
+    with pytest.raises(ValueError, match="lazy=True is not supported"):
+        H5DataSource("nonexistent_path", lazy=True)

--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -228,7 +228,7 @@ def test_dataset_lazy_hf_defers_download(tmp_path):
     generate_example_dataset(f1)
     generate_example_dataset(f2)
 
-    hf_files = ["file1.hdf5", "file2.hdf5"]
+    hf_files = [("file1.hdf5", 1024), ("file2.hdf5", 2048)]
 
     with (
         patch("zea.data.datasets._hf_list_h5_files", return_value=hf_files),

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from .backend import device
     from .config import Config
     from .data.dataloader import Dataloader
-    from .data.datasets import Dataset, Folder
+    from .data.datasets import Dataset
     from .data.file import File, load_file
     from .datapaths import set_data_paths
     from .internal.device import init_device
@@ -146,7 +146,6 @@ _LAZY_ATTRS = {
     "Config": ("zea.config", "Config"),
     "Dataloader": ("zea.data.dataloader", "Dataloader"),
     "Dataset": ("zea.data.datasets", "Dataset"),
-    "Folder": ("zea.data.datasets", "Folder"),
     "File": ("zea.data.file", "File"),
     "load_file": ("zea.data.file", "load_file"),
     "set_data_paths": ("zea.datapaths", "set_data_paths"),

--- a/zea/data/dataloader.py
+++ b/zea/data/dataloader.py
@@ -241,7 +241,16 @@ class H5DataSource:
         assert self.n_frames > 0, f"`n_frames` must be > 0, got {self.n_frames}"
 
         # Discover files and shapes (reuses Dataset machinery)
-        _dataset = Dataset(file_paths, validate=validate, revision=revision, **kwargs)
+        lazy = kwargs.pop("lazy", False)
+        if lazy:
+            raise ValueError(
+                "lazy=True is not supported in Dataloader / H5DataSource. "
+                "All files must be downloaded before building the data pipeline. "
+                "Use Dataset(..., lazy=True) directly for interactive use."
+            )
+        _dataset = Dataset(
+            file_paths, validate=validate, revision=revision, _suggest_lazy=False, **kwargs
+        )
         self.file_paths = _dataset.file_paths
         self.file_shapes = _dataset.load_file_shapes(key)
         _dataset.close()

--- a/zea/data/datasets.py
+++ b/zea/data/datasets.py
@@ -493,14 +493,16 @@ class Dataset(H5FileHandleCache):
         if self.revision is not None:
             hf_kwargs["revision"] = self.revision
 
-        hf_files = _hf_list_h5_files(hf_path, **hf_kwargs)
+        hf_files = _hf_list_h5_files(hf_path, **hf_kwargs)  # [(filename, size_bytes), ...]
 
         if not hf_files:
             raise FileNotFoundError(f"No HDF5 files found in {hf_path}")
 
         if len(hf_files) > 10 and not self.lazy:
+            total_gb = sum(size for _, size in hf_files) / 1e9
             msg = (
-                f"About to download {len(hf_files)} files from '{hf_path}'. This may take a while."
+                f"About to download {len(hf_files)} files ({total_gb:.1f} GB) "
+                f"from '{hf_path}'. This may take a while."
             )
             if self._suggest_lazy:
                 msg += (
@@ -510,7 +512,7 @@ class Dataset(H5FileHandleCache):
             log.warning(msg)
 
         if self.lazy:
-            return [f"{HF_PREFIX}{repo_id}/{f}" for f in hf_files]
+            return [f"{HF_PREFIX}{repo_id}/{f}" for f, _ in hf_files]
 
         resolved = _hf_resolve_path(hf_path, **hf_kwargs)
         if resolved.is_dir():

--- a/zea/data/datasets.py
+++ b/zea/data/datasets.py
@@ -49,6 +49,7 @@ from zea.internal.preset_utils import (
     HF_DATASETS_DIR,
     HF_PREFIX,
     _hf_list_files,
+    _hf_list_h5_files,
     _hf_parse_path,
     _hf_resolve_path,
 )
@@ -444,6 +445,8 @@ class Dataset(H5FileHandleCache):
         validate: bool = False,
         directory_splits: list | None = None,
         revision: str | None = None,
+        lazy: bool = False,
+        _suggest_lazy: bool = True,
         **kwargs,
     ):
         """Initializes the Dataset.
@@ -457,11 +460,16 @@ class Dataset(H5FileHandleCache):
                 If none, all files in file_paths are used.
             revision (str, optional): HuggingFace revision (branch, tag, or commit hash).
                 Only used when ``file_paths`` contains ``hf://`` paths. Defaults to ``None``.
+            lazy (bool, optional): If True, ``hf://`` files are not downloaded at init — each
+                file is downloaded on first access. ``len(ds)`` returns the number of files
+                (not total frames). Defaults to False.
 
         """
         super().__init__(**kwargs)
         self.validate = validate
         self.revision = revision
+        self.lazy = lazy
+        self._suggest_lazy = _suggest_lazy
         self.file_paths = self.find_files(file_paths)
 
         if directory_splits is not None:
@@ -478,9 +486,48 @@ class Dataset(H5FileHandleCache):
         """Load the shapes of the datasets in each file."""
         return _find_h5_file_shapes(self.file_paths, key, _file_hash(self.file_paths))
 
+    def _find_hf_files(self, hf_path: str) -> List[str]:
+        """Resolve an HF path to a list of local paths (or HF strings if lazy)."""
+        repo_id, _ = _hf_parse_path(hf_path)
+        hf_kwargs = {}
+        if self.revision is not None:
+            hf_kwargs["revision"] = self.revision
+
+        hf_files = _hf_list_h5_files(hf_path, **hf_kwargs)
+
+        if not hf_files:
+            raise FileNotFoundError(f"No HDF5 files found in {hf_path}")
+
+        if len(hf_files) > 10 and not self.lazy:
+            msg = (
+                f"About to download {len(hf_files)} files from '{hf_path}'. This may take a while."
+            )
+            if self._suggest_lazy:
+                msg += (
+                    f" Use {type(self).__name__}(..., lazy=True) to defer "
+                    "downloads until each file is first accessed."
+                )
+            log.warning(msg)
+
+        if self.lazy:
+            return [f"{HF_PREFIX}{repo_id}/{f}" for f in hf_files]
+
+        resolved = _hf_resolve_path(hf_path, **hf_kwargs)
+        if resolved.is_dir():
+            paths = sorted(str(fp) for fp in search_file_tree(resolved, filetypes=FILE_TYPES))
+            if self.validate:
+                for p in paths:
+                    with File(p) as f:
+                        f.validate()
+            return paths
+        else:
+            if self.validate:
+                with File(resolved) as f:
+                    f.validate()
+            return [str(resolved)]
+
     def find_files(self, paths) -> List[str]:
         """Find files and optionally validate folders and files."""
-        # Initialize file paths and shapes
         file_paths = []
 
         if not isinstance(paths, (list, tuple)):
@@ -488,26 +535,21 @@ class Dataset(H5FileHandleCache):
 
         for file_path in paths:
             if isinstance(file_path, (list, tuple)):
-                # If the path is a list, recursively call find_files
                 file_paths += self.find_files(file_path)
                 continue
 
             file_path = str(file_path)
-            if file_path.startswith(HF_PREFIX):
-                file_path = HFPath(file_path)
-            else:
-                file_path = Path(file_path)
 
+            if file_path.startswith(HF_PREFIX):
+                file_paths += self._find_hf_files(file_path)
+                continue
+
+            file_path = Path(file_path)
             if file_path.is_dir():
                 folder = Folder(file_path, self.validate, revision=self.revision)
                 file_paths += folder.file_paths
                 del folder
             elif file_path.is_file():
-                if str(file_path).startswith(HF_PREFIX):
-                    hf_kwargs = {}
-                    if self.revision is not None:
-                        hf_kwargs["revision"] = self.revision
-                    file_path = _hf_resolve_path(str(file_path), **hf_kwargs)
                 file_paths.append(str(file_path))
                 with File(file_path) as file:
                     if self.validate:
@@ -533,8 +575,15 @@ class Dataset(H5FileHandleCache):
 
     def __getitem__(self, index) -> File:
         """Retrieves an item from the dataset."""
-        file = self.get_file(self.file_paths[index])
-        return file
+        path = self.file_paths[index]
+        if path.startswith(HF_PREFIX):
+            hf_kwargs = {}
+            if self.revision is not None:
+                hf_kwargs["revision"] = self.revision
+            local_path = str(_hf_resolve_path(path, **hf_kwargs))
+            self.file_paths[index] = local_path
+            path = local_path
+        return self.get_file(path)
 
     def __iter__(self):
         """

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -3,9 +3,10 @@
 See https://huggingface.co/zeahub/
 """
 
+import os
 from pathlib import Path
 
-from huggingface_hub import hf_hub_download, list_repo_files, login
+from huggingface_hub import RepoFile, hf_hub_download, list_repo_files, list_repo_tree, login
 from huggingface_hub.utils import (
     EntryNotFoundError,
     HFValidationError,
@@ -19,6 +20,19 @@ HF_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
 
 HF_SCHEME = "hf"
 HF_PREFIX = "hf://"
+
+
+def _hf_login() -> None:
+    """Authenticate using a token from the environment, if available.
+
+    Reads ``HF_TOKEN`` (or ``HUGGING_FACE_HUB_TOKEN``) and only logs in when a
+    token is present. This avoids ``login()`` falling back to an interactive
+    prompt in headless environments; cached credentials or anonymous access are
+    used when no token is set.
+    """
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        login(token=token, skip_if_logged_in=True)
 
 
 def _hf_parse_path(hf_path: str):
@@ -36,7 +50,7 @@ def _hf_list_files(repo_id, repo_type="dataset", **kwargs):
     try:
         files = list_repo_files(repo_id, repo_type=repo_type, **kwargs)
     except (RepositoryNotFoundError, HFValidationError, EntryNotFoundError):
-        login()
+        _hf_login()
         files = list_repo_files(repo_id, repo_type=repo_type, **kwargs)
     return files
 
@@ -92,24 +106,43 @@ def _download_files_in_path(
 _HF_H5_EXTENSIONS = (".hdf5", ".h5")
 
 
-def _hf_list_h5_files(hf_path: str, **kwargs) -> list[str]:
-    """List HDF5 filenames in an HF repo path (relative to repo root, no download).
+def _hf_list_h5_files(hf_path: str, **kwargs) -> list[tuple[str, int]]:
+    """List HDF5 files with sizes for an HF path (no download).
+
+    Returns a list of ``(filename_relative_to_repo_root, size_bytes)`` tuples.
+    Only .h5 / .hdf5 files are included; other repo files are ignored.
 
     Handles:
     - hf://org/repo           — all .h5/.hdf5 files in the repo
     - hf://org/repo/subdir    — all .h5/.hdf5 files under subdir/
-    - hf://org/repo/file.h5   — [file.h5] if it exists as a single file
+    - hf://org/repo/file.h5   — [(file.h5, size)] if it exists as a single file
     """
     repo_id, subpath = _hf_parse_path(hf_path)
-    all_files = list(_hf_list_files(repo_id, **kwargs))
+    try:
+        entries = {
+            e.path: e.size
+            for e in list_repo_tree(repo_id, recursive=True, repo_type="dataset", **kwargs)
+            if isinstance(e, RepoFile)
+        }
+    except (RepositoryNotFoundError, HFValidationError, EntryNotFoundError):
+        _hf_login()
+        entries = {
+            e.path: e.size
+            for e in list_repo_tree(repo_id, recursive=True, repo_type="dataset", **kwargs)
+            if isinstance(e, RepoFile)
+        }
+
+    all_files = list(entries)
 
     if subpath and any(f == subpath for f in all_files):
-        return [subpath]
+        matched = [subpath]
     elif subpath:
         prefix = subpath.rstrip("/") + "/"
-        return [f for f in all_files if f.startswith(prefix) and f.endswith(_HF_H5_EXTENSIONS)]
+        matched = [f for f in all_files if f.startswith(prefix) and f.endswith(_HF_H5_EXTENSIONS)]
     else:
-        return [f for f in all_files if f.endswith(_HF_H5_EXTENSIONS)]
+        matched = [f for f in all_files if f.endswith(_HF_H5_EXTENSIONS)]
+
+    return [(f, entries[f]) for f in matched]
 
 
 def _hf_resolve_path(

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -89,6 +89,29 @@ def _download_files_in_path(
     return downloaded_files
 
 
+_HF_H5_EXTENSIONS = (".hdf5", ".h5")
+
+
+def _hf_list_h5_files(hf_path: str, **kwargs) -> list[str]:
+    """List HDF5 filenames in an HF repo path (relative to repo root, no download).
+
+    Handles:
+    - hf://org/repo           — all .h5/.hdf5 files in the repo
+    - hf://org/repo/subdir    — all .h5/.hdf5 files under subdir/
+    - hf://org/repo/file.h5   — [file.h5] if it exists as a single file
+    """
+    repo_id, subpath = _hf_parse_path(hf_path)
+    all_files = list(_hf_list_files(repo_id, **kwargs))
+
+    if subpath and any(f == subpath for f in all_files):
+        return [subpath]
+    elif subpath:
+        prefix = subpath.rstrip("/") + "/"
+        return [f for f in all_files if f.startswith(prefix) and f.endswith(_HF_H5_EXTENSIONS)]
+    else:
+        return [f for f in all_files if f.endswith(_HF_H5_EXTENSIONS)]
+
+
 def _hf_resolve_path(
     hf_path: str, cache_dir=HF_DATASETS_DIR, repo_type="dataset", **kwargs
 ) -> Path:

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -13,9 +13,8 @@ from huggingface_hub.utils import EntryNotFoundError, HFValidationError
 
 import zea
 from zea.internal.cache import ZEA_CACHE_DIR
-from zea.internal.preset_utils import _hf_parse_path
+from zea.internal.preset_utils import _hf_login, _hf_parse_path
 from zea.internal.registry import model_registry
-from zea.tools.hf import _hf_login
 
 HF_PREFIX = "hf://"
 

--- a/zea/tools/hf.py
+++ b/zea/tools/hf.py
@@ -1,27 +1,13 @@
 """Huggingface hub (hf) tooling."""
 
-import os
 from pathlib import Path, PurePosixPath
 
-from huggingface_hub import HfApi, login, snapshot_download
+from huggingface_hub import HfApi, snapshot_download
 
 from zea import log
-from zea.internal.preset_utils import _hf_list_files, _hf_parse_path
+from zea.internal.preset_utils import _hf_list_files, _hf_login, _hf_parse_path
 
 HF_PREFIX = "hf://"
-
-
-def _hf_login() -> None:
-    """Authenticate using a token from the environment, if available.
-
-    Reads ``HF_TOKEN`` (or ``HUGGING_FACE_HUB_TOKEN``) and only logs in when a
-    token is present. This avoids ``login()`` falling back to an interactive
-    prompt in headless environments; cached credentials or anonymous access are
-    used when no token is set.
-    """
-    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-    if token:
-        login(token=token, skip_if_logged_in=True)
 
 
 def load_model_from_hf(repo_id, revision="main", verbose=True):


### PR DESCRIPTION
Adding a bit more logic to support easy handling of large datasets on HF. Code speaks for itself.

```python
import zea

# small dataset
ds = zea.Dataset("hf://zeahub/camus-sample")

print(f"Dataset has {len(ds)} samples")

# large dataset load lazily
ds = zea.Dataset("hf://zeahub/zea-carotid-2023", revision="v0.1.0", lazy=True)
# or without it will give you a nice warning
# zea: WARNING About to download 81 files (1023.6 GB) from 'hf://zeahub/zea-carotid-2023'. This may take a while. Use Dataset(..., lazy=True) to defer downloads until each file is first accessed.

# still possible to get length without triggering any download
print(f"Dataset has {len(ds)} samples")

# only after accessing a sample do we trigger the download of that sample
sample = ds[0]
print(f"First sample shape: {sample.data.raw_data.shape}")


# for dataloaders we don't allow lazy loading
dataloader = zea.Dataloader(
    "hf://zeahub/camus", revision="v0.1.0", batch_size=2, lazy=True
)  # raises ValueError with lazy=True not supported

# next(iter(dataloader))
```