### PR TITLE
Improve pipeline indexing and spec saving warnings

### DIFF
--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -496,7 +496,7 @@ def test_metadata_accepts_custom_signal_nd_keys_and_warns(tmp_path):
             metadata=metadata,
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-    assert any("Custom signal key(s) added to 'metadata'" in m for m in messages)
+    assert any("Custom key(s) added to 'metadata'" in m for m in messages)
 
 
 def test_metadata_custom_key_requires_signal_nd_spec():
@@ -541,7 +541,7 @@ def test_data_accepts_custom_map_keys_and_warns(tmp_path):
             probe=_probe_minimal(n_el=n_el),
         )
     messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-    assert any("Custom spatial map key(s) added to 'data'" in m for m in messages)
+    assert any("Custom key(s) added to 'data'" in m for m in messages)
 
 
 def test_data_custom_key_requires_map_spec():
@@ -1252,7 +1252,7 @@ class TestScanSpecSaveWarnings:
                 probe=_probe_minimal(n_el=n_el),
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-        assert any("Custom spatial map key(s) added to 'data'" in m for m in messages)
+        assert any("Custom key(s) added to 'data'" in m for m in messages)
 
     def test_custom_metadata_signal_key_warns(self, tmp_path):
         n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1
@@ -1272,7 +1272,7 @@ class TestScanSpecSaveWarnings:
                 metadata=metadata,
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
-        assert any("Custom signal key(s) added to 'metadata'" in m for m in messages)
+        assert any("Custom key(s) added to 'metadata'" in m for m in messages)
 
     def test_subject_id_missing_warns(self):
         n_frames, n_tx, n_el, n_ax, n_ch = 2, 2, 4, 8, 1

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -420,6 +420,98 @@ def test_pipeline_operations_compact_after_check_config():
     assert not any(isinstance(op, Config) for op in config.pipeline.operations)
 
 
+def test_config_operations_string_indexing():
+    """config.pipeline.operations supports name-based string indexing."""
+    config = Config(
+        {
+            "pipeline": {
+                "operations": [
+                    "demodulate",
+                    {"name": "normalize", "params": {"output_range": [0, 1]}},
+                ],
+            }
+        }
+    )
+
+    assert config.pipeline.operations["demodulate"] == "demodulate"
+    result = config.pipeline.operations["normalize"]
+    assert result == {"name": "normalize", "params": {"output_range": [0, 1]}}
+
+
+def test_config_operations_int_indexing_unchanged():
+    """Integer indexing on config.pipeline.operations is unaffected."""
+    config = Config({"pipeline": {"operations": ["demodulate", "normalize"]}})
+
+    assert config.pipeline.operations[0] == "demodulate"
+    assert config.pipeline.operations[1] == "normalize"
+
+
+def test_config_operations_is_list():
+    """config.pipeline.operations is still a list (backward compat)."""
+    from zea.internal.ops_list import OperationList
+
+    config = Config({"pipeline": {"operations": ["demodulate"]}})
+    assert isinstance(config.pipeline.operations, list)
+    assert isinstance(config.pipeline.operations, OperationList)
+
+
+def test_config_operations_not_found():
+    """KeyError lists available names when key is missing."""
+    config = Config({"pipeline": {"operations": ["demodulate"]}})
+
+    with pytest.raises(KeyError, match="Available"):
+        config.pipeline.operations["nonexistent"]
+
+
+def test_config_operations_close_match():
+    """KeyError suggests a close match when the name is slightly wrong."""
+    config = Config({"pipeline": {"operations": ["demodulate"]}})
+
+    with pytest.raises(KeyError, match="demodulate"):
+        config.pipeline.operations["demoulate"]  # intentional typo
+
+
+def test_config_operations_duplicate_raises():
+    """Ambiguous bare name raises with numbered hints when duplicates exist."""
+    config = Config({"pipeline": {"operations": ["normalize", "normalize"]}})
+
+    with pytest.raises(KeyError, match="normalize_0"):
+        config.pipeline.operations["normalize"]
+
+
+def test_config_operations_numbered_suffix():
+    """Numbered suffix resolves duplicate operations in a config."""
+    config = Config(
+        {
+            "pipeline": {
+                "operations": [
+                    {"name": "normalize", "params": {"output_range": [0, 1]}},
+                    {"name": "normalize", "params": {"output_range": [-1, 1]}},
+                ]
+            }
+        }
+    )
+
+    assert config.pipeline.operations["normalize_0"]["params"]["output_range"] == [0, 1]
+    assert config.pipeline.operations["normalize_1"]["params"]["output_range"] == [-1, 1]
+
+
+def test_config_operations_mutate_via_index():
+    """Modifying the returned dict mutates the entry in-place."""
+    config = Config(
+        {
+            "pipeline": {
+                "operations": [
+                    {"name": "beamform", "params": {"enable_pfield": False}},
+                ]
+            }
+        }
+    )
+
+    config.pipeline.operations["beamform"]["params"]["enable_pfield"] = True
+    assert config.pipeline.operations["beamform"]["params"]["enable_pfield"] is True
+
+
 def test_config_pickle():
     """Tests if the config can be pickled and unpickled without changing its contents."""
     import pickle

