### PR TITLE
Cleanups OpenH-RF branch

### DIFF
--- a/.github/actions/load-image/action.yml
+++ b/.github/actions/load-image/action.yml
@@ -1,11 +1,20 @@
 name: Load CI image
 description: >
-  Downloads and loads the Docker image from artifact when a fork PR has
-  changed image dependencies. No-op when the base-branch image is reused.
+  Makes the CI Docker image available locally. When a fork PR changed image
+  dependencies, the locally-built image is loaded from the uploaded artifact.
+  Otherwise the image is pulled from the registry so that self-hosted runners
+  refresh mutable tags (e.g. the base-branch tag) instead of reusing a stale
+  cached image.
 inputs:
   needs_artifact:
     description: Whether to load from artifact ('true'/'false')
     required: true
+  docker_image:
+    description: >
+      Registry reference to pull when needs_artifact is 'false'. Required in
+      that case; ignored when loading from an artifact.
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -16,3 +25,12 @@ runs:
     - if: inputs.needs_artifact == 'true'
       shell: bash
       run: docker load < fork-image.tar
+    # Reused registry image: pull so self-hosted runners don't run a stale tag.
+    - if: inputs.needs_artifact != 'true'
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.docker_image }}" ]; then
+          echo "load-image: 'docker_image' input is required when needs_artifact='false'" >&2
+          exit 1
+        fi
+        docker pull "${{ inputs.docker_image }}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -62,7 +62,10 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           git fetch origin "$BASE_REF"
-          if git diff --quiet "origin/$BASE_REF" -- Dockerfile pyproject.toml uv.lock; then
+          # Compare against the just-fetched tip (FETCH_HEAD). On the shallow
+          # checkout used here the remote-tracking ref origin/$BASE_REF is not
+          # updated by `git fetch origin "$BASE_REF"` and may be stale or absent.
+          if git diff --quiet FETCH_HEAD -- Dockerfile pyproject.toml uv.lock; then
             # Verify the branch-tagged image actually exists before deciding to reuse it.
             # It may be absent on first run after this workflow feature was introduced.
             BASE_TAG="${{ env.BASE_IMAGE }}:${{ github.event.pull_request.base.ref }}"
@@ -166,6 +169,7 @@ jobs:
       - uses: ./.github/actions/load-image
         with:
           needs_artifact: ${{ needs.image.outputs.needs_artifact }}
+          docker_image: ${{ needs.image.outputs.docker_image }}
 
       - name: Run Pytest in container
         run: |
@@ -196,6 +200,7 @@ jobs:
       - uses: ./.github/actions/load-image
         with:
           needs_artifact: ${{ needs.image.outputs.needs_artifact }}
+          docker_image: ${{ needs.image.outputs.docker_image }}
 
       - name: Run heavy tests
         run: |
@@ -248,6 +253,7 @@ jobs:
       - uses: ./.github/actions/load-image
         with:
           needs_artifact: ${{ needs.image.outputs.needs_artifact }}
+          docker_image: ${{ needs.image.outputs.docker_image }}
 
       - name: Run ${{ matrix.name }} notebook tests
         run: |
@@ -277,6 +283,7 @@ jobs:
       - uses: ./.github/actions/load-image
         with:
           needs_artifact: ${{ needs.image.outputs.needs_artifact }}
+          docker_image: ${{ needs.image.outputs.docker_image }}
 
       - name: Build documentation with Sphinx (fails on warnings)
         run: |

--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -82,6 +82,41 @@ Stored as HDF5 root-level attributes (not groups).
      - |badge-opt|
 
 
+.. _data-spec-units:
+
+Units
+~~~~~
+
+Unit symbols used in the ``Unit`` column of the field tables below.
+A unit of ``-`` denotes a unitless (dimensionless) quantity.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - Symbol
+     - Meaning
+   * - ``m/s``
+     - meters per second
+   * - ``m``
+     - meters
+   * - ``Hz``
+     - Hertz
+   * - ``s``
+     - seconds
+   * - ``V``
+     - volts
+   * - ``-``
+     - unitless
+   * - ``rad``
+     - radians
+   * - ``dB``
+     - decibels
+   * - ``#``
+     - count
+   * - ``%``
+     - percent
+
 .. _group-reference:
 
 Group reference
