### PR TITLE
Adding attenuation map to spec

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -524,7 +524,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``attenuation_map``
 
-         Acoustic attenuation coefficient map in dB/cm/MHz (frequency-normalized). Values are ``float32``.
+         Acoustic attenuation coefficient map in dB/m/Hz (frequency-normalized), with a scalar power-law exponent ``gamma`` (alpha(f) = alpha_0 * f**gamma; default 1.0). Values are ``float32``.
 
          .. list-table::
             :header-rows: 1
@@ -579,6 +579,11 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - ``float32``
               - scalar
               - Maximum value of the map.
+              - |badge-opt|
+            * - ``gamma``
+              - ``float32``
+              - scalar
+              - Power-law exponent of the frequency dependence alpha(f) = alpha_0 * f**gamma. 1.0 is linear (soft tissue ~1-1.5, e.g. liver ~1.14), 2.0 for water.
               - |badge-opt|
 
       .. _spec-data-strain-percentage-map:

--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -23,6 +23,7 @@ See the :ref:`group reference <group-reference>` for a full description of each 
    │   ├── image/                    group (Image)
    │   ├── segmentation/             group (Segmentation)
    │   ├── sos_map/                  group (SosMap)
+   │   ├── attenuation_map/          group (AttenuationMap)
    │   ├── strain_percentage_map/    group (StrainPercentageMap)
    │   ├── tissue_doppler/           group (TissueDopplerMap)
    │   ├── color_doppler/            group (ColorDopplerMap)
@@ -149,6 +150,11 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
            - :class:`~zea.data.spec.SosMap`
            - group
            - Speed-of-sound map data.
+           - |badge-opt|
+         * - ``attenuation_map`` :ref:`↓ <spec-data-attenuation-map>`
+           - :class:`~zea.data.spec.AttenuationMap`
+           - group
+           - Acoustic attenuation map data.
            - |badge-opt|
          * - ``strain_percentage_map`` :ref:`↓ <spec-data-strain-percentage-map>`
            - :class:`~zea.data.spec.StrainPercentageMap`
@@ -457,6 +463,67 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
       .. dropdown:: ``sos_map``
 
          Speed-of-sound map in m/s. Values are ``float32``.
+
+         .. list-table::
+            :header-rows: 1
+            :widths: 22 16 22 30 10
+         
+            * - Field
+              - Type
+              - Shape
+              - Description
+              - 
+            * - ``values``
+              - ``float32``
+              - (n_frames, z, x, y, n_spatial_ch) or (n_frames, z, x, y) or (n_frames, z, x, n_spatial_ch) or (n_frames, z, x)
+              - Map pixel values.
+              - |badge-req|
+            * - ``coordinates``
+              - ``float32``
+              - (..., 3)
+              - Per-pixel Cartesian positions (x, y, z) in metres.
+              - |badge-opt|
+            * - ``timestamps``
+              - ``float32``
+              - (n_frames)
+              - Per-frame acquisition timestamps relative to frame 0.
+              - |badge-opt|
+            * - ``start_time_offset``
+              - ``float32``
+              - scalar
+              - Time offset between the first transmit event of the ultrasound acquisition and frame 0 of this map. Negative means frame 0 was acquired before the first transmit event; positive means it was acquired after.
+              - |badge-opt|
+            * - ``labels``
+              - ``str``
+              - (n_spatial_ch)
+              - Labels for each channel in values.
+              - |badge-opt|
+            * - ``description``
+              - ``str``
+              - scalar
+              - Free-text description of the map contents.
+              - |badge-opt|
+            * - ``unit``
+              - ``str``
+              - scalar
+              - Physical unit of the map values, e.g. 'm/s', '%'.
+              - |badge-opt|
+            * - ``min``
+              - ``float32``
+              - scalar
+              - Minimum value of the map.
+              - |badge-opt|
+            * - ``max``
+              - ``float32``
+              - scalar
+              - Maximum value of the map.
+              - |badge-opt|
+
+      .. _spec-data-attenuation-map:
+
+      .. dropdown:: ``attenuation_map``
+
+         Acoustic attenuation coefficient map in dB/cm/MHz (frequency-normalized). Values are ``float32``.
 
          .. list-table::
             :header-rows: 1

