### PR TITLE
Add UTC acquisition timestamp to `zea.File`

### DIFF
--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -628,6 +628,60 @@ def test_subject_id_warning_includes_field_metadata_description(tmp_path):
     assert any("subject-wise splits" in m for m in messages)
 
 
+def test_acquisition_time_auto_set_for_non_human(tmp_path):
+    from datetime import datetime, timezone
+
+    n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+    path = tmp_path / "acq_time_non_human.hdf5"
+    File.create(
+        path,
+        data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+        scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+        probe=_probe_minimal(n_el=n_el),
+        metadata={"subject": {"type": "phantom"}},
+        overwrite=True,
+    )
+    with File(path) as f:
+        ts = f.acquisition_time
+    assert ts is not None
+    assert ts.tzinfo is not None
+    assert ts.tzinfo == timezone.utc or ts.utcoffset().total_seconds() == 0
+    assert isinstance(ts, datetime)
+
+
+def test_acquisition_time_not_set_for_human(tmp_path):
+    n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+    path = tmp_path / "acq_time_human_no_stamp.hdf5"
+    File.create(
+        path,
+        data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+        scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+        probe=_probe_minimal(n_el=n_el),
+        metadata={"subject": {"type": "human"}},
+        overwrite=True,
+    )
+    with File(path) as f:
+        assert f.acquisition_time is None
+
+
+def test_acquisition_time_explicit_human_emits_phi_warning(tmp_path):
+    n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+    path = tmp_path / "acq_time_human_explicit.hdf5"
+    with patch("zea.log.warning") as mock_warn:
+        File.create(
+            path,
+            data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+            scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+            probe=_probe_minimal(n_el=n_el),
+            metadata={"subject": {"type": "human"}},
+            acquisition_time="2026-06-12T14:30:00+00:00",
+            overwrite=True,
+        )
+    messages = [str(c.args[0]) for c in mock_warn.call_args_list]
+    assert any("PHI" in m for m in messages)
+    assert any("Protected Health Information" in m for m in messages)
+
+
 class TestScanValidationErrors:
     """TypeError / ValueError raised by Scan spec validation."""
 

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -682,6 +682,54 @@ def test_acquisition_time_explicit_human_emits_phi_warning(tmp_path):
     assert any("Protected Health Information" in m for m in messages)
 
 
+def test_acquisition_time_naive_string_assumed_utc(tmp_path):
+    n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+    path = tmp_path / "acq_time_naive.hdf5"
+    File.create(
+        path,
+        data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+        scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+        probe=_probe_minimal(n_el=n_el),
+        acquisition_time="2026-06-12T14:30:00",  # no tzinfo
+        overwrite=True,
+    )
+    with File(path) as f:
+        ts = f.acquisition_time
+    assert ts.utcoffset().total_seconds() == 0
+    assert ts.year == 2026 and ts.hour == 14
+
+
+def test_acquisition_time_malformed_raises(tmp_path):
+    n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+    path = tmp_path / "acq_time_bad.hdf5"
+    with pytest.raises(ValueError, match="Invalid acquisition_time"):
+        File.create(
+            path,
+            data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+            scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+            probe=_probe_minimal(n_el=n_el),
+            acquisition_time="not-a-date",
+            overwrite=True,
+        )
+
+
+def test_acquisition_time_human_type_whitespace_and_case(tmp_path):
+    """' HUMAN ' and 'Human' should both suppress auto-stamp."""
+    n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
+    for subject_type in (" HUMAN ", "Human", "HUMAN"):
+        path = tmp_path / f"acq_time_{subject_type.strip()}.hdf5"
+        File.create(
+            path,
+            data=_example_data(n_frames, n_tx, n_el, n_ax, n_ch),
+            scan=_scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+            probe=_probe_minimal(n_el=n_el),
+            metadata={"subject": {"type": subject_type.strip()}},
+            overwrite=True,
+        )
+        with File(path) as f:
+            assert f.acquisition_time is None, f"expected no stamp for type={subject_type!r}"
+
+
 class TestScanValidationErrors:
     """TypeError / ValueError raised by Scan spec validation."""
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -1,6 +1,7 @@
 """zea data file (HDF5)."""
 
 import enum
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, List, Tuple, Union
 
