### PR TITLE
Add `File.timestamps` and default track timestamps

### DIFF
--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -308,11 +308,15 @@ the full timing of the acquisition.
     ...     # access the global timing information for the planewave track:
     ...     planewave_track.timestamps
     ...     # ... process with e.g. a plane-wave Doppler pipeline
+    ...     # access global timestamps for all transmit events in the file:
+    ...     f.timestamps
     ['focused_bmode', 'planewave_doppler']
     array([[0.    , 0.0001, 0.0002],
            [0.0007, 0.0008, 0.0009]], dtype=float32)
     array([[0.0003, 0.0005],
            [0.001 , 0.0012]], dtype=float32)
+    array([0.    , 0.0001, 0.0002, 0.0003, 0.0005, 0.0007, 0.0008, 0.0009,
+           0.001 , 0.0012], dtype=float32)
 
 .. testcleanup::
 

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -1656,6 +1656,186 @@ class TestMultiTrackFile:
         np.testing.assert_allclose(ts_b, expected_b, atol=1e-6)
 
 
+class TestSingleTrackImplicitSchedule:
+    """Single-track files without an explicit track_schedule still get timestamps."""
+
+    def test_timestamps_available_without_explicit_schedule(self, tmp_path):
+        """File.create(data=…, scan=…) with t2nt set → timestamps available on track."""
+        n_frames, n_tx, n_el, n_ax = 2, 3, 4, 8
+        raw = np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+        scan = _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el)
+        scan["time_to_next_transmit"] = np.full((n_frames, n_tx), 0.1, dtype=np.float32)
+
+        path = tmp_path / "implicit.hdf5"
+        File.create(path, data={"raw_data": raw}, scan=scan, probe=_probe_minimal(n_el=n_el))
+
+        with File(path) as f:
+            assert f.track_schedule is None, "no schedule should be stored on disk"
+            ts = f.tracks[0].timestamps
+            assert ts is not None
+            assert ts.shape == (n_frames, n_tx)
+
+    def test_timestamps_values_implicit_schedule(self, tmp_path):
+        """Implicit all-zeros schedule produces the same timestamps as an explicit one."""
+        n_frames, n_tx, n_el, n_ax = 1, 3, 4, 8
+        raw = np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+        dt = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+        scan = _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el)
+        scan["time_to_next_transmit"] = dt
+
+        path = tmp_path / "implicit_vals.hdf5"
+        File.create(path, data={"raw_data": raw}, scan=scan, probe=_probe_minimal(n_el=n_el))
+
+        with File(path) as f:
+            ts = f.tracks[0].timestamps  # shape (1, 3)
+
+        # cumulative sum starting at 0: [0, 0.1, 0.3]
+        expected = np.array([[0.0, 0.1, 0.3]], dtype=np.float32)
+        np.testing.assert_allclose(ts, expected, atol=1e-6)
+
+    def test_timestamps_none_without_t2nt_no_schedule(self, tmp_path):
+        """Single-track file with no t2nt and no schedule → timestamps is None (no crash)."""
+        n_frames, n_tx, n_el, n_ax = 2, 3, 4, 8
+        raw = np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+        scan = _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el)
+        del scan["time_to_next_transmit"]
+
+        path = tmp_path / "no_t2nt.hdf5"
+        File.create(path, data={"raw_data": raw}, scan=scan, probe=_probe_minimal(n_el=n_el))
+
+        with File(path) as f:
+            assert f.tracks[0].timestamps is None
+
+    def test_explicit_schedule_still_works_single_track(self, tmp_path):
+        """Explicitly stored all-zeros schedule still produces the same timestamps."""
+        n_frames, n_tx, n_el, n_ax = 2, 3, 4, 8
+        raw = np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+        scan = _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el)
+        scan["time_to_next_transmit"] = np.full((n_frames, n_tx), 0.1, dtype=np.float32)
+        schedule = np.zeros(n_frames * n_tx, dtype=np.int32)
+
+        path_implicit = tmp_path / "implicit.hdf5"
+        path_explicit = tmp_path / "explicit.hdf5"
+        File.create(
+            path_implicit, data={"raw_data": raw}, scan=scan, probe=_probe_minimal(n_el=n_el)
+        )
+        File.create(
+            path_explicit,
+            tracks=[{"data": {"raw_data": raw}, "scan": scan}],
+            track_schedule=schedule,
+            probe=_probe_minimal(n_el=n_el),
+        )
+
+        with File(path_implicit) as f:
+            ts_implicit = f.tracks[0].timestamps
+        with File(path_explicit) as f:
+            ts_explicit = f.tracks[0].timestamps
+
+        np.testing.assert_array_equal(ts_implicit, ts_explicit)
+
+
+class TestFileTimestamps:
+    """Tests for File.timestamps — the global flat timestamp array."""
+
+    def test_single_track_timestamps_shape_and_values(self, tmp_path):
+        """File.timestamps returns shape (n_frames*n_tx,) with correct cumulative values."""
+        n_frames, n_tx, n_el, n_ax = 1, 3, 4, 8
+        raw = np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+        scan = _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el)
+        scan["time_to_next_transmit"] = np.array([[0.1, 0.2, 0.3]], dtype=np.float32)
+
+        path = tmp_path / "single.hdf5"
+        File.create(path, data={"raw_data": raw}, scan=scan, probe=_probe_minimal(n_el=n_el))
+
+        with File(path) as f:
+            ts = f.timestamps
+
+        assert ts is not None
+        assert ts.shape == (n_frames * n_tx,)
+        np.testing.assert_allclose(ts, [0.0, 0.1, 0.3], atol=1e-6)
+
+    def test_single_track_file_timestamps_none_without_t2nt(self, tmp_path):
+        """File.timestamps is None when time_to_next_transmit is absent."""
+        n_frames, n_tx, n_el, n_ax = 2, 3, 4, 8
+        raw = np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+        scan = _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el)
+        del scan["time_to_next_transmit"]
+
+        path = tmp_path / "no_t2nt.hdf5"
+        File.create(path, data={"raw_data": raw}, scan=scan, probe=_probe_minimal(n_el=n_el))
+
+        with File(path) as f:
+            assert f.timestamps is None
+
+    def test_multi_track_timestamps_interleaved(self, tmp_path):
+        """File.timestamps follows the schedule order across tracks.
+
+        Schedule [0, 1, 0, 1, 0] with dt_a=0.1, dt_b=0.05:
+          global events:  0     1      2      3      4
+          cumtime:        0  +0.1  +0.05  +0.1  +0.05
+          → [0, 0.1, 0.15, 0.25, 0.30]
+        """
+        n_frames, n_tx_a, n_tx_b, n_el, n_ax = 1, 3, 2, 4, 8
+        raw_a = np.zeros((n_frames, n_tx_a, n_ax, n_el, 1), dtype=np.float32)
+        raw_b = np.zeros((n_frames, n_tx_b, n_ax, n_el, 1), dtype=np.float32)
+        scan_a = _scan_minimal(n_frames=n_frames, n_tx=n_tx_a, n_el=n_el)
+        scan_a["time_to_next_transmit"] = np.full((n_frames, n_tx_a), 0.1, dtype=np.float32)
+        scan_b = _scan_minimal(n_frames=n_frames, n_tx=n_tx_b, n_el=n_el)
+        scan_b["time_to_next_transmit"] = np.full((n_frames, n_tx_b), 0.05, dtype=np.float32)
+        schedule = np.array([0, 1, 0, 1, 0], dtype=np.int32)
+
+        path = tmp_path / "multi.hdf5"
+        File.create(
+            path,
+            tracks=[
+                {"data": {"raw_data": raw_a}, "scan": scan_a, "label": "a"},
+                {"data": {"raw_data": raw_b}, "scan": scan_b, "label": "b"},
+            ],
+            track_schedule=schedule,
+            probe=_probe_minimal(n_el=n_el),
+        )
+
+        with File(path) as f:
+            ts = f.timestamps
+
+        assert ts is not None
+        assert ts.shape == (5,)
+        np.testing.assert_allclose(ts, [0.0, 0.1, 0.15, 0.25, 0.30], atol=1e-6)
+
+    def test_file_timestamps_consistent_with_track_timestamps(self, tmp_path):
+        """File.timestamps values appear in each track's per-frame matrix."""
+        n_frames, n_tx_a, n_tx_b, n_el, n_ax = 1, 3, 2, 4, 8
+        raw_a = np.zeros((n_frames, n_tx_a, n_ax, n_el, 1), dtype=np.float32)
+        raw_b = np.zeros((n_frames, n_tx_b, n_ax, n_el, 1), dtype=np.float32)
+        scan_a = _scan_minimal(n_frames=n_frames, n_tx=n_tx_a, n_el=n_el)
+        scan_a["time_to_next_transmit"] = np.full((n_frames, n_tx_a), 0.1, dtype=np.float32)
+        scan_b = _scan_minimal(n_frames=n_frames, n_tx=n_tx_b, n_el=n_el)
+        scan_b["time_to_next_transmit"] = np.full((n_frames, n_tx_b), 0.05, dtype=np.float32)
+        schedule = np.array([0, 1, 0, 1, 0], dtype=np.int32)
+
+        path = tmp_path / "consistent.hdf5"
+        File.create(
+            path,
+            tracks=[
+                {"data": {"raw_data": raw_a}, "scan": scan_a, "label": "a"},
+                {"data": {"raw_data": raw_b}, "scan": scan_b, "label": "b"},
+            ],
+            track_schedule=schedule,
+            probe=_probe_minimal(n_el=n_el),
+        )
+
+        with File(path) as f:
+            global_ts = f.timestamps
+            track_ts_a = f.tracks[0].timestamps.ravel()
+            track_ts_b = f.tracks[1].timestamps.ravel()
+
+        # Every per-track timestamp must appear somewhere in the global array
+        for t in track_ts_a:
+            assert np.any(np.isclose(global_ts, t, atol=1e-6))
+        for t in track_ts_b:
+            assert np.any(np.isclose(global_ts, t, atol=1e-6))
+
+
 class TestLegacyFileLoading:
     """Integration tests: legacy files written with generate_zea_dataset load correctly."""
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -738,7 +738,7 @@ class File(h5py.File):
     def timestamps(self) -> "np.ndarray | None":
         """Global transmit timestamps in acquisition order, shape ``(n_total_tx,)``.
 
-        Returns a 1-D ``float32`` array whose ``i``-th entry is the absolute
+        Returns a 1-D ``float32`` array whose ``i``-th entry is the
         start time of the ``i``-th transmit event across **all** tracks, in the
         order defined by :attr:`track_schedule`.  This is the flattened view
         complementary to the per-track ``(n_frames, n_tx)`` matrices returned

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -640,6 +640,14 @@ class File(h5py.File):
             i += 1
 
         schedule = self.track_schedule
+        if schedule is None and len(tracks) == 1:
+            # For single-track files without an explicit schedule every transmit
+            # event belongs to track 0, so synthesise the schedule on the fly.
+            try:
+                n_events = tracks[0].n_frames * tracks[0].n_tx
+                schedule = np.zeros(n_events, dtype=np.int32)
+            except (TypeError, KeyError):
+                schedule = None
         if schedule is not None:
             all_timestamps = _compute_all_track_timestamps(schedule, tracks)
             for track, ts in zip(tracks, all_timestamps):
@@ -725,6 +733,56 @@ class File(h5py.File):
         if "track_schedule" not in self:
             return None
         return self["track_schedule"][()].astype(np.int32)
+
+    @property
+    def timestamps(self) -> "np.ndarray | None":
+        """Global transmit timestamps in acquisition order, shape ``(n_total_tx,)``.
+
+        Returns a 1-D ``float32`` array whose ``i``-th entry is the absolute
+        start time of the ``i``-th transmit event across **all** tracks, in the
+        order defined by :attr:`track_schedule`.  This is the flattened view
+        complementary to the per-track ``(n_frames, n_tx)`` matrices returned
+        by :attr:`Track.timestamps`.
+
+        Returns ``None`` when timestamps cannot be computed (missing
+        ``time_to_next_transmit`` on any track, or the file uses the legacy
+        flat layout with no tracks group).
+
+        Example::
+
+            with File("multi_track.hdf5") as f:
+                ts = f.timestamps  # shape (n_total_tx,)
+        """
+        try:
+            tracks = self.tracks
+        except AttributeError:
+            return None
+
+        if not tracks or any(t.timestamps is None for t in tracks):
+            return None
+
+        schedule = self.track_schedule
+        if schedule is None and len(tracks) == 1:
+            n_events = tracks[0].n_frames * tracks[0].n_tx
+            schedule = np.zeros(n_events, dtype=np.int32)
+        if schedule is None:
+            return None
+
+        ts_matrices = [np.asarray(t.timestamps, dtype=np.float32) for t in tracks]
+        n_tx_per_track = [m.shape[1] for m in ts_matrices]
+        track_counters = [[0, 0] for _ in tracks]
+
+        global_timestamps = np.empty(len(schedule), dtype=np.float32)
+        for event_idx, track_idx in enumerate(schedule):
+            frame_idx, tx_idx = track_counters[track_idx]
+            global_timestamps[event_idx] = ts_matrices[track_idx][frame_idx, tx_idx]
+            tx_idx += 1
+            if tx_idx >= n_tx_per_track[track_idx]:
+                tx_idx = 0
+                frame_idx += 1
+            track_counters[track_idx] = [frame_idx, tx_idx]
+
+        return global_timestamps
 
     @property
     def _scan_h5_group(self) -> "h5py.Group | None":


### PR DESCRIPTION
This PR makes two (non-breaking) changes:
- If no `track_schedule` is provided at `File.create`, and there's only a single track, we can default `track_schedule` to `ops.zeros`. This allows us to compute `track[0].timestamps`, without needing to explicitly pass a `track_schedule` of zeros.
- Add `File.timestamps` function, which returns the timestamps for the entire track schedule, across all tracks, acting as a sort of global timestamps function.


**Snippet**
```python
"""Quick demo: single-track file with a track_schedule."""

import os

os.environ["MPLBACKEND"] = "Agg"
import tempfile
from pathlib import Path

import numpy as np

from zea.data.file import File

# --- dimensions ---
n_frames, n_tx, n_el, n_ax, n_ch = 2, 3, 4, 8, 1

# --- dummy raw data ---
raw = np.arange(n_frames * n_tx * n_ax * n_el * n_ch, dtype=np.float32).reshape(
    n_frames, n_tx, n_ax, n_el, n_ch
)

# --- scan parameters ---
scan = {
    "sampling_frequency": np.float32(30e6),
    "center_frequency": np.float32(5e6),
    "demodulation_frequency": np.float32(5e6),
    "initial_times": np.zeros(n_tx, dtype=np.float32),
    "t0_delays": np.zeros((n_tx, n_el), dtype=np.float32),
    "tx_apodizations": np.ones((n_tx, n_el), dtype=np.float32),
    "focus_distances": np.zeros(n_tx, dtype=np.float32),
    "transmit_origins": np.zeros((n_tx, 3), dtype=np.float32),
    "polar_angles": np.zeros(n_tx, dtype=np.float32),
    "azimuth_angles": np.zeros(n_tx, dtype=np.float32),
    # time between consecutive transmits, shape (n_frames, n_tx)
    "time_to_next_transmit": np.full((n_frames, n_tx), 0.1, dtype=np.float32),
}

# --- track schedule: one entry per transmit event across all frames ---
# single track, so every slot points to track 0
track_schedule = np.zeros(n_frames * n_tx, dtype=np.int32)

with tempfile.TemporaryDirectory() as tmp:
    path = Path(tmp) / "single_track_scheduled.hdf5"

    # --- write ---
    File.create(
        path,
        data={"raw_data": raw},
        scan=scan,
        probe={"probe_geometry": np.zeros((n_el, 3), dtype=np.float32)},
    )
    print(f"Written: {path}")

    # --- read ---
    with File(path) as f:
        print(repr(f))

        track = f.tracks[0]
        print(f"  label       : {track.label}")
        print(f"  data keys   : {list(track.data.keys())}")
        print(f"  raw shape   : {track.data.raw_data.shape}")

        ts = track.timestamps
        print(f"  track timestamps  :\n{ts}")

        fts = f.timestamps
        print(f"  file timestamps  :\n{fts}")
```

Output:
```
<File "single_track_scheduled.hdf5" (mode r, 1 track)>
  label       : None
  data keys   : ['raw_data']
  raw shape   : (2, 3, 8, 4, 1)
  track timestamps  :
[[0.  0.1 0.2]
 [0.3 0.4 0.5]]
  file timestamps  :
[0.  0.1 0.2 0.3 0.4 0.5]
```