--- a/docs/source/_units_ref.rst
+++ b/docs/source/_units_ref.rst
@@ -34,6 +34,8 @@ A unit of ``–`` denotes a unitless (dimensionless) quantity.
      - radians
    * - ``dB``
      - decibels
+   * - ``dB/cm/MHz``
+     - decibels per centimeter per megahertz
    * - ``#``
      - count
    * - ``%``

--- a/docs/source/_units_ref.rst
+++ b/docs/source/_units_ref.rst
@@ -34,8 +34,8 @@ A unit of ``–`` denotes a unitless (dimensionless) quantity.
      - radians
    * - ``dB``
      - decibels
-   * - ``dB/cm/MHz``
-     - decibels per centimeter per megahertz
+   * - ``dB/m/Hz``
+     - decibels per meter per hertz
    * - ``#``
      - count
    * - ``%``

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -20,6 +20,7 @@ from zea.data.spec import (
     UNITS,
     AlignedData,
     Annotations,
+    AttenuationMap,
     BeamformedData,
     ColorDopplerMap,
     DataSpec,
@@ -248,6 +249,7 @@ FILE_TREE = """\
    \u2502   \u251c\u2500\u2500 image/                    group (Image)
    \u2502   \u251c\u2500\u2500 segmentation/             group (Segmentation)
    \u2502   \u251c\u2500\u2500 sos_map/                  group (SosMap)
+   \u2502   \u251c\u2500\u2500 attenuation_map/          group (AttenuationMap)
    \u2502   \u251c\u2500\u2500 strain_percentage_map/    group (StrainPercentageMap)
    \u2502   \u251c\u2500\u2500 tissue_doppler/           group (TissueDopplerMap)
    \u2502   \u251c\u2500\u2500 color_doppler/            group (ColorDopplerMap)
@@ -316,6 +318,7 @@ DATA_SUBGROUP_ANCHORS = {
     "image": "spec-data-image",
     "segmentation": "spec-data-segmentation",
     "sos_map": "spec-data-sos-map",
+    "attenuation_map": "spec-data-attenuation-map",
     "strain_percentage_map": "spec-data-strain-percentage-map",
     "shear_wave_elastography_map": "spec-data-shear-wave-elastography-map",
     "tissue_doppler": "spec-data-tissue-doppler",
@@ -338,6 +341,7 @@ MAP_DESCRIPTIONS = {
     "image": "Reconstructed (log-compressed) image. Values are ``uint8`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
     "segmentation": "Semantic segmentation mask. Values are ``bool`` in (n_frames, z, x, y, n_labels); ``labels`` names each channel.",  # noqa: E501
     "sos_map": "Speed-of-sound map in m/s. Values are ``float32``.",
+    "attenuation_map": "Acoustic attenuation coefficient map in dB/cm/MHz (frequency-normalized). Values are ``float32``.",  # noqa: E501
     "strain_percentage_map": "Strain map in %. Values are ``float32``.",
     "shear_wave_elastography_map": "Shear-wave elastography map in m/s. Values are ``float32``.",
     "tissue_doppler": "Tissue Doppler velocity map in m/s. Values are ``float32``.",
@@ -445,6 +449,7 @@ def generate() -> str:
         ("image", Image),
         ("segmentation", Segmentation),
         ("sos_map", SosMap),
+        ("attenuation_map", AttenuationMap),
         ("strain_percentage_map", StrainPercentageMap),
         ("shear_wave_elastography_map", ShearWaveElastographyMap),
         ("tissue_doppler", TissueDopplerMap),

--- a/docs/source/spec_doc.py
+++ b/docs/source/spec_doc.py
@@ -341,7 +341,7 @@ MAP_DESCRIPTIONS = {
     "image": "Reconstructed (log-compressed) image. Values are ``uint8`` in (n_frames, z, x) or (n_frames, z, x, y).",  # noqa: E501
     "segmentation": "Semantic segmentation mask. Values are ``bool`` in (n_frames, z, x, y, n_labels); ``labels`` names each channel.",  # noqa: E501
     "sos_map": "Speed-of-sound map in m/s. Values are ``float32``.",
-    "attenuation_map": "Acoustic attenuation coefficient map in dB/cm/MHz (frequency-normalized). Values are ``float32``.",  # noqa: E501
+    "attenuation_map": "Acoustic attenuation coefficient map in dB/m/Hz (frequency-normalized), with a scalar power-law exponent ``gamma`` (alpha(f) = alpha_0 * f**gamma; default 1.0). Values are ``float32``.",  # noqa: E501
     "strain_percentage_map": "Strain map in %. Values are ``float32``.",
     "shear_wave_elastography_map": "Shear-wave elastography map in m/s. Values are ``float32``.",
     "tissue_doppler": "Tissue Doppler velocity map in m/s. Values are ``float32``.",

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -166,7 +166,7 @@ def _example_data(n_frames, n_tx, n_el, n_ax, n_ch):
             "coordinates": coords_3d,
         },
         "attenuation_map": {
-            "values": np.full((n_frames, 16, 12, 1), 0.5, dtype=np.float32),
+            "values": np.full((n_frames, 16, 12, 1), 5e-5, dtype=np.float32),
             "coordinates": coords_3d,
         },
         "strain": {
@@ -819,31 +819,68 @@ class TestDataValidationErrors:
             )
 
     def test_attenuation_map_rejects_wrong_unit(self):
-        """AttenuationMap enforces a canonical unit of dB/cm/MHz."""
-        with pytest.raises(ValueError, match="Attenuation map unit should be 'dB/cm/MHz'"):
+        """AttenuationMap enforces a canonical unit of dB/m/Hz (not clinical dB/cm/MHz)."""
+        with pytest.raises(ValueError, match="Attenuation map unit should be 'dB/m/Hz'"):
             AttenuationMap(
-                values=np.full((2, 16, 12, 1), 0.5, dtype=np.float32),
+                values=np.full((2, 16, 12, 1), 5e-5, dtype=np.float32),
                 coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
-                unit="dB/cm",
+                unit="dB/cm/MHz",
             )
 
     def test_attenuation_map_accepts_canonical_unit(self):
-        """AttenuationMap accepts float32 values with the dB/cm/MHz unit."""
+        """AttenuationMap accepts float32 values with the dB/m/Hz unit."""
         att = AttenuationMap(
-            values=np.full((2, 16, 12, 1), 0.7, dtype=np.float32),
+            values=np.full((2, 16, 12, 1), 7e-5, dtype=np.float32),
             coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
-            unit="dB/cm/MHz",
+            unit="dB/m/Hz",
         )
         assert att.values.dtype == np.float32
+
+    def test_attenuation_map_gamma_defaults_to_linear(self):
+        """gamma defaults to 1.0 (linear frequency dependence) and is stored as float32."""
+        att = AttenuationMap(
+            values=np.full((2, 16, 12, 1), 5e-5, dtype=np.float32),
+            coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+        )
+        assert att.gamma == 1.0
+        assert np.dtype(np.asarray(att.gamma).dtype) == np.float32
+
+    def test_attenuation_map_accepts_gamma(self):
+        """A non-linear power-law exponent (e.g. water gamma=2) is accepted and cast to float32."""
+        att = AttenuationMap(
+            values=np.full((2, 16, 12, 1), 5e-5, dtype=np.float32),
+            coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+            gamma=2.0,
+        )
+        assert att.gamma == np.float32(2.0)
+
+    def test_attenuation_map_warns_on_implausible_gamma(self):
+        """A power-law exponent outside the physically typical (0, 2] range warns."""
+        with patch.object(spec_module.log, "warning") as mock_warning:
+            AttenuationMap(
+                values=np.full((2, 16, 12, 1), 5e-5, dtype=np.float32),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+                gamma=3.0,
+            )
+        assert any("gamma" in str(c) for c in mock_warning.call_args_list)
+
+    def test_attenuation_map_warns_on_clinical_unit_magnitude(self):
+        """Values sized like dB/cm/MHz (~0.5) are far too large for dB/m/Hz and warn."""
+        with patch.object(spec_module.log, "warning") as mock_warning:
+            AttenuationMap(
+                values=np.full((2, 16, 12, 1), 0.5, dtype=np.float32),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+            )
+        assert any("dB/m/Hz" in str(c) for c in mock_warning.call_args_list)
 
     def test_attenuation_map_warns_on_negative_values(self):
         """Negative attenuation coefficients are physically unexpected and warn."""
         with patch.object(spec_module.log, "warning") as mock_warning:
             AttenuationMap(
-                values=np.full((2, 16, 12, 1), -0.5, dtype=np.float32),
+                values=np.full((2, 16, 12, 1), -5e-5, dtype=np.float32),
                 coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
             )
-        assert any("Attenuation map" in str(c) for c in mock_warning.call_args_list)
+        assert any("negative values" in str(c) for c in mock_warning.call_args_list)
 
     def test_image_wrong_pixel_dtype_raises(self):
         """Image is UnsignedIntMap – values must be float32 or uint8, not complex128."""

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -9,6 +9,7 @@ from zea.data import spec as spec_module
 from zea.data.file import File
 from zea.data.spec import (
     Annotations,
+    AttenuationMap,
     DataSpec,
     FileSpec,
     Image,
@@ -161,6 +162,10 @@ def _example_data(n_frames, n_tx, n_el, n_ax, n_ch):
         },
         "sos_map": {
             "values": np.full((n_frames, 16, 12, 1), 1540.0, dtype=np.float32),
+            "coordinates": coords_3d,
+        },
+        "attenuation_map": {
+            "values": np.full((n_frames, 16, 12, 1), 0.5, dtype=np.float32),
             "coordinates": coords_3d,
         },
         "strain": {
@@ -811,6 +816,33 @@ class TestDataValidationErrors:
                 values=np.zeros((2, 16, 12, 1), dtype=np.uint8),
                 coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
             )
+
+    def test_attenuation_map_rejects_wrong_unit(self):
+        """AttenuationMap enforces a canonical unit of dB/cm/MHz."""
+        with pytest.raises(ValueError, match="Attenuation map unit should be 'dB/cm/MHz'"):
+            AttenuationMap(
+                values=np.full((2, 16, 12, 1), 0.5, dtype=np.float32),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+                unit="dB/cm",
+            )
+
+    def test_attenuation_map_accepts_canonical_unit(self):
+        """AttenuationMap accepts float32 values with the dB/cm/MHz unit."""
+        att = AttenuationMap(
+            values=np.full((2, 16, 12, 1), 0.7, dtype=np.float32),
+            coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+            unit="dB/cm/MHz",
+        )
+        assert att.values.dtype == np.float32
+
+    def test_attenuation_map_warns_on_negative_values(self):
+        """Negative attenuation coefficients are physically unexpected and warn."""
+        with patch.object(spec_module.log, "warning") as mock_warning:
+            AttenuationMap(
+                values=np.full((2, 16, 12, 1), -0.5, dtype=np.float32),
+                coordinates=np.zeros((2, 16, 12, 3), dtype=np.float32),
+            )
+        assert any("Attenuation map" in str(c) for c in mock_warning.call_args_list)
 
     def test_image_wrong_pixel_dtype_raises(self):
         """Image is UnsignedIntMap – values must be float32 or uint8, not complex128."""

--- a/zea/data/app.py
+++ b/zea/data/app.py
@@ -81,6 +81,7 @@ _DATA_KEYS = [
     "data/image/values",
     "data/segmentation/values",
     "data/sos_map/values",
+    "data/attenuation_map/values",
 ]
 
 # ── Presets ───────────────────────────────────────────────────────────────────

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -240,6 +240,7 @@ if TYPE_CHECKING:
         image: _SpatialMapProxy
         segmentation: _SpatialMapProxy
         sos_map: _SpatialMapProxy
+        attenuation_map: _SpatialMapProxy
         strain_percentage_map: _SpatialMapProxy
         shear_wave_elastography_map: _SpatialMapProxy
         tissue_doppler: _SpatialMapProxy

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -25,7 +25,7 @@ UNITS = {
     "–": "unitless",
     "rad": "radians",
     "dB": "decibels",
-    "dB/cm/MHz": "decibels per centimeter per megahertz",
+    "dB/m/Hz": "decibels per meter per hertz",
     "#": "count",
     "%": "percent",
     "kg/m²": "kilograms per square meter",
@@ -985,33 +985,91 @@ class SosMap(FloatMap):
 class AttenuationMap(FloatMap):
     """Acoustic attenuation map with per-pixel Cartesian coordinates.
 
-    Holds the frequency-normalized acoustic attenuation coefficient (the
-    "attenuation coefficient slope") in dB/cm/MHz. Acoustic attenuation describes
-    the loss of acoustic energy as the wave propagates through tissue (through
-    absorption and scattering). Because attenuation increases approximately
-    linearly with frequency, it is conventionally reported normalized by frequency
-    so that values are comparable across systems and transmit frequencies.
+    Acoustic attenuation describes the loss of acoustic energy as the wave
+    propagates through tissue (through absorption and scattering).  Attenuation
+    is frequency dependent and is modelled here with the usual power law
+
+    .. math::
+
+        \\alpha(f) = \\alpha_0 \\, f^{\\gamma},
+
+    where :math:`\\alpha_0` is the per-pixel attenuation coefficient stored in
+    ``values`` and :math:`\\gamma` is the (scalar) power-law exponent stored in
+    ``gamma``.  Reporting the coefficient normalized by frequency makes values
+    comparable across systems and transmit frequencies.
+
+    The coefficient is stored in the spec's base units of ``dB/m/Hz`` (rather
+    than the common clinical ``dB/cm/MHz``; note ``1 dB/cm/MHz = 1e-4 dB/m/Hz``).
+    Strictly, when :math:`\\gamma \\neq 1` the coefficient carries the exponent in
+    its units (``dB/m/Hz**gamma``); the ``dB/m/Hz`` label reflects the linear
+    (:math:`\\gamma = 1`) convention.
+
+    The exponent is close to 1 for most soft tissue (attenuation is roughly
+    linear in frequency), e.g. liver :math:`\\gamma \\approx 1.14`, breast
+    :math:`\\gamma \\approx 1.5`, while water / low-loss viscous media follow
+    :math:`\\gamma = 2`.  It defaults to ``1.0`` (linear), which reproduces the
+    plain frequency-normalized "attenuation coefficient slope".
 
     Args:
-        values: The attenuation coefficient values in dB/cm/MHz of shape
-            ``(n_frames, z, x, y)`` and type float32.
+        values: The attenuation coefficient :math:`\\alpha_0` in ``dB/m/Hz`` of
+            shape ``(n_frames, z, x, y)`` and type float32.
         coordinates: Per-pixel Cartesian positions in metres, shape
             ``(n_frames, z, x, 3)`` or ``(n_frames, z, x, y, 3)``.
             The leading frame axis may be omitted to broadcast one coordinate grid
             across all frames.
+        gamma: Scalar power-law exponent :math:`\\gamma` of the frequency
+            dependence :math:`\\alpha(f) = \\alpha_0 f^{\\gamma}`.  Defaults to
+            ``1.0`` (linear frequency dependence).
     """
+
+    gamma: float = 1.0
+
+    SCHEMA = {
+        **FloatMap.SCHEMA,
+        "gamma": {"dtype": np.float32, "shape": ()},
+    }
+
+    FIELD_METADATA = {
+        **Map.FIELD_METADATA,
+        "gamma": {
+            "unit": "–",
+            "description": (
+                "Power-law exponent of the frequency dependence alpha(f) = alpha_0 * f**gamma. "
+                "1.0 is linear (soft tissue ~1-1.5, e.g. liver ~1.14), 2.0 for water."
+            ),
+            "rare": True,
+        },
+    }
 
     def __post_init__(self):
         super().__post_init__()
 
-        if self.unit is not None and self.unit != "dB/cm/MHz":
-            raise ValueError(f"Attenuation map unit should be 'dB/cm/MHz', got '{self.unit}'")
+        if self.unit is not None and self.unit != "dB/m/Hz":
+            raise ValueError(f"Attenuation map unit should be 'dB/m/Hz', got '{self.unit}'")
 
         # Attenuation coefficients describe energy loss and are therefore non-negative.
         if np.any(self.values < 0):
             log.warning(
                 "Attenuation map contains negative values, which is physically unexpected "
-                "for an attenuation coefficient. Please verify the values are in dB/cm/MHz."
+                "for an attenuation coefficient. Please verify the values are in dB/m/Hz."
+            )
+
+        # Guard against the coefficient being supplied in the common clinical unit
+        # dB/cm/MHz (= 1e-4 dB/m/Hz) instead of the spec's dB/m/Hz base unit: even
+        # highly attenuating media stay well below 1e-2 dB/m/Hz.
+        max_abs = float(np.max(np.abs(self.values), initial=0.0))
+        if max_abs > 1e-2:
+            log.warning(
+                f"Attenuation map has a maximum absolute value of {max_abs:.4g} dB/m/Hz, which "
+                "is unusually high.  Please verify the values are in dB/m/Hz "
+                "(1 dB/cm/MHz = 1e-4 dB/m/Hz), not dB/cm/MHz."
+            )
+
+        # The power-law exponent is positive; soft tissue is ~1, water is 2.
+        if self.gamma is not None and (self.gamma <= 0 or self.gamma > 2.0):
+            log.warning(
+                f"Attenuation map gamma={self.gamma} is outside the physically typical range "
+                "(0, 2]. Soft tissue is around 1.0-1.5 and water is 2.0."
             )
 
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -25,6 +25,7 @@ UNITS = {
     "–": "unitless",
     "rad": "radians",
     "dB": "decibels",
+    "dB/cm/MHz": "decibels per centimeter per megahertz",
     "#": "count",
     "%": "percent",
     "kg/m²": "kilograms per square meter",
@@ -981,6 +982,40 @@ class SosMap(FloatMap):
 
 
 @dataclass
+class AttenuationMap(FloatMap):
+    """Acoustic attenuation map with per-pixel Cartesian coordinates.
+
+    Holds the frequency-normalized acoustic attenuation coefficient (the
+    "attenuation coefficient slope") in dB/cm/MHz. Acoustic attenuation describes
+    the loss of acoustic energy as the wave propagates through tissue (through
+    absorption and scattering). Because attenuation increases approximately
+    linearly with frequency, it is conventionally reported normalized by frequency
+    so that values are comparable across systems and transmit frequencies.
+
+    Args:
+        values: The attenuation coefficient values in dB/cm/MHz of shape
+            ``(n_frames, z, x, y)`` and type float32.
+        coordinates: Per-pixel Cartesian positions in metres, shape
+            ``(n_frames, z, x, 3)`` or ``(n_frames, z, x, y, 3)``.
+            The leading frame axis may be omitted to broadcast one coordinate grid
+            across all frames.
+    """
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.unit is not None and self.unit != "dB/cm/MHz":
+            raise ValueError(f"Attenuation map unit should be 'dB/cm/MHz', got '{self.unit}'")
+
+        # Attenuation coefficients describe energy loss and are therefore non-negative.
+        if np.any(self.values < 0):
+            log.warning(
+                "Attenuation map contains negative values, which is physically unexpected "
+                "for an attenuation coefficient. Please verify the values are in dB/cm/MHz."
+            )
+
+
+@dataclass
 class StrainPercentageMap(FloatMap):
     """Strain map data with per-pixel Cartesian coordinates.
 