@@ -764,6 +765,7 @@ class File(h5py.File):
         probe: "ProbeSpec | dict | None" = None,
         us_machine: str | None = None,
         description: str | None = None,
+        acquisition_time: str | None = None,
         compression: str = DEFAULT_COMPRESSION,
         chunk_frames: bool = False,
         overwrite: bool = False,
@@ -800,6 +802,14 @@ class File(h5py.File):
                 plain dict accepted by :class:`~zea.data.spec.ProbeSpec`.
             us_machine: Name of the ultrasound machine.
             description: Free-text description of the acquisition.
+            acquisition_time: UTC acquisition timestamp as an ISO 8601 string
+                (e.g. ``"2026-06-12T14:30:00+00:00"``). When *None* (default) the
+                current UTC time is recorded automatically, **unless** the subject
+                type is ``"human"`` — in that case no timestamp is saved by default
+                (recording timestamps for human subjects may constitute Protected
+                Health Information / PHI). To capture the current moment explicitly,
+                pass ``datetime.now(timezone.utc).isoformat()`` (requires
+                ``from datetime import datetime, timezone``).
             compression: HDF5 compression filter (default ``"lzf"``).
             chunk_frames: If *True*, use frame-wise chunking for all datasets containing
                 a "frames" dimension. Dataset will be stored with HDF5 chunking enabled,
@@ -814,6 +824,7 @@ class File(h5py.File):
         .. doctest::
 
             >>> import os, tempfile
+            >>> from datetime import datetime, timezone
             >>> import numpy as np
             >>> from zea import File
 
@@ -839,9 +850,14 @@ class File(h5py.File):
             ...     data={"raw_data": raw},
             ...     scan=scan,
             ...     probe={"name": "verasonics_l11_4v", "probe_geometry": probe_geometry},
+            ...     acquisition_time=datetime.now(timezone.utc).isoformat(),
             ...     overwrite=True,
             ... )
-            >>> os.unlink(path)
+
+        .. testcleanup::
+
+            import os
+            os.unlink(path)
         """
         if tracks is not None and (data is not None or scan is not None):
             raise ValueError("Provide either 'tracks' or 'data'/'scan', not both.")
@@ -882,6 +898,8 @@ class File(h5py.File):
             kwargs["us_machine"] = us_machine
         if description is not None:
             kwargs["description"] = description
+        if acquisition_time is not None:
+            kwargs["acquisition_time"] = acquisition_time
 
         _warn_custom_keys(kwargs.get("data", {}), kwargs.get("metadata", {}))
         spec = FileSpec(**kwargs)
@@ -1130,6 +1148,23 @@ class File(h5py.File):
         )
         description = self.attrs["description"]
         return description
+
+    @property
+    def acquisition_time(self) -> datetime | None:
+        """Return the acquisition timestamp as a timezone-aware UTC :class:`datetime`.
+
+        Returns *None* when no timestamp was stored (e.g. human-subject files
+        saved without an explicit ``acquisition_time``).
+        """
+        if "acquisition_time" not in self.attrs:
+            return None
+        raw = self.attrs["acquisition_time"]
+        if isinstance(raw, bytes):
+            raw = raw.decode()
+        dt = datetime.fromisoformat(raw)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
 
     def get_scan_parameters(self):
         """Returns a dictionary of parameters to initialize a scan
@@ -1425,6 +1460,8 @@ class File(h5py.File):
             kwargs["us_machine"] = self.attrs["us_machine"]
         if "description" in self.attrs:
             kwargs["description"] = self.attrs["description"]
