### PR TITLE
Improved links on docs data page

### DIFF
--- a/docs/_static/open-anchor-dropdown.js
+++ b/docs/_static/open-anchor-dropdown.js
@@ -1,25 +1,61 @@
 /**
- * Auto-open a sphinx-design dropdown when navigating to its anchor.
- * Handles both page-load with a hash and same-page hash changes (↓ links).
+ * Make sphinx-design tabs and dropdowns deep-linkable.
+ *
+ * When navigating to an anchor (on page load or via a same-page hash change)
+ * this:
+ *   1. selects the tab if the anchor is a tab label (e.g. ``#group-metadata``);
+ *   2. selects any enclosing tab(s) so a target nested inside a tab panel is
+ *      revealed (e.g. ``#spec-meta-subject`` lives in the ``metadata`` tab);
+ *   3. opens the target dropdown (or a dropdown following the anchor span).
  */
 (function () {
-    function openDropdownForHash(hash) {
-        if (!hash) return;
-        const id = decodeURIComponent(hash.startsWith('#') ? hash.slice(1) : hash);
-        const target = document.getElementById(id);
-        if (!target) return;
+    var TAB_STORAGE_PREFIX = 'sphinx-design-tab-id-';
 
+    function activateTab(label) {
+        // ``label`` is a <label class="sd-tab-label"> immediately preceded by
+        // its radio <input>. Checking that input selects the tab.
+        var input = label.previousElementSibling;
+        if (!input || input.tagName !== 'INPUT') return;
+        input.checked = true;
+
+        // Keep sphinx-design's session-storage sync in agreement, otherwise it
+        // may re-select a different tab on the next page load.
+        var group = label.getAttribute('data-sync-group');
+        var id = label.getAttribute('data-sync-id');
+        if (group && id) {
+            try {
+                window.sessionStorage.setItem(TAB_STORAGE_PREFIX + group, id);
+            } catch (e) {
+                /* sessionStorage may be unavailable; selection still works */
+            }
+        }
+    }
+
+    function activateAncestorTabs(el) {
+        // Walk up through any enclosing tab panels, selecting each so that
+        // ``el`` becomes visible. Supports nested tab-sets.
+        var content = el.closest ? el.closest('.sd-tab-content') : null;
+        while (content) {
+            var label = content.previousElementSibling; // <label> precedes content
+            if (label && label.classList.contains('sd-tab-label')) {
+                activateTab(label);
+            }
+            content = content.parentElement
+                ? content.parentElement.closest('.sd-tab-content')
+                : null;
+        }
+    }
+
+    function openDropdown(target) {
         // The label may resolve to the <details> itself, to a wrapper <div>
         // containing it, or to a preceding <span> anchor.
-        let details =
-            target.tagName === 'DETAILS'
-                ? target
-                : target.querySelector('details');
+        var details =
+            target.tagName === 'DETAILS' ? target : target.querySelector('details');
 
         if (!details) {
             // Sphinx sometimes renders the explicit label as a <span id="...">
             // that precedes the directive container in the DOM.
-            let sib = target.nextElementSibling;
+            var sib = target.nextElementSibling;
             while (sib && !details) {
                 details =
                     sib.tagName === 'DETAILS' ? sib : sib.querySelector('details');
@@ -30,11 +66,96 @@
         if (details) details.open = true;
     }
 
+    function handleHash(hash) {
+        if (!hash) return;
+        var id = decodeURIComponent(hash.charAt(0) === '#' ? hash.slice(1) : hash);
+        var target = document.getElementById(id);
+        if (!target) return;
+
+        if (target.classList.contains('sd-tab-label')) {
+            // The anchor is a tab itself — select it (and any outer tabs).
+            activateTab(target);
+            activateAncestorTabs(target);
+        } else {
+            // Reveal the target if it lives inside one or more tab panels,
+            // then open it if it is (or precedes) a dropdown.
+            activateAncestorTabs(target);
+            openDropdown(target);
+        }
+
+        // Re-scroll now that tabs/dropdowns have expanded.
+        if (target.scrollIntoView) target.scrollIntoView();
+    }
+
+    function updateHash(id) {
+        // Reflect the current tab in the address bar so it can be copied and
+        // shared, without scrolling or polluting the back/forward history.
+        var newHash = '#' + id;
+        if (window.location.hash === newHash) return;
+        if (window.history && window.history.replaceState) {
+            window.history.replaceState(null, '', newHash);
+        } else {
+            window.location.hash = id;
+        }
+    }
+
+    function wireTabHashSync() {
+        // When a named tab is selected, update the URL to its anchor.
+        document.querySelectorAll('label.sd-tab-label[id]').forEach(function (label) {
+            label.addEventListener('click', function () {
+                updateHash(label.id);
+            });
+        });
+    }
+
+    function accordionGroupOf(details) {
+        // A dropdown belongs to an accordion group if it carries a
+        // ``dropdown-accordion-<group>`` class (set via :class-container:).
+        for (var i = 0; i < details.classList.length; i++) {
+            if (details.classList[i].indexOf('dropdown-accordion-') === 0) {
+                return details.classList[i];
+            }
+        }
+        return null;
+    }
+
+    function wireDropdownAccordions() {
+        // Make grouped dropdowns behave like tabs: opening one closes the
+        // others in its group and updates the URL to the open panel's anchor.
+        var groups = {};
+        document
+            .querySelectorAll('details[class*="dropdown-accordion-"]')
+            .forEach(function (details) {
+                var group = accordionGroupOf(details);
+                if (!group) return;
+                (groups[group] = groups[group] || []).push(details);
+            });
+
+        Object.keys(groups).forEach(function (group) {
+            var members = groups[group];
+            members.forEach(function (details) {
+                details.addEventListener('toggle', function () {
+                    if (!details.open) return;
+                    members.forEach(function (other) {
+                        if (other !== details && other.open) other.open = false;
+                    });
+                    if (details.id) updateHash(details.id);
+                });
+            });
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
-        openDropdownForHash(window.location.hash);
+        wireTabHashSync();
+        wireDropdownAccordions();
+        // Defer so this runs after sphinx-design's own tab session-restore
+        // (both register DOMContentLoaded listeners).
+        window.setTimeout(function () {
+            handleHash(window.location.hash);
+        }, 0);
     });
 
     window.addEventListener('hashchange', function () {
-        openDropdownForHash(window.location.hash);
+        handleHash(window.location.hash);
     });
 })();

--- a/docs/_static/open-anchor-dropdown.js
+++ b/docs/_static/open-anchor-dropdown.js
@@ -46,21 +46,28 @@
         }
     }
 
+    function dropdownIn(el) {
+        // Resolve ``el`` to a sphinx-design dropdown: the <details.sd-dropdown>
+        // itself or one wrapped inside it. Plain <details> (or unrelated
+        // elements) are ignored so we never expand non-dropdown content.
+        if (!el) return null;
+        if (el.tagName === 'DETAILS') {
+            return el.classList.contains('sd-dropdown') ? el : null;
+        }
+        return el.querySelector ? el.querySelector('details.sd-dropdown') : null;
+    }
+
     function openDropdown(target) {
-        // The label may resolve to the <details> itself, to a wrapper <div>
-        // containing it, or to a preceding <span> anchor.
-        var details =
-            target.tagName === 'DETAILS' ? target : target.querySelector('details');
+        // The label may resolve to the dropdown's <details> itself or to a
+        // wrapper <div> containing it.
+        var details = dropdownIn(target);
 
         if (!details) {
             // Sphinx sometimes renders the explicit label as a <span id="...">
-            // that precedes the directive container in the DOM.
-            var sib = target.nextElementSibling;
-            while (sib && !details) {
-                details =
-                    sib.tagName === 'DETAILS' ? sib : sib.querySelector('details');
-                sib = sib.nextElementSibling;
-            }
+            // immediately preceding the dropdown's directive container. Only
+            // the adjacent sibling qualifies — walking further could match an
+            // unrelated dropdown later in the document for an ordinary anchor.
+            details = dropdownIn(target.nextElementSibling);
         }
 
         if (details) details.open = true;

--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -100,6 +100,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
    .. tab-item:: data
       :sync: data
+      :name: group-data
 
       Data group containing raw channel data, derived pipeline products,
       and optional grouped data products.
@@ -759,6 +760,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
    .. tab-item:: scan
       :sync: scan
+      :name: group-scan
 
       Scan group with acquisition and transmit sequence parameters.
 
@@ -865,6 +867,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
    .. tab-item:: probe
       :sync: probe
+      :name: group-probe
 
       Probe group with probe geometry and frequency parameters.
 
@@ -935,6 +938,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
    .. tab-item:: metadata
       :sync: metadata
+      :name: group-metadata
 
       Optional metadata group for subject, acquisition context, annotations,
       and extra time-series signals (ECG, voice narration, probe orientation).
@@ -1165,6 +1169,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
    .. tab-item:: metrics
       :sync: metrics
+      :name: group-metrics
 
       Optional metrics group for acquisition-level quality and performance metrics.
 

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -350,6 +350,8 @@ that do not fit the standard scan and probe fields can be stored as **custom ele
 see below:
 
 .. dropdown:: Custom spatial maps (``data`` group)
+   :name: custom-spatial-maps
+   :class-container: dropdown-accordion-custom-fields
 
    A custom map is a named entry in the ``data`` group that associates a pixel array with a
    per-pixel Cartesian coordinate grid.  Each map is then a function from Cartesian space to
@@ -407,6 +409,8 @@ see below:
       docstrings for full details.
 
 .. dropdown:: Custom metadata (``metadata`` group)
+   :name: custom-metadata
+   :class-container: dropdown-accordion-custom-fields
 
    Standard metadata fields (``credit``, ``annotations``, ``text_report``, ``subject``, ``ecg``, …)
    are validated by :class:`~zea.data.spec.MetadataSpec`.  Pass a plain dict to ``File.create``'s
@@ -486,6 +490,8 @@ see below:
    See :class:`~zea.data.spec.MetadataSpec` for the full list of supported standard fields.
 
 .. dropdown:: Custom elements (``custom`` group)
+   :name: custom-elements
+   :class-container: dropdown-accordion-custom-fields
 
    Sometimes you need to store data that does not fit the zea spec at all — neither a spatial map
    nor a metadata signal. Use :class:`~zea.data.CustomElement` for this: a named array (or

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -417,6 +417,7 @@ def generate() -> str:
     lines += [
         "   .. tab-item:: data",
         "      :sync: data",
+        "      :name: group-data",
         "",
         "      Data group containing raw channel data, derived pipeline products,",
         "      and optional grouped data products.",
@@ -471,6 +472,7 @@ def generate() -> str:
     lines += [
         "   .. tab-item:: scan",
         "      :sync: scan",
+        "      :name: group-scan",
         "",
         "      Scan group with acquisition and transmit sequence parameters.",
         "",
@@ -481,6 +483,7 @@ def generate() -> str:
     lines += [
         "   .. tab-item:: probe",
         "      :sync: probe",
+        "      :name: group-probe",
         "",
         "      Probe group with probe geometry and frequency parameters.",
         "",
@@ -491,6 +494,7 @@ def generate() -> str:
     lines += [
         "   .. tab-item:: metadata",
         "      :sync: metadata",
+        "      :name: group-metadata",
         "",
         "      Optional metadata group for subject, acquisition context, annotations,",
         "      and extra time-series signals (ECG, voice narration, probe orientation).",
@@ -526,6 +530,7 @@ def generate() -> str:
     lines += [
         "   .. tab-item:: metrics",
         "      :sync: metrics",
+        "      :name: group-metrics",
         "",
         "      Optional metrics group for acquisition-level quality and performance metrics.",
         "",


### PR DESCRIPTION
When navigating through the file spec, url is being updated so you can share to more finegrained locations in the docs. Test it for the group reference tab and custom fields tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved documentation navigation so deep links can open the correct tabs, nested tab sets, and dropdown sections from a URL.
  * Clicking tab labels or grouped dropdowns now updates the page address for easier sharing and bookmarking.
  * Added consistent anchor names to several reference tabs and accordion sections to support reliable links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->