### PR TITLE
Verasonics saving improvements

### DIFF
--- a/tests/data/test_conversion_scripts.py
+++ b/tests/data/test_conversion_scripts.py
@@ -25,7 +25,12 @@ from zea.data.convert.utils import (
     sitk_load,
     unzip,
 )
-from zea.data.convert.verasonics import VerasonicsFile, convert_verasonics
+from zea.data.convert.verasonics import (
+    VerasonicsFile,
+    bs100bw_to_iq,
+    convert_verasonics,
+    estimate_lens_probe_params,
+)
 from zea.data.file import File
 from zea.data.spec import DEFAULT_COMPRESSION
 from zea.func.tensor import translate
@@ -1426,6 +1431,53 @@ def test_verasonics_upload_requires_revision(tmp_path, monkeypatch):
 
     with pytest.raises(AssertionError, match="revision must be provided"):
         convert_verasonics(args)
+
+
+def testestimate_lens_probe_params_no_element():
+    """Returns an empty dict when lens_correction is None."""
+    assert estimate_lens_probe_params(None, center_frequency=7e6) == {}
+
+
+def testestimate_lens_probe_params_with_element():
+    """Returns correct ProbeSpec lens fields derived from lens_correction."""
+    lens_wl = 0.5
+    f_c = 7e6
+    c_lens = 1000.0
+
+    result = estimate_lens_probe_params(lens_wl, center_frequency=f_c, lens_sound_speed=c_lens)
+
+    assert set(result.keys()) == {"lens_sound_speed", "lens_thickness"}
+    assert result["lens_sound_speed"] == np.float32(c_lens)
+    np.testing.assert_allclose(
+        result["lens_thickness"], np.float32(lens_wl * c_lens / f_c), rtol=1e-6
+    )
+
+
+def testestimate_lens_probe_params_custom_sound_speed():
+    """lens_sound_speed scales thickness proportionally."""
+    f_c = 5e6
+    r1 = estimate_lens_probe_params(1.0, center_frequency=f_c, lens_sound_speed=1000.0)
+    r2 = estimate_lens_probe_params(1.0, center_frequency=f_c, lens_sound_speed=1600.0)
+
+    assert r2["lens_sound_speed"] == np.float32(1600.0)
+    np.testing.assert_allclose(
+        r2["lens_thickness"] / r1["lens_thickness"], 1600.0 / 1000.0, rtol=1e-5
+    )
+
+
+def test_bs100bw_to_iq_shape_and_values():
+    """bs100bw_to_iq splits interleaved axial samples into I/Q channels."""
+    rng = np.random.default_rng(42)
+    n_frames, n_tx, n_ax_raw, n_el = 2, 3, 8, 4
+    data = rng.integers(-100, 100, (n_frames, n_tx, n_ax_raw, n_el, 1), dtype=np.int16).astype(
+        np.float32
+    )
+
+    iq = bs100bw_to_iq(data)
+
+    assert iq.shape == (n_frames, n_tx, n_ax_raw // 2, n_el, 2)
+    np.testing.assert_array_equal(iq[..., 0], data[:, :, 0::2, :, 0])  # I = even samples
+    np.testing.assert_array_equal(iq[..., 1], -data[:, :, 1::2, :, 0])  # Q = -odd samples
 
 
 def test_check_output_dir_ownership_empty_dir(tmp_path):

--- a/tests/data/test_conversion_scripts.py
+++ b/tests/data/test_conversion_scripts.py
@@ -32,7 +32,6 @@ from zea.data.convert.verasonics import (
     estimate_lens_probe_params,
 )
 from zea.data.file import File
-from zea.data.spec import DEFAULT_COMPRESSION
 from zea.func.tensor import translate
 from zea.internal.preset_utils import _hf_resolve_path
 from zea.io_lib import _SUPPORTED_IMG_TYPES
@@ -1344,16 +1343,7 @@ def test_images_uint8_passes(tmp_path):
 
 
 def test_verasonics_compression_flag_respected(tmp_path):
-    """When enable_compression=False the File.create call must use
-    compression=None, not force 'lzf'."""
-    enable_compression = False
-    compression = DEFAULT_COMPRESSION if enable_compression else None
-
-    assert (compression or DEFAULT_COMPRESSION) == DEFAULT_COMPRESSION, (
-        "old code always used default compression"
-    )
-    assert compression is None, "fixed code uses None when compression is disabled"
-
+    """When enable_compression=False the File.create call must use compression=None."""
     n_tx, n_el = 4, 16
     scan = {
         "sampling_frequency": np.float32(40e6),
@@ -1431,53 +1421,6 @@ def test_verasonics_upload_requires_revision(tmp_path, monkeypatch):
 
     with pytest.raises(AssertionError, match="revision must be provided"):
         convert_verasonics(args)
-
-
-def testestimate_lens_probe_params_no_element():
-    """Returns an empty dict when lens_correction is None."""
-    assert estimate_lens_probe_params(None, center_frequency=7e6) == {}
-
-
-def testestimate_lens_probe_params_with_element():
-    """Returns correct ProbeSpec lens fields derived from lens_correction."""
-    lens_wl = 0.5
-    f_c = 7e6
-    c_lens = 1000.0
-
-    result = estimate_lens_probe_params(lens_wl, center_frequency=f_c, lens_sound_speed=c_lens)
-
-    assert set(result.keys()) == {"lens_sound_speed", "lens_thickness"}
-    assert result["lens_sound_speed"] == np.float32(c_lens)
-    np.testing.assert_allclose(
-        result["lens_thickness"], np.float32(lens_wl * c_lens / f_c), rtol=1e-6
-    )
-
-
-def testestimate_lens_probe_params_custom_sound_speed():
-    """lens_sound_speed scales thickness proportionally."""
-    f_c = 5e6
-    r1 = estimate_lens_probe_params(1.0, center_frequency=f_c, lens_sound_speed=1000.0)
-    r2 = estimate_lens_probe_params(1.0, center_frequency=f_c, lens_sound_speed=1600.0)
-
-    assert r2["lens_sound_speed"] == np.float32(1600.0)
-    np.testing.assert_allclose(
-        r2["lens_thickness"] / r1["lens_thickness"], 1600.0 / 1000.0, rtol=1e-5
-    )
-
-
-def test_bs100bw_to_iq_shape_and_values():
-    """bs100bw_to_iq splits interleaved axial samples into I/Q channels."""
-    rng = np.random.default_rng(42)
-    n_frames, n_tx, n_ax_raw, n_el = 2, 3, 8, 4
-    data = rng.integers(-100, 100, (n_frames, n_tx, n_ax_raw, n_el, 1), dtype=np.int16).astype(
-        np.float32
-    )
-
-    iq = bs100bw_to_iq(data)
-
-    assert iq.shape == (n_frames, n_tx, n_ax_raw // 2, n_el, 2)
-    np.testing.assert_array_equal(iq[..., 0], data[:, :, 0::2, :, 0])  # I = even samples
-    np.testing.assert_array_equal(iq[..., 1], -data[:, :, 1::2, :, 0])  # Q = -odd samples
 
 
 def test_check_output_dir_ownership_empty_dir(tmp_path):

--- a/tests/data/test_conversion_scripts.py
+++ b/tests/data/test_conversion_scripts.py
@@ -1559,6 +1559,14 @@ class TestEstimateLensProbeParams:
         with pytest.raises(ValueError, match="lens_correction"):
             estimate_lens_probe_params(-0.5, 7e6)
 
+    def test_invalid_lens_correction_nan(self):
+        with pytest.raises(ValueError, match="lens_correction"):
+            estimate_lens_probe_params(float("nan"), 7e6)
+
+    def test_invalid_lens_correction_inf(self):
+        with pytest.raises(ValueError, match="lens_correction"):
+            estimate_lens_probe_params(float("inf"), 7e6)
+
 
 class TestBs100bwToIq:
     def _make_data(self, n_frames=2, n_tx=3, n_ax=8, n_el=4):

--- a/tests/data/test_conversion_scripts.py
+++ b/tests/data/test_conversion_scripts.py
@@ -25,7 +25,12 @@ from zea.data.convert.utils import (
     sitk_load,
     unzip,
 )
-from zea.data.convert.verasonics import VerasonicsFile, convert_verasonics
+from zea.data.convert.verasonics import (
+    VerasonicsFile,
+    bs100bw_to_iq,
+    convert_verasonics,
+    estimate_lens_probe_params,
+)
 from zea.data.file import File
 from zea.data.spec import DEFAULT_COMPRESSION
 from zea.func.tensor import translate
@@ -1518,3 +1523,80 @@ def test_require_output_dir_ownership_mismatched_readme(tmp_path):
     # Should raise ValueError when repo_id doesn't match
     with pytest.raises(ValueError, match="does not declare 'zea_repo_id"):
         require_output_dir_ownership(output_dir, "zeahub/test_dataset")
+
+
+class TestEstimateLensProbeParams:
+    def test_none_returns_empty_dict(self):
+        assert estimate_lens_probe_params(None, 7e6) == {}
+
+    def test_known_values(self):
+        result = estimate_lens_probe_params(1.0, 7e6, lens_sound_speed=1000.0)
+        expected_thickness = np.float32(1.0 * 1000.0 / 7e6)
+        assert result["lens_sound_speed"] == np.float32(1000.0)
+        assert result["lens_thickness"] == pytest.approx(expected_thickness, rel=1e-5)
+
+    def test_invalid_lens_sound_speed_zero(self):
+        with pytest.raises(ValueError, match="lens_sound_speed"):
+            estimate_lens_probe_params(1.0, 7e6, lens_sound_speed=0.0)
+
+    def test_invalid_lens_sound_speed_negative(self):
+        with pytest.raises(ValueError, match="lens_sound_speed"):
+            estimate_lens_probe_params(1.0, 7e6, lens_sound_speed=-500.0)
+
+    def test_invalid_lens_sound_speed_nan(self):
+        with pytest.raises(ValueError, match="lens_sound_speed"):
+            estimate_lens_probe_params(1.0, 7e6, lens_sound_speed=float("nan"))
+
+    def test_invalid_center_frequency_zero(self):
+        with pytest.raises(ValueError, match="center_frequency"):
+            estimate_lens_probe_params(1.0, 0.0)
+
+    def test_invalid_center_frequency_inf(self):
+        with pytest.raises(ValueError, match="center_frequency"):
+            estimate_lens_probe_params(1.0, float("inf"))
+
+    def test_invalid_lens_correction_negative(self):
+        with pytest.raises(ValueError, match="lens_correction"):
+            estimate_lens_probe_params(-0.5, 7e6)
+
+
+class TestBs100bwToIq:
+    def _make_data(self, n_frames=2, n_tx=3, n_ax=8, n_el=4):
+        return np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32)
+
+    def test_output_shape(self):
+        data = self._make_data()
+        out = bs100bw_to_iq(data)
+        assert out.shape == (2, 3, 4, 4, 2)
+
+    def test_i_samples_are_even_rows(self):
+        data = np.zeros((1, 1, 4, 1, 1), dtype=np.float32)
+        data[0, 0, 0, 0, 0] = 5.0  # even index → I
+        data[0, 0, 2, 0, 0] = 7.0  # even index → I
+        out = bs100bw_to_iq(data)
+        np.testing.assert_array_equal(out[0, 0, :, 0, 0], [5.0, 7.0])  # I channel
+
+    def test_q_samples_are_negated_odd_rows(self):
+        data = np.zeros((1, 1, 4, 1, 1), dtype=np.float32)
+        data[0, 0, 1, 0, 0] = 3.0  # odd index → Q (negated)
+        out = bs100bw_to_iq(data)
+        assert out[0, 0, 0, 0, 1] == -3.0  # Q channel negated
+
+    def test_wrong_ndim_raises(self):
+        with pytest.raises(ValueError, match="Expected shape"):
+            bs100bw_to_iq(np.zeros((2, 3, 8, 4)))
+
+    def test_wrong_last_dim_raises(self):
+        with pytest.raises(ValueError, match="Expected shape"):
+            bs100bw_to_iq(np.zeros((2, 3, 8, 4, 2)))
+
+    def test_odd_axial_dim_raises(self):
+        with pytest.raises(ValueError, match="Axial dimension must be even"):
+            bs100bw_to_iq(np.zeros((2, 3, 7, 4, 1), dtype=np.float32))
+
+    def test_int16_saturation_no_overflow(self):
+        data = np.full((1, 1, 2, 1, 1), -32768, dtype=np.int16)
+        out = bs100bw_to_iq(data)
+        # Q channel negation of -32768 would overflow in int16; must be 32768.0
+        assert out[0, 0, 0, 0, 1] == 32768.0
+        assert out.dtype == np.float32

--- a/zea/__main__.py
+++ b/zea/__main__.py
@@ -95,7 +95,7 @@ def main() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        args = tyro.cli(SubCmd)
+        args = tyro.cli(SubCmd)  # ty: ignore[no-matching-overload]
 
     from zea.internal.device import init_device
 

--- a/zea/__main__.py
+++ b/zea/__main__.py
@@ -95,7 +95,7 @@ def main() -> None:
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        args = tyro.cli(SubCmd)  # ty: ignore[no-matching-overload]
+        args = tyro.cli(SubCmd)
 
     from zea.internal.device import init_device
 

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -115,6 +115,12 @@ def estimate_lens_probe_params(
     """
     if lens_correction is None:
         return {}
+    if not (np.isfinite(lens_sound_speed) and lens_sound_speed > 0):
+        raise ValueError(f"lens_sound_speed must be finite and positive, got {lens_sound_speed!r}")
+    if not (np.isfinite(center_frequency) and center_frequency > 0):
+        raise ValueError(f"center_frequency must be finite and positive, got {center_frequency!r}")
+    if lens_correction < 0:
+        raise ValueError(f"lens_correction must be non-negative, got {lens_correction!r}")
     lens_thickness = np.float32(float(lens_correction) * lens_sound_speed / center_frequency)
     log.info(
         f"Lens: {float(lens_correction):.3f} wl → {float(lens_thickness) * 1e3:.3f} mm "
@@ -139,7 +145,12 @@ def bs100bw_to_iq(data: np.ndarray) -> np.ndarray:
     Returns:
         IQ array of shape ``(n_frames, n_tx, n_ax, n_el, 2)``.
     """
-    return np.stack([data[:, :, 0::2, :, 0], -data[:, :, 1::2, :, 0]], axis=-1)
+    if data.ndim != 5 or data.shape[-1] != 1:
+        raise ValueError(f"Expected shape (n_frames, n_tx, n_ax_raw, n_el, 1), got {data.shape}")
+    if data.shape[2] % 2 != 0:
+        raise ValueError(f"Axial dimension must be even for IQ deinterleaving, got {data.shape[2]}")
+    d = data.astype(np.float32)
+    return np.stack([d[:, :, 0::2, :, 0], -d[:, :, 1::2, :, 0]], axis=-1)
 
 
 def _validate_convert_config(data):
@@ -1112,7 +1123,7 @@ class VerasonicsFile(h5py.File):
             log.error(f"Could not read Verasonics ImgDataP buffer: {e}, skipping.")
 
         probe_dict = self.probe.to_probe_spec()
-        f_c = float(np.asarray(scan_dict["center_frequency"]).flat[0])
+        f_c = self.probe.center_frequency
         probe_dict.update(
             estimate_lens_probe_params(self.probe.lens_correction, f_c, lens_sound_speed)
         )
@@ -1185,6 +1196,7 @@ class VerasonicsFile(h5py.File):
         allow_accumulate=False,
         enable_compression=True,
         additional_functions=None,
+        lens_sound_speed: float = 1000.0,
     ):
         """Converts the Verasonics file to the zea format.
 
@@ -1204,6 +1216,10 @@ class VerasonicsFile(h5py.File):
             additional_functions (list, optional): A list of functions that read additional
                 data from the file. Each function should take the `VerasonicsFile` as input
                 and return a `CustomElement`. Defaults to None.
+            lens_sound_speed (float, optional): Speed of sound in the lens material in m/s.
+                Used to convert ``Trans.lensCorrection`` (wavelengths) into
+                ``lens_thickness`` and ``lens_sound_speed`` fields on the probe. Defaults
+                to 1000.0.
         """
         # Here we call all the functions to read the data from the file
         log.info("Reading Verasonics file...")
@@ -1211,6 +1227,7 @@ class VerasonicsFile(h5py.File):
             frames=frames,
             allow_accumulate=allow_accumulate,
             additional_functions=additional_functions,
+            lens_sound_speed=lens_sound_speed,
         )
 
         # Generate the zea dataset

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -82,6 +82,66 @@ _VERASONICS_TO_ZEA_PROBE_NAMES = {
 _FRAMES_RANGE_RE = re.compile(r"^\d+(-\d+)?$")
 
 
+def estimate_lens_probe_params(
+    lens_correction: float | None,
+    center_frequency: float,
+    lens_sound_speed: float = 1000.0,
+) -> dict:
+    """Return ProbeSpec lens fields derived from the Verasonics lens correction.
+
+    Converts the Verasonics one-way scalar delay (wavelengths) to a physical
+    ``(lens_thickness, lens_sound_speed)`` pair::
+
+        t_one_way = lens_correction / f_c  =  lens_thickness / lens_sound_speed
+        → lens_thickness = lens_correction × lens_sound_speed / f_c
+
+    The raw Verasonics value (``Trans.lensCorrection``) is a scalar one-way
+    delay offset in wavelengths applied uniformly across all elements.  It is
+    not directly compatible with zea's Fermat-based model, which solves the
+    refracted path per element–pixel pair via Newton-Raphson.
+
+    Args:
+        lens_correction (float or None): One-way delay through the lens in
+            wavelengths (``Trans.lensCorrection``).  Returns an empty dict
+            when ``None``.
+        center_frequency (float): Center frequency in Hz.
+        lens_sound_speed (float, optional): Speed of sound in the lens
+            material in m/s. Defaults to 1000.0.
+
+    Returns:
+        dict: ``{"lens_sound_speed": ..., "lens_thickness": ...}`` ready to
+        merge into a ProbeSpec dict, or ``{}`` when ``lens_correction`` is
+        ``None``.
+    """
+    if lens_correction is None:
+        return {}
+    lens_thickness = np.float32(float(lens_correction) * lens_sound_speed / center_frequency)
+    log.info(
+        f"Lens: {float(lens_correction):.3f} wl → {float(lens_thickness) * 1e3:.3f} mm "
+        f"(c_lens = {lens_sound_speed:.0f} m/s)"
+    )
+    return {
+        "lens_sound_speed": np.float32(lens_sound_speed),
+        "lens_thickness": lens_thickness,
+    }
+
+
+def bs100bw_to_iq(data: np.ndarray) -> np.ndarray:
+    """Convert BS100BW/BS50BW interleaved data to IQ format.
+
+    Both Verasonics baseband modes (BS100BW and BS50BW) interleave I and Q
+    samples along the axial axis: even samples are I, odd samples are Q
+    (negated).
+
+    Args:
+        data: Input array of shape ``(n_frames, n_tx, n_ax_raw, n_el, 1)``.
+
+    Returns:
+        IQ array of shape ``(n_frames, n_tx, n_ax, n_el, 2)``.
+    """
+    return np.stack([data[:, :, 0::2, :, 0], -data[:, :, 1::2, :, 0]], axis=-1)
+
+
 def _validate_convert_config(data):
     """Validate the structure of a convert.yaml config dict.
 
@@ -626,16 +686,8 @@ class VerasonicsFile(h5py.File):
         # Add channel dimension
         raw_data = raw_data[..., None]
 
-        # If the data is captured in BS100BW mode or BS50BW mode, the data is stored in
-        # as complex IQ data.
         if self.is_baseband_mode:
-            raw_data = np.concatenate(
-                (
-                    raw_data[:, :, 0::2, :, :],
-                    -raw_data[:, :, 1::2, :, :],
-                ),
-                axis=-1,
-            )
+            raw_data = bs100bw_to_iq(raw_data)
 
         return raw_data
 
@@ -977,6 +1029,7 @@ class VerasonicsFile(h5py.File):
         allow_accumulate=False,
         buffer_index=0,
         additional_functions=None,
+        lens_sound_speed: float = 1000.0,
     ):
         """Reads data from a .mat Verasonics output file.
 
@@ -992,6 +1045,11 @@ class VerasonicsFile(h5py.File):
             additional_functions (list, optional): A list of functions that read additional
                 data from the file. Each function should take the `VerasonicsFile` as input
                 and return a `CustomElement`. Defaults to None.
+            lens_sound_speed (float, optional): Speed of sound in the lens material in m/s.
+                Used to convert the Verasonics scalar lens correction (one-way delay in
+                wavelengths) into ``lens_thickness`` and ``lens_sound_speed`` fields on the
+                probe dict.  Only applied when the file contains a ``lensCorrection`` field.
+                Defaults to 1000.0.
         """
 
         if additional_functions is None:
@@ -1053,7 +1111,13 @@ class VerasonicsFile(h5py.File):
         except Exception as e:
             log.error(f"Could not read Verasonics ImgDataP buffer: {e}, skipping.")
 
-        return {"raw_data": raw_data}, scan_dict, custom_elements
+        probe_dict = self.probe.to_probe_spec()
+        f_c = float(np.asarray(scan_dict["center_frequency"]).flat[0])
+        probe_dict.update(
+            estimate_lens_probe_params(self.probe.lens_correction, f_c, lens_sound_speed)
+        )
+
+        return {"raw_data": raw_data}, scan_dict, probe_dict, custom_elements
 
     def _parse_frames_argument(self, frames, n_frames):
         value_error = ValueError(
@@ -1143,7 +1207,7 @@ class VerasonicsFile(h5py.File):
         """
         # Here we call all the functions to read the data from the file
         log.info("Reading Verasonics file...")
-        data_dict, scan_dict, custom_elements = self.read_verasonics_file(
+        data_dict, scan_dict, probe_dict, custom_elements = self.read_verasonics_file(
             frames=frames,
             allow_accumulate=allow_accumulate,
             additional_functions=additional_functions,
@@ -1156,7 +1220,7 @@ class VerasonicsFile(h5py.File):
             path=output_path,
             data=data_dict,
             scan=scan_dict,
-            probe=self.probe.to_probe_spec(),
+            probe=probe_dict,
             description="Verasonics data",
             custom=custom_elements,
             compression=compression,

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -119,8 +119,10 @@ def estimate_lens_probe_params(
         raise ValueError(f"lens_sound_speed must be finite and positive, got {lens_sound_speed!r}")
     if not (np.isfinite(center_frequency) and center_frequency > 0):
         raise ValueError(f"center_frequency must be finite and positive, got {center_frequency!r}")
-    if lens_correction < 0:
-        raise ValueError(f"lens_correction must be non-negative, got {lens_correction!r}")
+    if not (np.isfinite(lens_correction) and lens_correction >= 0):
+        raise ValueError(
+            f"lens_correction must be finite and non-negative, got {lens_correction!r}"
+        )
     lens_thickness = np.float32(float(lens_correction) * lens_sound_speed / center_frequency)
     log.info(
         f"Lens: {float(lens_correction):.3f} wl → {float(lens_thickness) * 1e3:.3f} mm "


### PR DESCRIPTION
Solves #441 in a more elegant way. 

Added:
- `zea.data.convert.verasonics.estimate_lens_probe_params`
- `zea.data.convert.verasonics.bs100bw_to_iq`

Changed:
- Return of `VerasonicsFile.read_verasonics_file` now also includes probe dict.

See how it affects conversion script here: https://github.com/open-h/OpenH-RF/pull/22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added lens-correction support to Verasonics file conversion with a configurable lens sound speed parameter
  * Improved baseband IQ conversion with enhanced input validation and error handling

* **Tests**
  * Added comprehensive unit test coverage for lens parameter estimation and IQ conversion functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->