--- a/tests/test_ops_infra.py
+++ b/tests/test_ops_infra.py
@@ -272,6 +272,100 @@ def test_string_representation(verbose=False):
 """Pipeline Class Tests"""
 
 
+def test_pipeline_operations_int_indexing_unchanged():
+    """Existing integer indexing on pipeline.operations is unaffected."""
+    m_op = MultiplyOperation()
+    a_op = AddOperation()
+    pipeline = ops.Pipeline(operations=[m_op, a_op], jit_options=None)
+
+    assert pipeline.operations[0] is m_op
+    assert pipeline.operations[-1] is a_op
+
+
+def test_pipeline_operations_is_plain_list():
+    """pipeline.operations is a plain list; string lookup goes via pipeline[key]."""
+    from zea.internal.ops_list import OperationList
+
+    pipeline = ops.Pipeline(operations=[MultiplyOperation()], jit_options=None)
+    assert isinstance(pipeline.operations, list)
+    assert not isinstance(pipeline.operations, OperationList)
+
+
+def test_pipeline_getitem_by_name():
+    """pipeline[name] looks up an operation by registry name."""
+    m_op = MultiplyOperation()
+    a_op = AddOperation()
+    pipeline = ops.Pipeline(operations=[m_op, a_op], jit_options=None)
+
+    assert pipeline["multiply"] is m_op
+    assert pipeline["add"] is a_op
+
+
+def test_pipeline_getitem_not_found():
+    """KeyError lists available names when the name is not found."""
+    pipeline = ops.Pipeline(operations=[MultiplyOperation()], jit_options=None)
+
+    with pytest.raises(KeyError, match="Available"):
+        pipeline["nonexistent"]
+
+
+def test_pipeline_getitem_close_match():
+    """KeyError suggests a close match when the name is slightly wrong."""
+    pipeline = ops.Pipeline(operations=[MultiplyOperation()], jit_options=None)
+
+    with pytest.raises(KeyError, match="multiply"):
+        pipeline["multipy"]  # intentional typo
+
+
+def test_pipeline_getitem_duplicate_raises():
+    """Ambiguous bare name raises with numbered hints when duplicates exist."""
+    pipeline = ops.Pipeline(
+        operations=[MultiplyOperation(), MultiplyOperation()],
+        jit_options=None,
+        validate=False,
+    )
+
+    with pytest.raises(KeyError, match="multiply_0"):
+        pipeline["multiply"]
+
+
+def test_pipeline_getitem_numbered_suffix():
+    """Numbered suffix 'name_N' resolves to the Nth duplicate."""
+    m0 = MultiplyOperation()
+    m1 = MultiplyOperation()
+    pipeline = ops.Pipeline(operations=[m0, m1], jit_options=None, validate=False)
+
+    assert pipeline["multiply_0"] is m0
+    assert pipeline["multiply_1"] is m1
+
+
+def test_pipeline_getitem_numbered_out_of_range():
+    """Numbered index beyond available matches raises a KeyError."""
+    pipeline = ops.Pipeline(operations=[MultiplyOperation()], jit_options=None)
+
+    with pytest.raises(KeyError, match="out of range"):
+        pipeline["multiply_5"]
+
+
+def test_pipeline_keys():
+    """pipeline.keys() returns the list of indexable string names."""
+    pipeline = ops.Pipeline(operations=[MultiplyOperation(), AddOperation()], jit_options=None)
+
+    assert pipeline.keys() == ["multiply", "add"]
+
+
+def test_pipeline_dotted_registry_name():
+    """Operations with dotted registry names (e.g. keras built-ins) are reachable
+    by their short last-component name."""
+    from zea.ops.pipeline import Pipeline
+    from zea.ops.keras_ops import Cast
+
+    pipeline = Pipeline.from_default(jit_options=None)
+    # Cast is registered as "keras.ops.cast" but must be addressable as "cast"
+    assert isinstance(pipeline["cast"], Cast)
+    assert "cast" in pipeline.keys()
+
+
 def test_pipeline_initialization():
     """Tests initialization of a Pipeline."""
     operations = [MultiplyOperation(), AddOperation()]

