### PR TITLE
Split image build into separate workflow to fix duplicate check names

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,57 @@
+name: Build and Push CI Image
+
+on:
+  push:
+    branches:
+      - main
+      - openh-rf
+
+env:
+  BASE_IMAGE: ghcr.io/tue-bmd/zea/all-cpu
+
+jobs:
+  tag:
+    uses: ./.github/workflows/set-tag.yaml
+
+  image:
+    needs: [tag]
+    runs-on: ubuntu-latest
+    timeout-minutes: 100
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf "/usr/local/share/boost" "$AGENT_TOOLSDIRECTORY" /opt/hostedtoolcache
+
+      - name: Build and push CI Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          build-args: |
+            INSTALL_JAX=cpu
+            INSTALL_TORCH=cpu
+            INSTALL_TF=cpu
+            DEV=true
+          push: true
+          tags: |
+            ${{ env.BASE_IMAGE }}:${{ needs.tag.outputs.docker_tag }}
+            ${{ env.BASE_IMAGE }}:${{ github.ref_name }}
+            ${{ github.ref == 'refs/heads/main' && format('{0}:latest', env.BASE_IMAGE) || '' }}
+          cache-from: type=registry,ref=ghcr.io/tue-bmd/zea/build-cache:all-cpu
+          cache-to: type=registry,ref=ghcr.io/tue-bmd/zea/build-cache:all-cpu,mode=max

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - openh-rf
 
 env:
   REGISTRY: ghcr.io
@@ -79,11 +78,10 @@ jobs:
             echo "Image-relevant files changed — building locally"
           fi
 
-      # Free disk space before any docker build. Runs for same-repo builds and fork PRs
-      # that need a local build; skipped for fork PRs reusing the base-branch image.
+      # Free disk space before any docker build. Skipped for fork PRs reusing the base-branch image.
       - name: Free up disk space
         if: >
-          github.event_name != 'pull_request'
+          github.event_name == 'push'
           || github.event.pull_request.head.repo.full_name == github.repository
           || steps.image-check.outputs.changed == 'true'
         run: |
@@ -91,7 +89,7 @@ jobs:
 
       - name: Build and push CI Docker image
         id: build
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -102,10 +100,7 @@ jobs:
             INSTALL_TF=cpu
             DEV=true
           push: true
-          tags: |
-            ${{ env.BASE_IMAGE }}:${{ needs.tag.outputs.docker_tag }}
-            ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && format('{0}:latest', env.BASE_IMAGE) || '' }}
-            ${{ github.event_name == 'push' && format('{0}:{1}', env.BASE_IMAGE, github.ref_name) || '' }}
+          tags: ${{ env.BASE_IMAGE }}:${{ needs.tag.outputs.docker_tag }}
           cache-from: type=registry,ref=ghcr.io/tue-bmd/zea/build-cache:all-cpu
           cache-to: type=registry,ref=ghcr.io/tue-bmd/zea/build-cache:all-cpu,mode=max
 


### PR DESCRIPTION
tests.yaml triggers on pull_request + push to main only — check names are never ambiguous (no (push)/(pull_request) suffix duplication).

build-image.yaml triggers on push to main/openh-rf — builds and pushes the image tagged with commit SHA, branch name, and :latest (main only).

Splitting these concerns means openh-rf branch pushes only run the image build, not the full test suite, eliminating the event collision that caused duplicate check names on PRs targeting openh-rf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced dedicated CI image build workflow with automated Docker container creation and registry distribution.
  * Refined CI/CD pipeline branch filtering and Docker image tagging strategy for streamlined build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->