@@ -1064,6 +1099,7 @@ class DataSpec(Spec):
         - image: Reconstructed image data and per-pixel coordinates.
         - segmentation: Segmentation data and per-pixel coordinates.
         - sos_map: Speed-of-sound map data and per-pixel coordinates.
+        - attenuation_map: Acoustic attenuation map data and per-pixel coordinates.
         - strain_percentage_map: Strain map data and per-pixel coordinates.
         - shear_wave_elastography_map: Shear-wave elastography data and per-pixel coordinates.
         - tissue_doppler: Tissue Doppler data and per-pixel coordinates.
@@ -1082,6 +1118,7 @@ class DataSpec(Spec):
     image: Image | dict | None = None
     segmentation: Segmentation | dict | None = None
     sos_map: SosMap | dict | None = None
+    attenuation_map: AttenuationMap | dict | None = None
     strain_percentage_map: StrainPercentageMap | dict | None = None
     shear_wave_elastography_map: ShearWaveElastographyMap | dict | None = None
     tissue_doppler: TissueDopplerMap | dict | None = None
@@ -1100,6 +1137,7 @@ class DataSpec(Spec):
         "image": {"spec": Image},
         "segmentation": {"spec": Segmentation},
         "sos_map": {"spec": SosMap},
+        "attenuation_map": {"spec": AttenuationMap},
         "strain_percentage_map": {"spec": StrainPercentageMap},
         "shear_wave_elastography_map": {"spec": ShearWaveElastographyMap},
         "tissue_doppler": {"spec": TissueDopplerMap},