--- a/zea/backend/__init__.py
+++ b/zea/backend/__init__.py
@@ -104,6 +104,25 @@ def jit(func=None, jax=True, tensorflow=True, **kwargs):
         return _jit_compile(func, jax=jax, tensorflow=tensorflow, **kwargs)
 
 
+_jit_not_supported_warned = False
+
+
+def _warn_jit_not_supported(backend_name: str) -> None:
+    """Emit the 'JIT not supported' warning at most once, and only when it will
+    actually be shown (i.e. not when suppressed by log.set_level("ERROR"))."""
+    global _jit_not_supported_warned
+    import logging
+
+    if not _jit_not_supported_warned and log.logger.isEnabledFor(logging.WARNING):
+        _jit_not_supported_warned = True
+        log.warning(
+            f"JIT compilation not currently supported for backend {backend_name}. "
+            "Supported backends are 'tensorflow' and 'jax'. "
+            "Initialize zea.Pipeline with jit_options=None to suppress this warning. "
+            "Falling back to non-compiled mode."
+        )
+
+
 def _jit_compile(func, jax=True, tensorflow=True, **kwargs):
     backend = keras.backend.backend()
 
@@ -121,12 +140,7 @@ def _jit_compile(func, jax=True, tensorflow=True, **kwargs):
     elif backend == "jax" and not jax:
         return func
     else:
-        log.warning(
-            f"JIT compilation not currently supported for backend {backend}. "
-            "Supported backends are 'tensorflow' and 'jax'."
-        )
-        log.warning("Initialize zea.Pipeline with jit_options=None to suppress this warning.")
-        log.warning("Falling back to non-compiled mode.")
+        _warn_jit_not_supported(backend)
         return func
 
 

--- a/zea/config.py
+++ b/zea/config.py
@@ -56,6 +56,7 @@ import yaml
 from zea import log
 from zea.internal.config.validation import validate_config
 from zea.internal.core import dict_to_tensor
+from zea.internal.ops_list import OperationList
 from zea.internal.preset_utils import HF_PREFIX, _hf_resolve_path
 from zea.internal.utils import deprecated
 
@@ -281,7 +282,7 @@ class Config(dict):
         # ``config.pipeline.operations`` reads as e.g.
         # ``['demodulate', {'name': 'downsample', 'params': {'factor': 4}}]``.
         if name == "operations" and isinstance(value, list):
