### PR TITLE
Lazy import `Tk` for viewer

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -2,14 +2,24 @@
 
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
+import pytest
 
 from zea.interface import Interface
 from zea.internal.setup_zea import setup_config
+from zea.internal.viewer import filename_from_window_dialog
 
 wd = Path(__file__).parent.parent
 sys.path.append(str(wd))
+
+
+def test_filename_from_window_dialog_no_tkinter():
+    """Test that ImportError is raised when tkinter is not available."""
+    with patch.dict(sys.modules, {"tkinter": None, "tkinter.filedialog": None}):
+        with pytest.raises(ImportError, match="Tkinter"):
+            filename_from_window_dialog()
 
 
 def test_interface_initialization():

--- a/zea/internal/viewer.py
+++ b/zea/internal/viewer.py
@@ -6,8 +6,6 @@ import sys
 from collections import deque
 from multiprocessing.pool import ThreadPool
 from pathlib import Path
-from tkinter import Tk
-from tkinter.filedialog import askopenfilename
 from typing import Callable, Optional
 
 import matplotlib
@@ -41,6 +39,17 @@ def filename_from_window_dialog(window_name=None, filetypes=None, initialdir=Non
     """
     if filetypes is None:
         filetypes = (("all files", "*.*"),)
+
+    try:
+        from tkinter import Tk
+        from tkinter.filedialog import askopenfilename
+    except ImportError as error:
+        raise ImportError(
+            "The file dialog window features in zea require Python's native Tkinter GUI toolkit. "
+            "Tkinter was not found in your current Python environment. Please ensure that "
+            "your Python distribution includes Tkinter or install your system's corresponding "
+            "python-tk package."
+        ) from error
 
     try:
         root = Tk()


### PR DESCRIPTION
**Problem**
At the moment, in `zea/internal/viewer.py`, `Tk` is imported at the top of the file. In other files, e.g. `zea/data/convert/verasonics.py` there's a lazy import. Because if the top-level import in `viewer.py`, if you install zea and run `import zea` you get this error:
```python
>>> import zea
zea: Using backend 'jax'
Traceback (most recent call last):
  File "<python-input-6>", line 1, in <module>
    import zea
  File "/Users/noisin/Documents/zea/test_uv/.venv/lib/python3.13/site-packages/zea/__init__.py", line 112, in <module>
    from .interface import Interface
  File "/Users/noisin/Documents/zea/test_uv/.venv/lib/python3.13/site-packages/zea/interface.py", line 35, in <module>
    from zea.internal.viewer import (
    ...<4 lines>...
    )
  File "/Users/noisin/Documents/zea/test_uv/.venv/lib/python3.13/site-packages/zea/internal/viewer.py", line 9, in <module>
    from tkinter import Tk
  File "/opt/homebrew/Cellar/python@3.13/3.13.6/Frameworks/Python.framework/Versions/3.13/lib/python3.13/tkinter/__init__.py", line 38, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
    ^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named '_tkinter'
```

**Solution**
Simply lazy import zea in viewer.py, matching how it's done in the rest of the codebase


**Testing**
I ran `uv add` on this branch and it allowed me to import zea without error:
```
>>> import zea
zea: Using backend 'jax'
>>> zea
<module 'zea' from '/Users/noisin/Documents/zea/test_uv/.venv/lib/python3.13/site-packages/zea/__init__.py'>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling when a GUI dependency is missing so the application initializes more robustly and raises a clearer error message if the GUI library isn't available.
* **Tests**
  * Added test coverage to ensure behavior and error messaging are correct when the GUI dependency is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->