+        if "acquisition_time" in self.attrs:
+            kwargs["acquisition_time"] = self.attrs["acquisition_time"]
 
         return FileSpec(**kwargs)
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -823,7 +823,6 @@ class File(h5py.File):
 
         .. doctest::
 
-            >>> import os, tempfile
             >>> from datetime import datetime, timezone
             >>> import numpy as np
             >>> from zea import File
@@ -844,9 +843,8 @@ class File(h5py.File):
             ...     "time_to_next_transmit": np.ones((n_frames, n_tx), dtype=np.float32) * 1e-4,
             ... }
 
-            >>> _, path = tempfile.mkstemp(suffix=".hdf5")
             >>> File.create(
-            ...     path,
+            ...     "example.hdf5",
             ...     data={"raw_data": raw},
             ...     scan=scan,
             ...     probe={"name": "verasonics_l11_4v", "probe_geometry": probe_geometry},
@@ -857,7 +855,7 @@ class File(h5py.File):
         .. testcleanup::
 
             import os
-            os.unlink(path)
+            os.unlink("example.hdf5")
         """
         if tracks is not None and (data is not None or scan is not None):
             raise ValueError("Provide either 'tracks' or 'data'/'scan', not both.")

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -2105,21 +2105,28 @@ class FileSpec(Spec):
         if isinstance(self.metadata, MetadataSpec):
             subject = self.metadata.subject
             if isinstance(subject, Subject) and subject.type is not None:
-                subject_type = str(subject.type).lower()
+                subject_type = str(subject.type).strip().casefold()
 
         is_human = subject_type == "human"
 
-        if self.acquisition_time is None:
-            if not is_human:
-                self.acquisition_time = datetime.now(timezone.utc).isoformat()
-        elif is_human:
-            log.warning(
-                "PHI WARNING: 'acquisition_time' is set for a human subject. "
-                "Recording acquisition timestamps for human data constitutes "
-                "Protected Health Information (PHI) under HIPAA and similar "
-                "regulations. Ensure you have appropriate authorization and "
-                "de-identification measures in place before sharing this file."
-            )
+        if self.acquisition_time is not None:
+            try:
+                dt = datetime.fromisoformat(self.acquisition_time)
+            except ValueError as e:
+                raise ValueError(f"Invalid acquisition_time: {e}") from e
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            self.acquisition_time = dt.astimezone(timezone.utc).isoformat()
+            if is_human:
+                log.warning(
+                    "PHI WARNING: 'acquisition_time' is set for a human subject. "
+                    "Recording acquisition timestamps for human data constitutes "
+                    "Protected Health Information (PHI) under HIPAA and similar "
+                    "regulations. Ensure you have appropriate authorization and "
+                    "de-identification measures in place before sharing this file."
+                )
+        elif not is_human:
+            self.acquisition_time = datetime.now(timezone.utc).isoformat()
 
         with File(str(path), "w") as f:
             f.attrs["zea_version"] = _zea_version

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from dataclasses import MISSING, dataclass, field, fields
+from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _get_pkg_version
 from pathlib import Path
@@ -1839,6 +1840,7 @@ class FileSpec(Spec):
     Example:
         .. doctest::
 
+            >>> from datetime import datetime, timezone
             >>> from zea.data.spec import FileSpec
             >>> import numpy as np
 
@@ -1858,9 +1860,12 @@ class FileSpec(Spec):
             ...         "polar_angles": np.zeros(4, dtype=np.float32),
             ...     },
             ...     probe={"name": "test_probe", "probe_geometry": np.zeros((8, 3))},
+            ...     acquisition_time=datetime.now(timezone.utc).isoformat(),
             ... )
             >>> dataset.data.raw_data.shape
             (2, 4, 64, 8, 1)
+            >>> dataset.acquisition_time is not None
+            True
     """
 
     # NOTE: data and scan are intentionally NOT dataclass fields — they are
@@ -1873,6 +1878,7 @@ class FileSpec(Spec):
     probe: ProbeSpec | dict | None = None
     us_machine: str | None = None
     description: str | None = None
+    acquisition_time: str | None = None
 
     # tells the SCHEMA ↔ fields consistency test that 'tracks' is intentionally
     # absent from SCHEMA (list[TrackSpec] doesn't fit the standard SCHEMA patterns)
@@ -1885,6 +1891,17 @@ class FileSpec(Spec):
         "probe": {"spec": ProbeSpec},
         "us_machine": {"dtype": str, "shape": ()},
         "description": {"dtype": str, "shape": ()},
+        "acquisition_time": {"dtype": str, "shape": ()},
+    }
+
+    FIELD_METADATA = {
+        "acquisition_time": {
+            "description": (
+                "UTC acquisition timestamp in ISO 8601 format "
+                "(e.g. '2026-06-12T14:30:00+00:00'). "
+                "Auto-set to the moment of saving for non-human subjects."
+            ),
+        },
     }
 
     def __init__(
@@ -1899,6 +1916,7 @@ class FileSpec(Spec):
         probe: "ProbeSpec | dict | None" = None,
         us_machine: "str | None" = None,
         description: "str | None" = None,
+        acquisition_time: "str | None" = None,
     ):
         if data is not None or scan is not None:
             if tracks:
@@ -1923,6 +1941,7 @@ class FileSpec(Spec):
         self.probe = probe
         self.us_machine = us_machine
         self.description = description
+        self.acquisition_time = acquisition_time
 
         self.__post_init__(_implicit_track)
 
@@ -2081,6 +2100,26 @@ class FileSpec(Spec):
 
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
+
+        subject_type = None
+        if isinstance(self.metadata, MetadataSpec):
+            subject = self.metadata.subject
+            if isinstance(subject, Subject) and subject.type is not None:
+                subject_type = str(subject.type).lower()
+
+        is_human = subject_type == "human"
+
+        if self.acquisition_time is None:
+            if not is_human:
+                self.acquisition_time = datetime.now(timezone.utc).isoformat()
+        elif is_human:
+            log.warning(
+                "PHI WARNING: 'acquisition_time' is set for a human subject. "
+                "Recording acquisition timestamps for human data constitutes "
+                "Protected Health Information (PHI) under HIPAA and similar "
+                "regulations. Ensure you have appropriate authorization and "
+                "de-identification measures in place before sharing this file."
+            )
 
         with File(str(path), "w") as f:
             f.attrs["zea_version"] = _zea_version


### PR DESCRIPTION
### What

Adds an optional `acquisition_time` field (ISO 8601 UTC string) to `FileSpec` and surfaces it as a `datetime` property on `zea.File`.

### Behaviour

- **Non-human subjects** — `File.create` auto-records `datetime.now(timezone.utc)` at save time when no value is supplied.
- **Human subjects** — no timestamp is written by default, since acquisition times for human data constitute **Protected Health Information (PHI)**. If a caller explicitly passes `acquisition_time` for a human subject, a warning is emitted citing PHI / HIPAA.
- **Reading back** — `file.acquisition_time` returns a timezone-aware `datetime` (UTC), or `None` if no timestamp was stored.

```python
from datetime import datetime, timezone
from zea import File

# auto-stamped at save time for non-human subjects
File.create(path, data=..., metadata={"subject": {"type": "phantom"}})

# PHI WARNING emitted: explicit timestamp on a human subject
File.create(path, data=..., metadata={"subject": {"type": "human"}}, acquisition_time=datetime.now(timezone.utc).isoformat())
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for storing `acquisition_time` on HDF5 files. For non-human subjects, it auto-populates with the current UTC timestamp when not explicitly provided.
  * PHI warnings are emitted when human subjects provide explicit acquisition time values.

* **Tests**
  * Added validation tests for acquisition_time auto-population and PHI warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->