-            value = [_compact_operation(x) for x in value]
+            value = OperationList([_compact_operation(x) for x in value])
         # Ensures lists and tuples of dictionaries are converted to Config objects as well
         elif isinstance(value, list):
             value = [

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -1,5 +1,6 @@
 """zea data file (HDF5)."""
 
+import difflib
 import enum
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +25,8 @@ from zea.internal.checks import _DATA_TYPES, _NON_IMAGE_DATA_TYPES
 from zea.internal.core import DataTypes
 from zea.internal.preset_utils import HF_PREFIX, _hf_resolve_path
 from zea.internal.utils import deprecated
+
+_ZEA_ISSUES_URL = "https://github.com/tue-bmd/zea/issues"
 
 if TYPE_CHECKING:
     # ``Self`` is in ``typing`` only from 3.11; import lazily to keep the
@@ -521,24 +524,45 @@ def _warn_if_legacy_file(file: "File") -> None:
 
 def _warn_custom_keys(data: dict, metadata: dict):
     """Warn about custom keys in data/metadata dicts when saving."""
+    known_map_keys = [k for k, v in DataSpec.SCHEMA.items() if "spec" in v]
     custom_maps = [k for k in data if k not in DataSpec.SCHEMA]
     if custom_maps:
-        supported = ", ".join(k for k, v in DataSpec.SCHEMA.items() if "spec" in v)
-        log.warning(
-            f"Custom spatial map key(s) added to 'data': {', '.join(sorted(custom_maps))}. "
-            "These are validated as generic Map specs. "
-            "If your data matches an existing type, prefer one of the supported "
-            f"spatial maps: {supported}."
+        parts = [
+            f"Custom key(s) added to 'data' and validated as generic Map specs: "
+            f"{', '.join(sorted(custom_maps))}."
+        ]
+        for key in sorted(custom_maps):
+            close = difflib.get_close_matches(key, known_map_keys, n=1, cutoff=0.6)
+            if close:
+                parts.append(
+                    f"  '{key}' closely resembles the built-in field '{close[0]}' — "
+                    f"did you mean '{close[0]}'?"
+                )
+        parts.append(f"Supported data fields: {', '.join(known_map_keys)}.")
+        parts.append(
+            f"Think one of your keys should be a recognized field? Open an issue: {_ZEA_ISSUES_URL}"
         )
+        log.warning("\n".join(parts))
+
+    known_signal_keys = [k for k, v in MetadataSpec.SCHEMA.items() if "spec" in v]
     custom_signals = [k for k in metadata if k not in MetadataSpec.SCHEMA]
     if custom_signals:
-        supported = ", ".join(k for k, v in MetadataSpec.SCHEMA.items() if "spec" in v)
-        log.warning(
-            f"Custom signal key(s) added to 'metadata': {', '.join(sorted(custom_signals))}. "
-            "These are validated as generic SignalND specs. "
-            "If your signal matches an existing type, prefer one of the supported "
-            f"signal fields: {supported}."
+        parts = [
+            f"Custom key(s) added to 'metadata' and validated as generic SignalND specs: "
+            f"{', '.join(sorted(custom_signals))}."
+        ]
+        for key in sorted(custom_signals):
+            close = difflib.get_close_matches(key, known_signal_keys, n=1, cutoff=0.6)
+            if close:
+                parts.append(
+                    f"  '{key}' closely resembles the built-in field '{close[0]}' — "
+                    f"did you mean '{close[0]}'?"
+                )
+        parts.append(f"Supported metadata fields: {', '.join(known_signal_keys)}.")
+        parts.append(
+            f"Think one of your keys should be a recognized field? Open an issue: {_ZEA_ISSUES_URL}"
         )
+        log.warning("\n".join(parts))
 
 
 class File(h5py.File):

--- a/zea/internal/ops_list.py
+++ b/zea/internal/ops_list.py
@@ -1,0 +1,126 @@
+"""OperationList: a list subclass with name-based indexing for pipeline operations."""
+
+import difflib
+
+
+class OperationList(list):
+    """A list of operations that supports both integer and name-based string indexing.
+
+    Works for both:
+
+    - **Pipeline operations** (:class:`~zea.ops.Operation` /
+      :class:`~zea.ops.Pipeline` instances): names are resolved via the
+      :data:`~zea.internal.registry.ops_registry`.
+    - **Config operations** (``str`` / ``dict`` elements produced by
+      :func:`~zea.config._compact_operation`): the string itself or the
+      ``"name"`` key of the dict is used directly.
+
+    Duplicate operations are disambiguated with a ``_N`` numeric suffix.
+    If a pipeline contains two ``Normalize`` ops, use ``"normalize_0"``
+    and ``"normalize_1"``.  Using the bare name ``"normalize"`` when
+    duplicates exist raises a :exc:`KeyError` with a helpful hint.
+
+    Call :meth:`keys` to see all available string keys.
+
+    Examples:
+        .. code-block:: python
+
+            pipeline = zea.Pipeline.from_default()
+            pipeline.operations["beamform"]
+            pipeline.operations["beamform"].operations["tof_correction"]
+            # or using the shorthand on Pipeline directly:
+            pipeline["beamform"]["tof_correction"]
+
+            pipeline.operations.keys()
+            # ['cast', 'apply_window', 'demodulate', 'beamform', ...]
+
+            config = zea.Config.from_path("config.yaml")
+            config.pipeline.operations["beamform"].params.enable_pfield = True
+    """
+
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return self._get_by_name(key)
+        return super().__getitem__(key)
+
+    @staticmethod
+    def _get_op_name(op):
+        """Return the user-facing lookup name for one element of the list."""
+        if isinstance(op, str):
+            return op
+        if isinstance(op, dict):
+            return op.get("name")
+        # Operation/Pipeline instances — lazy import avoids circular deps with config.py
+        from zea.internal.registry import ops_registry
+
+        try:
+            reg_name = ops_registry.get_name(type(op))
+        except KeyError:
+            return getattr(op, "name", None)
+
+        # Dotted registry names (e.g. "keras.ops.cast") → expose only the last component
+        # so users can write operations["cast"] instead of operations["keras.ops.cast"].
+        return reg_name.rsplit(".", 1)[-1] if "." in reg_name else reg_name
+
+    def _get_by_name(self, name):
+        # Resolve optional numeric suffix: "normalize_1" -> base="normalize", index=1
+        base, sep, suffix = name.rpartition("_")
+        if sep and suffix.isdigit():
+            base_name, index = base, int(suffix)
+        else:
+            base_name, index = name, None
+
+        matches = [op for op in self if self._get_op_name(op) == base_name]
+
+        if not matches:
+            available = self.keys()
+            msg = f"No operation named '{base_name}' found."
+            closest = difflib.get_close_matches(base_name, available, n=1, cutoff=0.6)
+            if closest:
+                msg += f" Did you mean '{closest[0]}'?"
+            msg += f" Available operations: {available}"
+            raise KeyError(msg)
+
+        if index is not None:
+            if index >= len(matches):
+                raise KeyError(
+                    f"Index {index} out of range for '{base_name}' "
+                    f"(found {len(matches)} match{'es' if len(matches) != 1 else ''})."
+                )
+            return matches[index]
+
+        if len(matches) > 1:
+            numbered = [f"'{base_name}_{i}'" for i in range(len(matches))]
+            raise KeyError(
+                f"Ambiguous: {len(matches)} operations named '{base_name}'. "
+                f"Use a numbered form to be specific: {', '.join(numbered)}."
+            )
+
+        return matches[0]
+
+    def keys(self):
+        """Return the list of string keys that can be used for name-based indexing.
+
+        Duplicate names are disambiguated with a ``_N`` suffix so that every
+        returned key is unambiguously usable::
+
+            pipeline.keys()  # ['cast', 'normalize_0', 'normalize_1', ...]
+        """
+        raw = [self._get_op_name(op) for op in self]
+        counts = {}
+        for name in raw:
+            if name is not None:
+                counts[name] = counts.get(name, 0) + 1
+
+        seen: dict = {}
+        result = []
+        for name in raw:
+            if name is None:
+                continue
+            if counts[name] > 1:
+                idx = seen.get(name, 0)
+                result.append(f"{name}_{idx}")
+                seen[name] = idx + 1
+            else:
+                result.append(name)
+        return result

--- a/zea/internal/ops_list.py
+++ b/zea/internal/ops_list.py
@@ -63,7 +63,20 @@ class OperationList(list):
         return reg_name.rsplit(".", 1)[-1] if "." in reg_name else reg_name
 
     def _get_by_name(self, name):
-        # Resolve optional numeric suffix: "normalize_1" -> base="normalize", index=1
+        # Exact match first: ops whose registered name ends in _N are reachable
+        # without being confused for a disambiguated duplicate.
+        exact = [op for op in self if self._get_op_name(op) == name]
+        if len(exact) == 1:
+            return exact[0]
+        if len(exact) > 1:
+            numbered = [f"'{name}_{i}'" for i in range(len(exact))]
+            raise KeyError(
+                f"Ambiguous: {len(exact)} operations named '{name}'. "
+                f"Use a numbered form to be specific: {', '.join(numbered)}."
+            )
+
+        # No exact match — resolve optional numeric suffix:
+        # "normalize_1" -> base="normalize", index=1
         base, sep, suffix = name.rpartition("_")
         if sep and suffix.isdigit():
             base_name, index = base, int(suffix)
@@ -74,8 +87,8 @@ class OperationList(list):
 
         if not matches:
             available = self.keys()
-            msg = f"No operation named '{base_name}' found."
-            closest = difflib.get_close_matches(base_name, available, n=1, cutoff=0.6)
+            msg = f"No operation named '{name}' found."
+            closest = difflib.get_close_matches(name, available, n=1, cutoff=0.6)
             if closest:
                 msg += f" Did you mean '{closest[0]}'?"
             msg += f" Available operations: {available}"

--- a/zea/ops/pipeline.py
+++ b/zea/ops/pipeline.py
@@ -13,6 +13,7 @@ from zea.func.tensor import vmap
 from zea.func.ultrasound import channels_to_complex, complex_to_channels
 from zea.internal.core import DataTypes, ZEADecoderJSON, ZEAEncoderJSON, dict_to_tensor
 from zea.internal.core import Object as ZEAObject
+from zea.internal.ops_list import OperationList
 from zea.internal.registry import beamformer_registry, ops_registry
 from zea.internal.utils import deprecated
 from zea.ops.base import Operation, get_ops
@@ -275,18 +276,31 @@ class Pipeline:
             device=self.device,
         )
 
+    @staticmethod
+    def _check_op_is_instance(operation):
+        """Raise a clear TypeError when a class is passed instead of an instance."""
+        if isinstance(operation, type):
+            raise TypeError(
+                f"Expected an Operation instance, got class {operation.__name__!r}. "
+                f"Did you forget the parentheses? "
+                f"Use {operation.__name__}() instead of {operation.__name__}."
+            )
+
     def prepend(self, operation: Operation):
         """Prepend an operation to the pipeline."""
+        self._check_op_is_instance(operation)
         self._pipeline_layers.insert(0, operation)
         self.reinitialize()
 
     def append(self, operation: Operation):
         """Append an operation to the pipeline."""
+        self._check_op_is_instance(operation)
         self._pipeline_layers.append(operation)
         self.reinitialize()
 
     def insert(self, index: int, operation: Operation):
         """Insert an operation at a specific index in the pipeline."""
+        self._check_op_is_instance(operation)
         if index < 0 or index > len(self._pipeline_layers):
             raise IndexError("Index out of bounds for inserting operation.")
         self._pipeline_layers.insert(index, operation)
@@ -296,6 +310,29 @@ class Pipeline:
     def operations(self) -> List[Union[Operation, "Pipeline"]]:
         """Alias for self.layers to match the zea naming convention"""
         return self._pipeline_layers
+
+    def __getitem__(self, key: str):
+        """Look up an operation by name.
+
+        Allows chaining directly on the pipeline object::
+
+            pipeline["beamform"]["tof_correction"]
+
+        Use :meth:`keys` to see available names.
+        Duplicate operation names are disambiguated with a ``_N`` suffix,
+        e.g. ``pipeline["normalize_0"]``.
+        """
+        return OperationList(self._pipeline_layers)[key]
+
+    def keys(self):
+        """Return the string keys that can be used with ``pipeline[key]``.
+
+        Example::
+
+            pipeline.keys()
+            # ['cast', 'apply_window', 'demodulate', 'beamform', ...]
+        """
+        return OperationList(self._pipeline_layers).keys()
 
     def reset_timer(self):
         """Reset the timer for timed operations."""
@@ -467,6 +504,14 @@ class Pipeline:
     def validate(self):
         """Validate the pipeline by checking the compatibility of the operations."""
         operations = self.operations
+        for i, op in enumerate(operations):
+            if isinstance(op, type):
+                raise TypeError(
+                    f"Pipeline operation at index {i} is a class ({op.__name__!r}), "
+                    "not an instance. "
+                    f"Did you forget the parentheses? "
+                    f"Use {op.__name__}() instead of {op.__name__}."
+                )
         for i in range(len(operations) - 1):
             if operations[i].output_data_type is None:
                 continue


### PR DESCRIPTION
Addressed #331 as well as improved warnings / errors for custom fields with `zea.File.create`

## Summary

Two ergonomics improvements to make working with pipelines and files less error-prone. Note this is none breaking and all old behavior is still valid too.

### 1. Look up pipeline operations by name

You can now index into a pipeline (or `config.pipeline.operations`) by operation name instead of having to know the position:

```python
pipeline = zea.Pipeline.from_default()

# Before
beamformer = pipeline.operations[3]

# After
beamformer = pipeline["beamform"]
config.pipeline.operations["beamform"]["params"]["enable_pfield"] = True
```

If the same operation appears more than once, use a `_N` suffix to disambiguate:

```python
pipeline["normalize_0"]  # first normalize
pipeline["normalize_1"]  # second normalize
```

Typos get a close-match hint:

```
KeyError: No operation named 'beamforrm' found. Did you mean 'beamform'?
Available operations: ['cast', 'apply_window', 'demodulate', 'beamform', ...]
```

Passing a class instead of an instance now raises early with a clear message:

```python
pipeline.append(Normalize)  # forgot the ()
# TypeError: Expected an Operation instance, got class 'Normalize'.
# Did you forget the parentheses? Use Normalize() instead of Normalize.
```

The JIT-not-supported warning is also deduplicated — it now fires at most once per session instead of three times per pipeline call.

---

### 2. Smarter warnings for custom data/metadata keys in `zea.File.create`

When you pass a key that isn't a recognized field, the warning now suggests what you probably meant and always includes a link to open an issue.

```python
zea.File.create(path, data={"raw_data": raw, "sos_maps": make_map()}, ...)
```
```
WARNING: Custom key(s) added to 'data' and validated as generic Map specs: sos_maps.
  'sos_maps' closely resembles the built-in field 'sos_map' — did you mean 'sos_map'?
Supported data fields: sos_map, b_mode_map, ...
Think one of your keys should be a recognized field? Open an issue: https://github.com/tue-bmd/zea/issues
```

Works for longer names too:

```
'shear_wave_elastograhy_map' closely resembles 'shear_wave_elastography_map' — did you mean 'shear_wave_elastography_map'?
```

Falls back gracefully when there's no close match — just shows supported fields and the issue link.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline operations can now be accessed by name string in addition to integer index, with helpful error messages and close-match suggestions for unknown names.

* **Improvements**
  * Enhanced custom key warnings with close-match field suggestions and issue tracker guidance.
  * Added validation to prevent passing operation classes without instantiation.
  * Throttled redundant JIT compilation warnings.

* **Tests**
  * Expanded test coverage for operation indexing and lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->