### PR TITLE
Fix auto timestamping

### DIFF
--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -675,9 +675,7 @@ def test_subject_id_warning_includes_field_metadata_description(tmp_path):
     assert any("subject-wise splits" in m for m in messages)
 
 
-def test_acquisition_time_auto_set_for_non_human(tmp_path):
-    from datetime import datetime, timezone
-
+def test_acquisition_time_not_auto_set_for_non_human(tmp_path):
     n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
     path = tmp_path / "acq_time_non_human.hdf5"
     File.create(
@@ -689,11 +687,7 @@ def test_acquisition_time_auto_set_for_non_human(tmp_path):
         overwrite=True,
     )
     with File(path) as f:
-        ts = f.acquisition_time
-    assert ts is not None
-    assert ts.tzinfo is not None
-    assert ts.tzinfo == timezone.utc or ts.utcoffset().total_seconds() == 0
-    assert isinstance(ts, datetime)
+        assert f.acquisition_time is None
 
 
 def test_acquisition_time_not_set_for_human(tmp_path):

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -883,13 +883,12 @@ class File(h5py.File):
             us_machine: Name of the ultrasound machine.
             description: Free-text description of the acquisition.
             acquisition_time: UTC acquisition timestamp as an ISO 8601 string
-                (e.g. ``"2026-06-12T14:30:00+00:00"``). When *None* (default) the
-                current UTC time is recorded automatically, **unless** the subject
-                type is ``"human"`` — in that case no timestamp is saved by default
-                (recording timestamps for human subjects may constitute Protected
-                Health Information / PHI). To capture the current moment explicitly,
-                pass ``datetime.now(timezone.utc).isoformat()`` (requires
-                ``from datetime import datetime, timezone``).
+                (e.g. ``"2026-06-12T14:30:00+00:00"``). When *None* (default) no
+                timestamp is recorded. To capture the current moment, pass
+                ``datetime.now(timezone.utc).isoformat()`` (requires
+                ``from datetime import datetime, timezone``). Note: recording
+                timestamps for human subjects may constitute Protected Health
+                Information (PHI) under HIPAA and similar regulations.
             compression: HDF5 compression filter (default ``"lzf"``).
             chunk_frames: If *True*, use frame-wise chunking for all datasets containing
                 a "frames" dimension. Dataset will be stored with HDF5 chunking enabled,

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1938,7 +1938,7 @@ class FileSpec(Spec):
             "description": (
                 "UTC acquisition timestamp in ISO 8601 format "
                 "(e.g. '2026-06-12T14:30:00+00:00'). "
-                "Auto-set to the moment of saving for non-human subjects."
+                "Optional — not recorded when omitted."
             ),
         },
     }
@@ -2204,9 +2204,6 @@ class FileSpec(Spec):
                     "regulations. Ensure you have appropriate authorization and "
                     "de-identification measures in place before sharing this file."
                 )
-        elif not is_human:
-            self.acquisition_time = datetime.now(timezone.utc).isoformat()
-
         with File(str(_path), "w") as f:
             f.attrs["zea_version"] = _zea_version
 


### PR DESCRIPTION
Removes the automatic acquisition date that is set on non-human subjects.