### PR TITLE
Add bmi to zea file spec

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -1028,6 +1028,11 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - scalar
               - Subject fat percentage.
               - |badge-opt|
+            * - ``bmi``
+              - ``float32``
+              - scalar
+              - Subject body mass index.
+              - |badge-opt|
 
 
       .. _spec-meta-annotations:

--- a/docs/source/_units_ref.rst
+++ b/docs/source/_units_ref.rst
@@ -38,4 +38,6 @@ A unit of ``–`` denotes a unitless (dimensionless) quantity.
      - count
    * - ``%``
      - percent
+   * - ``kg/m²``
+     - kilograms per square meter
 

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -946,6 +946,28 @@ class TestMetadataAndMetricsValidationErrors:
         with pytest.raises(TypeError, match="age"):
             Subject(age="forty two")
 
+    def test_subject_bmi_out_of_range_raises(self):
+        """bmi must be within the physically-possible range (0, 100]."""
+        with pytest.raises(ValueError, match="BMI"):
+            Subject(bmi=np.float32(150.0))
+        with pytest.raises(ValueError, match="BMI"):
+            Subject(bmi=np.float32(0.0))
+        with pytest.raises(ValueError, match="BMI"):
+            Subject(bmi=np.float32(-1.0))
+
+    def test_subject_bmi_valid(self):
+        """A sensible bmi value passes validation without warning."""
+        with patch("zea.log.warning") as mock_warn:
+            subject = Subject(bmi=np.float32(23.4))
+        assert subject.bmi == np.float32(23.4)
+        assert not any("BMI" in str(c.args[0]) for c in mock_warn.call_args_list)
+
+    def test_subject_bmi_unusual_warns(self):
+        """Values outside the typical clinical range warn but do not raise."""
+        with patch("zea.log.warning") as mock_warn:
+            Subject(bmi=np.float32(75.0))
+        assert any("BMI" in str(c.args[0]) for c in mock_warn.call_args_list)
+
     def test_signal_missing_required_field_raises(self):
         """Signal1D requires either sampling_frequency or timestamps."""
         with pytest.raises(ValueError, match="sampling_frequency|timestamps"):
@@ -1342,6 +1364,7 @@ class TestSubjectFieldWarnings:
                 age=np.uint8(42),
                 sex="f",
                 fat_percentage=np.float32(17.5),
+                bmi=np.float32(23.4),
             )
         messages = [str(c.args[0]) for c in mock_warn.call_args_list]
         assert not any("Optional Subject field" in m for m in messages)

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1574,6 +1574,8 @@ class Subject(Spec):
             )
 
         if self.bmi is not None:
+            if not np.isfinite(self.bmi):
+                raise ValueError(f"Subject BMI must be finite, got {self.bmi}")
             if self.bmi <= 0 or self.bmi > 100:
                 raise ValueError(f"Subject BMI must be between 0 and 100, got {self.bmi}")
             if self.bmi < 10 or self.bmi > 60:

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -27,6 +27,7 @@ UNITS = {
     "dB": "decibels",
     "#": "count",
     "%": "percent",
+    "kg/m²": "kilograms per square meter",
 }
 
 DEFAULT_COMPRESSION = "lzf"
@@ -1531,6 +1532,7 @@ class Subject(Spec):
         age: Subject age in years.
         sex: Subject sex.
         fat_percentage: Subject fat percentage.
+        bmi: Subject body mass index in kg/m².
     """
 
     id: str | None = None
@@ -1538,6 +1540,7 @@ class Subject(Spec):
     age: np.uint8 | None = None
     sex: str | None = None
     fat_percentage: np.float32 | None = None
+    bmi: np.float32 | None = None
 
     SCHEMA = {
         "id": {"dtype": str, "shape": ()},
@@ -1545,6 +1548,7 @@ class Subject(Spec):
         "age": {"dtype": np.uint8, "shape": ()},
         "sex": {"dtype": str, "shape": ()},
         "fat_percentage": {"dtype": np.float32, "shape": ()},
+        "bmi": {"dtype": np.float32, "shape": ()},
     }
 
     FIELD_METADATA = {
@@ -1553,6 +1557,7 @@ class Subject(Spec):
         "age": {"unit": "–", "description": "Subject age in years.", "rare": True},
         "sex": {"unit": "–", "description": "Subject sex.", "rare": True},
         "fat_percentage": {"unit": "%", "description": "Subject fat percentage.", "rare": True},
+        "bmi": {"unit": "kg/m²", "description": "Subject body mass index.", "rare": True},
     }
 
     def __post_init__(self):
@@ -1567,6 +1572,15 @@ class Subject(Spec):
             raise ValueError(
                 f"Subject fat percentage must be between 0 and 100, got {self.fat_percentage}"
             )
+
+        if self.bmi is not None:
+            if self.bmi <= 0 or self.bmi > 100:
+                raise ValueError(f"Subject BMI must be between 0 and 100, got {self.bmi}")
+            if self.bmi < 10 or self.bmi > 60:
+                log.warning(
+                    f"Subject BMI of {self.bmi} kg/m² is outside the typical clinical range "
+                    "(10-60). Please verify the value and that it is in kg/m²."
+                )
 
 
 @dataclass


### PR DESCRIPTION
Per request adding BMI to subject field of the zea data file spec.

### How to test
Try saving BMI during `zea.File.create` (test some value ranges).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional BMI field to subject metadata.
  * Documented the new `kg/m²` unit in the units reference.
* **Bug Fixes**
  * Added BMI validation: rejects non-finite and out-of-range values with errors.
  * Emits warnings for unusual (but non-fatal) BMI values outside the typical range.
* **Tests**
  * Expanded test coverage for BMI validation behavior and updated subject-field tests to include BMI.
* **Documentation**
  * Updated the subject metadata specification to include BMI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->