@@ -326,7 +361,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - 
             * - ``values``
               - ``float32`` | ``uint8``
-              - (n_frames, x, z, y) or (n_frames, x, z)
+              - (n_frames, z, x, y) or (n_frames, z, x)
               - –
               - |badge-req|
             * - ``coordinates``

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 import numpy as np
 
 from zea.data.spec import (
+    UNITS,
     AlignedData,
     Annotations,
     BeamformedData,
@@ -306,6 +307,28 @@ MAP_DESCRIPTIONS = {
 }
 
 
+def rst_units_table() -> str:
+    """Render the :data:`zea.data.spec.UNITS` mapping as a reference table.
+
+    Keeps the documented unit symbols in sync with the single source of truth
+    in ``spec.py`` — every ``unit`` shown in the field tables below is defined here.
+    """
+    lines = [
+        ".. list-table::",
+        "   :header-rows: 1",
+        "   :widths: 20 80",
+        "",
+        "   * - Symbol",
+        "     - Meaning",
+    ]
+    for symbol, meaning in UNITS.items():
+        lines += [
+            f"   * - ``{symbol}``",
+            f"     - {meaning}",
+        ]
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # generate
 # ---------------------------------------------------------------------------
@@ -333,6 +356,20 @@ def generate() -> str:
         "Stored as HDF5 root-level attributes (not groups).",
         "",
         ROOT_ATTRS_TABLE,
+        "",
+    ]
+
+    # --- Units legend ---------------------------------------------------------
+    lines += [
+        ".. _data-spec-units:",
+        "",
+        "Units",
+        "~~~~~",
+        "",
+        "Unit symbols used in the ``Unit`` column of the field tables below.",
+        "A unit of ``-`` denotes a unitless (dimensionless) quantity.",
+        "",
+        rst_units_table(),
         "",
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,6 +268,12 @@ filterwarnings = [
     "ignore:.*os\\.fork\\(\\) was called.*:RuntimeWarning",
 ]
 
+[tool.coverage.run]
+branch = true
+parallel = true
+concurrency = ["multiprocessing", "thread"]
+sigterm = true
+
 [tool.coverage.report]
 omit = [
     "zea/ops/keras_ops.py",

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1610,3 +1610,32 @@ class TestProbeSpec:
         with File(path) as f:
             assert f.probe.name == "my_probe"
             assert "probe" in f
+
+
+def _all_spec_subclasses(cls=Spec):
+    """Recursively collect every Spec subclass defined in the module."""
+    subclasses = set()
+    for sub in cls.__subclasses__():
+        subclasses.add(sub)
+        subclasses |= _all_spec_subclasses(sub)
+    return subclasses
+
+
+def test_field_metadata_units_are_defined():
+    """Every unit referenced in a spec's FIELD_METADATA must be defined in UNITS.
+
+    Guards against typos and undocumented unit symbols (the doc generator renders
+    UNITS as the units legend, so an undefined unit would appear without a meaning).
+    """
+    undefined = []
+    for cls in _all_spec_subclasses():
+        field_metadata = getattr(cls, "FIELD_METADATA", {})
+        for field_name, meta in field_metadata.items():
+            unit = meta.get("unit")
+            if unit is not None and unit not in spec_module.UNITS:
+                undefined.append(f"{cls.__name__}.{field_name}: {unit!r}")
+    assert not undefined, (
+        "Found units in FIELD_METADATA not defined in zea.data.spec.UNITS: "
+        + ", ".join(sorted(undefined))
+        + ". Add the symbol to UNITS (it is the source of truth rendered in the docs)."
+    )

--- a/tests/test_io_lib.py
+++ b/tests/test_io_lib.py
@@ -197,9 +197,9 @@ def test_color_palette(tmp_path):
     assert loaded_with_palette_gif.shape == (n_frames, height, width)
 
 
-def test_animate_images_scan_without_extent(tmp_path):
-    """animate_images must not raise AttributeError when the scan object has
-    no extent_imshow attribute (e.g. a minimal or mock Scan object)."""
+def test_animate_images_parameters_without_extent(tmp_path):
+    """animate_images must not raise AttributeError when the parameters object has
+    no extent_imshow attribute (e.g. a minimal or mock Parameters object)."""
     import matplotlib
 
     matplotlib.use("Agg")
@@ -208,10 +208,10 @@ def test_animate_images_scan_without_extent(tmp_path):
     images = [np.zeros((8, 8), dtype=np.uint8) for _ in range(3)]
     path = tmp_path / "anim.gif"
 
-    class MinimalScan:
+    class MinimalParameters:
         pass
 
     try:
-        animate_images(images, path=str(path), scan=MinimalScan(), interval=100)
+        animate_images(images, path=str(path), parameters=MinimalParameters(), interval=100)
     except AttributeError as e:
         pytest.fail(f"animate_images raised AttributeError: {e}")

--- a/tests/test_ops_infra.py
+++ b/tests/test_ops_infra.py
@@ -750,8 +750,8 @@ def ultrasound_probe():
     return get_probe()
 
 
-def get_scan(ultrasound_probe, grid_size_x=None, grid_size_z=None):
-    """Returns a scan for ultrasound simulation tests.
+def get_parameters(ultrasound_probe, grid_size_x=None, grid_size_z=None):
+    """Returns a Parameters object for ultrasound simulation tests.
 
     Note these parameters are not really realistic, but are used for testing purposes.
     """
@@ -798,8 +798,8 @@ def get_scan(ultrasound_probe, grid_size_x=None, grid_size_z=None):
 
 @pytest.fixture
 def ultrasound_parameters(ultrasound_probe):
-    """Returns a scan for ultrasound simulation tests."""
-    return get_scan(ultrasound_probe, grid_size_x=20, grid_size_z=20)
+    """Returns a Parameters object for ultrasound simulation tests."""
+    return get_parameters(ultrasound_probe, grid_size_x=20, grid_size_z=20)
 
 
 def get_scatterers():

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,6 +1,7 @@
 """Tests for the Parameters class."""
 
 import pickle
+from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -175,6 +176,50 @@ def test_scan_erroneous_set_transmits():
 
     with pytest.raises(ValueError):
         parameters.set_transmits("invalid_string")
+
+
+def test_grid_warns_on_aliasing():
+    """An under-sized cartesian grid (pixel pitch > wavelength/2) warns about aliasing."""
+    # scan_args sets grid_size_x=64, grid_size_z=128, which under-sample the imaging region.
+    parameters = Parameters(**scan_args)
+    with patch("zea.beamform.pixelgrid.log.warning") as mock_warn:
+        _ = parameters.grid
+    msgs = " ".join(str(c.args[0]) for c in mock_warn.call_args_list)
+    assert "wavelength/2" in msgs
+
+
+def test_grid_no_aliasing_warning_when_well_sampled():
+    """A sufficiently dense cartesian grid does not warn."""
+    args = scan_args.copy()
+    args["grid_size_x"] = 512
+    args["grid_size_z"] = 512
+    parameters = Parameters(**args)
+    with patch("zea.beamform.pixelgrid.log.warning") as mock_warn:
+        _ = parameters.grid
+    assert mock_warn.call_count == 0
+
+
+def test_polar_grid_no_aliasing_warning():
+    """The cartesian aliasing check is not applied to polar grids."""
+    parameters = Parameters(**scan_args, grid_type="polar")
+    with patch("zea.beamform.pixelgrid.log.warning") as mock_warn:
+        _ = parameters.grid
+    assert mock_warn.call_count == 0
+
+
+def test_set_transmits_focused_excludes_plane_waves():
+    """'focused' must select only finite-focus transmits, not plane waves (inf)."""
+    local_scan_args = scan_args.copy()
+    # Mix focused (finite > 0) and plane-wave (inf) transmits.
+    focus = np.full(scan_args["n_tx"], np.inf)
+    focus[: scan_args["n_tx"] // 2] = 0.04
+    local_scan_args["focus_distances"] = focus
+
+    parameters = Parameters(**local_scan_args)
+    parameters.set_transmits("focused")
+
+    assert list(parameters.selected_transmits) == list(range(scan_args["n_tx"] // 2))
+    assert np.all(np.isfinite(parameters.focus_distances))
 
 
 def test_initialization():

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -9,7 +9,7 @@ import pytest
 import zea
 from zea import Parameters
 from zea.data.spec import ProbeSpec, ScanSpec
-from zea.internal.dummy_scan import get_scan
+from zea.internal.dummy_scan import get_parameters
 
 scan_args = {
     "n_tx": 10,
@@ -417,14 +417,16 @@ def test_valid_params_default():
     was a mutable dictionary, leading to shared state across instances.
     """
 
-    scan1 = get_scan()
-    scan1.pfield_kwargs["norm"] = False
+    parameters1 = get_parameters()
+    parameters1.pfield_kwargs["norm"] = False
 
-    parameters2 = get_scan()
+    parameters2 = get_parameters()
     assert parameters2.pfield_kwargs == {}, (
-        "scan2.pfield_kwargs seems to be affected by scan1 modification"
+        "parameters2.pfield_kwargs seems to be affected by parameters1 modification"
     )
-    assert scan1 != parameters2, "scan1 and scan2 should be different after modification of scan1"
+    assert parameters1 != parameters2, (
+        "parameters1 and parameters2 should differ after modifying parameters1"
+    )  # noqa: E501
 
 
 def test_inplace_modification():
@@ -453,7 +455,7 @@ def test_inplace_modification():
         return parameters
 
     for edit_fn in (edit1, edit2, edit3):
-        parameters = get_scan(pfield_kwargs={"norm": True})
+        parameters = get_parameters(pfield_kwargs={"norm": True})
         original_pfield = parameters.pfield.copy()
         assert "pfield" in parameters._cache, "pfield should be cached after first access"
 
@@ -469,7 +471,7 @@ def test_inplace_modification():
 def test_inplace_modification_tensor_cache():
     """Test that modifying pfield_kwargs in-place, will update the pfield_tensor."""
 
-    parameters = get_scan(pfield_kwargs={"norm": True})
+    parameters = get_parameters(pfield_kwargs={"norm": True})
     tensor_dict = parameters.to_tensor(include=["pfield"])
     parameters.pfield_kwargs["norm"] = False  # in-place modification
     tensor_dict2 = parameters.to_tensor(include=["pfield"])

--- a/tests/test_transmit_schemes.py
+++ b/tests/test_transmit_schemes.py
@@ -7,7 +7,7 @@ import pytest
 from zea import ops
 from zea.beamform.phantoms import fibonacci, fish, golden_ratio, lissajous, rose
 from zea.internal.core import DEFAULT_DYNAMIC_RANGE
-from zea.internal.dummy_scan import _get_probe, _get_scan
+from zea.internal.dummy_scan import _get_parameters, _get_probe
 
 
 def _get_flatgrid(extent, shape):
@@ -140,7 +140,7 @@ def test_transmit_schemes(
     """Tests the default ultrasound pipeline."""
 
     probe = _get_probe(probe_kind)
-    parameters = _get_scan(probe, scan_kind)
+    parameters = _get_parameters(probe, scan_kind)
 
     inputs = default_pipeline.prepare_parameters(parameters)
 
@@ -174,7 +174,7 @@ def test_transmit_schemes(
 
     # Additional test for planewave: verify focus_distance=0 gives same result
     if scan_kind == "planewave":
-        parameters_zero_focus = _get_scan(
+        parameters_zero_focus = _get_parameters(
             probe, scan_kind, focus_distances=np.zeros(parameters.n_tx)
         )
         inputs_zero = default_pipeline.prepare_parameters(parameters_zero_focus)
@@ -202,7 +202,7 @@ def test_transmit_schemes(
 def test_polar_grid(default_pipeline: ops.Pipeline, ultrasound_scatterers):
     """Tests the polar grid generation."""
     probe = _get_probe("linear")
-    parameters = _get_scan(probe, "focused", grid_type="polar")
+    parameters = _get_parameters(probe, "focused", grid_type="polar")
 
     # Check if the grid type is set correctly
     assert parameters.grid_type == "polar"

--- a/zea/beamform/pixelgrid.py
+++ b/zea/beamform/pixelgrid.py
@@ -7,26 +7,28 @@ from zea import log
 eps = 1e-10
 
 
-def check_for_aliasing(scan):
-    """Checks if the scan class parameters will cause spatial aliasing due to a too low pixel
+def check_for_aliasing(parameters):
+    """Checks if the :class:`~zea.Parameters` will cause spatial aliasing due to a too low pixel
     density. If so, a warning is printed with a suggestion to increase the pixel density by either
     increasing the number of pixels, or decreasing the pixel spacing, depending on which parameter
     was set by the user."""
-    width = scan.xlims[1] - scan.xlims[0]
-    depth = scan.zlims[1] - scan.zlims[0]
-    wvln = scan.wavelength
+    width = parameters.xlims[1] - parameters.xlims[0]
+    depth = parameters.zlims[1] - parameters.zlims[0]
+    wvln = parameters.wavelength
 
-    if width / scan.grid_size_x > wvln / 2:
+    if width / parameters.grid_size_x > wvln / 2:
         log.warning(
-            f"width/grid_size_x = {width / scan.grid_size_x:.7f} < wavelength/2 = {wvln / 2}. "
-            f"Consider either increasing scan.grid_size_x to {int(np.ceil(width / (wvln / 2)))} "
-            "or more, or increasing scan.pixels_per_wavelength to 2 or more."
+            f"width/grid_size_x = {width / parameters.grid_size_x:.7f} > "
+            f"wavelength/2 = {wvln / 2:.7f}. "
+            f"Consider increasing grid_size_x to {int(np.ceil(width / (wvln / 2)))} "
+            "or more, or unsetting it to size the grid automatically."
         )
-    if depth / scan.grid_size_z > wvln / 2:
+    if depth / parameters.grid_size_z > wvln / 2:
         log.warning(
-            f"depth/grid_size_z = {depth / scan.grid_size_z:.7f} < wavelength/2 = {wvln / 2:.7f}. "
-            f"Consider either increasing scan.grid_size_z to {int(np.ceil(depth / (wvln / 2)))} "
-            "or more, or increasing scan.pixels_per_wavelength to 2 or more."
+            f"depth/grid_size_z = {depth / parameters.grid_size_z:.7f} > "
+            f"wavelength/2 = {wvln / 2:.7f}. "
+            f"Consider increasing grid_size_z to {int(np.ceil(depth / (wvln / 2)))} "
+            "or more, or unsetting it to size the grid automatically."
         )
 
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -817,7 +817,8 @@ class File(h5py.File):
             overwrite: If *False* (default), raise if the file exists.
 
         Returns:
-            File: An open read-only :class:`File` handle.
+            None. The validated file is written to ``path``; open it with
+            ``File(path)`` to read it back.
 
         Single-track example:
 

--- a/zea/data/process.py
+++ b/zea/data/process.py
@@ -425,9 +425,9 @@ def run_processing(
             data_output.append(processed_frame)
             pbar.add(1)
 
-            for key in keep_keys:
-                if key in output:
-                    params[key] = output[key]
+            for keep_key in keep_keys:
+                if keep_key in output:
+                    params[keep_key] = output[keep_key]
 
             if timings:
                 for tname in timer.timings.keys():

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -18,6 +18,7 @@ UNITS = {
     "m": "meters",
     "Hz": "Hertz",
     "s": "seconds",
+    "V": "volts",
     "-": "unitless",
     "rad": "radians",
     "dB": "decibels",
@@ -753,8 +754,8 @@ class Image(Map):
         "values": {
             "dtype": (np.float32, np.uint8),
             "shape": (
-                ("n_frames", "x", "z", "y"),
-                ("n_frames", "x", "z"),
+                ("n_frames", "z", "x", "y"),
+                ("n_frames", "z", "x"),
             ),
         },
     }
@@ -857,7 +858,7 @@ class EnvelopeData(FloatMap):
     """Envelope-detected data with per-pixel Cartesian coordinates.
 
     Args:
-        values: The envelope data of shape ``(n_frames, x, z)`` or
+        values: The envelope data of shape ``(n_frames, z, x)`` or
             ``(n_frames, z, x, y)`` and type float32.
         coordinates: Per-pixel Cartesian positions in metres, shape ``(*values.shape, 3)``.
             The leading frame axis may be omitted to broadcast one coordinate grid
@@ -950,7 +951,7 @@ class TissueDopplerMap(FloatMap):
         super().__post_init__()
 
         if self.unit is not None and self.unit != "m/s":
-            raise ValueError(f"SWE map unit should be 'm/s', got '{self.unit}'")
+            raise ValueError(f"Tissue Doppler map unit should be 'm/s', got '{self.unit}'")
 
 
 @dataclass
@@ -969,7 +970,7 @@ class ColorDopplerMap(FloatMap):
         super().__post_init__()
 
         if self.unit is not None and self.unit != "m/s":
-            raise ValueError(f"SWE map unit should be 'm/s', got '{self.unit}'")
+            raise ValueError(f"Color Doppler map unit should be 'm/s', got '{self.unit}'")
 
 
 @dataclass(init=False)
@@ -1424,7 +1425,7 @@ class Subject(Spec):
         type: Subject type, e.g. human, phantom, animal.
         age: Subject age in years.
         sex: Subject sex.
-        fat: Subject fat percentage.
+        fat_percentage: Subject fat percentage.
     """
 
     id: str | None = None

--- a/zea/internal/dummy_scan.py
+++ b/zea/internal/dummy_scan.py
@@ -1,4 +1,4 @@
-"""Module to create dummy Parameters objects for testing and simulation purposes."""
+"""Module to create dummy :class:`~zea.Parameters` objects for testing and simulation."""
 
 import numpy as np
 
@@ -67,7 +67,7 @@ def _get_probe(kind) -> Probe:
         raise ValueError(f"Unknown probe kind: {kind}")
 
 
-def _get_constant_scan_kwargs():
+def _get_constant_parameters_kwargs():
     return {
         "lens_sound_speed": 1000,
         "lens_thickness": 1e-3,
@@ -91,9 +91,9 @@ def _get_lims_and_gridsize(center_frequency, sound_speed):
     return {"xlims": xlims, "zlims": zlims, "grid_size_x": gridsize[0], "grid_size_z": gridsize[1]}
 
 
-def _get_planewave_scan(ultrasound_probe, grid_type, **kwargs):
-    """Returns a scan for ultrasound simulation tests."""
-    constant_scan_kwargs = _get_constant_scan_kwargs()
+def _get_planewave_parameters(ultrasound_probe, grid_type, **kwargs):
+    """Returns plane-wave Parameters for simulation tests."""
+    constant_scan_kwargs = _get_constant_parameters_kwargs()
     n_el = ultrasound_probe.n_el
     n_tx = 8
 
@@ -130,7 +130,7 @@ def _get_planewave_scan(ultrasound_probe, grid_type, **kwargs):
     )
 
 
-def _get_multistatic_scan(ultrasound_probe, grid_type, **kwargs):
+def _get_multistatic_parameters(ultrasound_probe, grid_type, **kwargs):
     n_el = ultrasound_probe.n_el
     n_tx = 8
 
@@ -142,7 +142,7 @@ def _get_multistatic_scan(ultrasound_probe, grid_type, **kwargs):
     focus_distances = np.zeros(n_tx)
     t0_delays = np.zeros((n_tx, n_el))
 
-    constant_scan_kwargs = _get_constant_scan_kwargs()
+    constant_scan_kwargs = _get_constant_parameters_kwargs()
 
     return Parameters(
         n_tx=n_tx,
@@ -166,9 +166,9 @@ def _get_multistatic_scan(ultrasound_probe, grid_type, **kwargs):
     )
 
 
-def _get_diverging_scan(ultrasound_probe, grid_type, **kwargs):
-    """Returns a scan for ultrasound simulation tests."""
-    constant_scan_kwargs = _get_constant_scan_kwargs()
+def _get_diverging_parameters(ultrasound_probe, grid_type, **kwargs):
+    """Returns diverging-wave Parameters for simulation tests."""
+    constant_scan_kwargs = _get_constant_parameters_kwargs()
     n_el = ultrasound_probe.n_el
     n_tx = 8
 
@@ -211,9 +211,9 @@ def _get_diverging_scan(ultrasound_probe, grid_type, **kwargs):
     )
 
 
-def _get_focused_scan(ultrasound_probe, grid_type, **kwargs):
-    """Returns a scan for ultrasound simulation tests."""
-    constant_scan_kwargs = _get_constant_scan_kwargs()
+def _get_focused_parameters(ultrasound_probe, grid_type, **kwargs):
+    """Returns focused-transmit Parameters for simulation tests."""
+    constant_scan_kwargs = _get_constant_parameters_kwargs()
     n_el = ultrasound_probe.n_el
     n_tx = 8
 
@@ -256,9 +256,9 @@ def _get_focused_scan(ultrasound_probe, grid_type, **kwargs):
     )
 
 
-def _get_linescan_scan(ultrasound_probe, grid_type, **kwargs):
-    """Returns a scan for ultrasound simulation tests."""
-    constant_scan_kwargs = _get_constant_scan_kwargs()
+def _get_linescan_parameters(ultrasound_probe, grid_type, **kwargs):
+    """Returns line-scan Parameters for simulation tests."""
+    constant_scan_kwargs = _get_constant_parameters_kwargs()
     n_el = ultrasound_probe.n_el
     n_tx = 8
 
@@ -314,22 +314,27 @@ def _get_linescan_scan(ultrasound_probe, grid_type, **kwargs):
     )
 
 
-def _get_scan(ultrasound_probe, kind, grid_type="cartesian", **kwargs) -> Parameters:
+def _get_parameters(ultrasound_probe, kind, grid_type="cartesian", **kwargs) -> Parameters:
     if kind == "planewave":
-        return _get_planewave_scan(ultrasound_probe, grid_type, **kwargs)
+        return _get_planewave_parameters(ultrasound_probe, grid_type, **kwargs)
     elif kind == "multistatic":
-        return _get_multistatic_scan(ultrasound_probe, grid_type, **kwargs)
+        return _get_multistatic_parameters(ultrasound_probe, grid_type, **kwargs)
     elif kind == "diverging":
-        return _get_diverging_scan(ultrasound_probe, grid_type, **kwargs)
+        return _get_diverging_parameters(ultrasound_probe, grid_type, **kwargs)
     elif kind == "focused":
-        return _get_focused_scan(ultrasound_probe, grid_type, **kwargs)
+        return _get_focused_parameters(ultrasound_probe, grid_type, **kwargs)
     elif kind == "linescan":
-        return _get_linescan_scan(ultrasound_probe, grid_type, **kwargs)
+        return _get_linescan_parameters(ultrasound_probe, grid_type, **kwargs)
     else:
         raise ValueError(f"Unknown scan kind: {kind}")
 
 
-def get_scan(kind="planewave", probe_kind="linear", grid_type="cartesian", **kwargs) -> Parameters:
-    """Returns a scan for ultrasound simulation tests."""
+def get_parameters(
+    kind="planewave",
+    probe_kind="linear",
+    grid_type="cartesian",
+    **kwargs,
+) -> Parameters:
+    """Returns a dummy :class:`~zea.Parameters` object for testing and simulation."""
     ultrasound_probe = _get_probe(probe_kind)
-    return _get_scan(ultrasound_probe, kind, grid_type, **kwargs)
+    return _get_parameters(ultrasound_probe, kind, grid_type, **kwargs)

--- a/zea/internal/notebooks.py
+++ b/zea/internal/notebooks.py
@@ -7,7 +7,7 @@ from zea.scan import Parameters
 
 
 def animate_images(
-    images, path, scan: Parameters = None, interval=100, cmap="gray", figsize=(5, 4.6), dpi=80
+    images, path, parameters: Parameters = None, interval=100, cmap="gray", figsize=(5, 4.6), dpi=80
 ):
     """Helper function to animate a list of images."""
     if interval <= 0:
@@ -15,9 +15,11 @@ def animate_images(
     if len(images) == 0:
         raise ValueError("images must be a non-empty sequence.")
     fig, ax = plt.subplots(figsize=figsize, dpi=dpi)
-    if scan is not None:
+    if parameters is not None:
         extent = (
-            scan.extent_imshow * 1e3 if getattr(scan, "extent_imshow", None) is not None else None
+            parameters.extent_imshow * 1e3
+            if getattr(parameters, "extent_imshow", None) is not None
+            else None
         )
     else:
         extent = None

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -546,7 +546,8 @@ class Parameters(BaseParameters):
             value = self._params.get("focus_distances")
             if value is None:
                 raise ValueError("No focus distances provided, cannot select focused transmits")
-            idx = np.where(value > 0)[0].tolist()
+            # Plane waves use inf (or 0); a finite positive focus marks a focused transmit.
+            idx = np.where((value > 0) & np.isfinite(value))[0].tolist()
             if len(idx) == 0:
                 raise ValueError("No focused transmits found.")
             self._params["selected_transmits"] = idx

--- a/zea/scan.py
+++ b/zea/scan.py
@@ -308,7 +308,7 @@ class Parameters(BaseParameters):
                 self.distance_to_apex,
             )
         elif self.grid_type == "cartesian":
-            return cartesian_pixel_grid(
+            grid = cartesian_pixel_grid(
                 self.xlims,
                 self.zlims,
                 self.ylims,
@@ -316,6 +316,12 @@ class Parameters(BaseParameters):
                 grid_size_x=self.grid_size_x,
                 grid_size_y=self.grid_size_y,
             )
+            try:
+                check_for_aliasing(self)
+            except MissingDependencyError:
+                # No wavelength (e.g. missing center frequency); cannot assess aliasing.
+                pass
+            return grid
         else:
             raise ValueError(
                 f"Unsupported grid type: {self.grid_type}. Supported types are "
@@ -615,9 +621,6 @@ class Parameters(BaseParameters):
             ]  # Convert numpy integers to Python ints
             self._invalidate("selected_transmits")
             return self
-
-        # Aliasing check
-        check_for_aliasing(self)
 
         raise ValueError(f"Unsupported selection type: {type(selection)}")
 


### PR DESCRIPTION
A set of small cleanups and bug fixes that came up while working on the OpenH-RF branch:

- Renamed `scan` to `parameters` across function names and variables to match current naming conventions
- Fixed a bug in `Parameters.set_transmits` that would incorrectly grab plane wave transmits when the selection was focused (was mainly unnoticed since both 0 and inf are valid for plane waves)
- Fixed `check_aliasing` which had become dead code
- Fixed the JAX CUDA extra name
- Two small Rabbit workflow fixes
- Improved codecov coverage by capturing multiprocessing calls used in conversion script tests
- Documented units in specs and cleaned up outdated docstrings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Units reference section to specification documentation.

* **Bug Fixes**
  * Corrected spatial axis ordering in Image data format specifications.
  * Fixed error messages for certain map type validations.
  * Corrected return value documentation for file creation.

* **Tests**
  * Added unit symbol validation tests for field metadata.
  * Expanded transmit selection test coverage.
  * Added cartesian grid aliasing detection tests.

* **Chores**
  * Updated GitHub Actions workflow for Docker image handling.
  * Added code coverage configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->