@@ -1114,6 +1152,7 @@ class DataSpec(Spec):
         "image": {"description": "Reconstructed image data.", "rare": True},
         "segmentation": {"description": "Segmentation data.", "rare": True},
         "sos_map": {"description": "Speed-of-sound map data.", "rare": True},
+        "attenuation_map": {"description": "Acoustic attenuation map data.", "rare": True},
         "strain_percentage_map": {"description": "Strain map data.", "rare": True},
         "shear_wave_elastography_map": {
             "description": "Shear-wave elastography data.",
@@ -1132,6 +1171,7 @@ class DataSpec(Spec):
         image: Image | dict | None = None,
         segmentation: Segmentation | dict | None = None,
         sos_map: SosMap | dict | None = None,
+        attenuation_map: AttenuationMap | dict | None = None,
         strain_percentage_map: StrainPercentageMap | dict | None = None,
         shear_wave_elastography_map: ShearWaveElastographyMap | dict | None = None,
         tissue_doppler: TissueDopplerMap | dict | None = None,
@@ -1145,6 +1185,7 @@ class DataSpec(Spec):
         self.image = image
         self.segmentation = segmentation
         self.sos_map = sos_map
+        self.attenuation_map = attenuation_map
         self.strain_percentage_map = strain_percentage_map
         self.shear_wave_elastography_map = shear_wave_elastography_map
         self.tissue_doppler = tissue_doppler


### PR DESCRIPTION
Added `data.attenuation_map` to `zea.File` spec. See #467. Has units `dB/cm/MHz` (frequency-normalized). 

@pjarosik could you verify if this would suite your needs and ideally attach a working stand-alone snippet where you would use this in a pipeline? Also can you report on some typical values so we can include this into the spec for validation and documentation.

TODO:
- [x] Add gamma (non-linearity) parameter (gamma=2 viscous / water, liver 1.14 etc.)
- [x] Change units to `dB/m/Hz`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for attenuation maps in data files and the UI.
  * Introduced a new unit, `dB/m/Hz`, for attenuation values.
  * Expanded documentation to describe attenuation map fields, metadata, and structure.

* **Bug Fixes**
  * Added validation and warnings for unusual attenuation values and unit mismatches.
  * Improved handling of the new attenuation map data in validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->