### PR TITLE
Improve parameter descriptions

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -806,13 +806,13 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
            - ``float32``
            - (n_tx, n_el)
            - –
-           - Transmit apodization per element.
+           - Transmit apodization per element, in [-1, 1]. 0 = element did not contribute, 1 = full contribution, negative = fired with opposite polarity.
            - |badge-req|
          * - ``focus_distances``
            - ``float32``
            - (n_tx)
            - m
-           - Transmit focus distances.
+           - Transmit focus distances. Positive = focused, negative = diverging (virtual source behind the array), ``np.inf`` = plane wave (preferred; ``0`` is also accepted).
            - |badge-req|
          * - ``transmit_origins``
            - ``float32``

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1225,9 +1225,22 @@ class ScanSpec(Spec):
             full contribution. Negative values indicate that the element was
             fired with opposite polarity.
         focus_distances: The transmit focus distances in meters of shape (n_tx,).
-            This is the distance from the origin point on the transducer to
-            where the beam comes to focus. For planewaves this is set to
-            infinity or zero.
+            This is the distance from the transmit origin on the transducer to
+            where the beam comes to focus. The sign and magnitude encode the
+            transmit type:
+
+            - **positive finite**: focused transmit; the beam focuses at this
+              distance in front of the array.
+            - **negative finite**: diverging transmit; the (virtual) source
+              lies this distance behind the array.
+            - **infinite** (``np.inf``): plane wave. This is the preferred,
+              canonical value for plane waves in zea. ``0.0`` is also accepted
+              as a plane-wave marker (e.g. raw Verasonics data stores ``0``),
+              but new data should use ``np.inf``.
+
+            See :meth:`zea.Parameters.find_transmits` for how these values are
+            used to classify transmits as ``"focused"``, ``"diverging"`` or
+            ``"plane"``.
         transmit_origins: The transmit origins of the transmit beams in meters of
             shape (n_tx, 3). This is the (x, y, z) position from which the beam
             is transmitted.
@@ -1300,8 +1313,21 @@ class ScanSpec(Spec):
         "demodulation_frequency": {"unit": "Hz", "description": "Demodulation frequency."},
         "initial_times": {"unit": "s", "description": "A/D converter start times per transmit."},
         "t0_delays": {"unit": "s", "description": "Transmit delays per element."},
-        "tx_apodizations": {"unit": "–", "description": "Transmit apodization per element."},
-        "focus_distances": {"unit": "m", "description": "Transmit focus distances."},
+        "tx_apodizations": {
+            "unit": "–",
+            "description": (
+                "Transmit apodization per element, in [-1, 1]. 0 = element did not "
+                "contribute, 1 = full contribution, negative = fired with opposite polarity."
+            ),
+        },
+        "focus_distances": {
+            "unit": "m",
+            "description": (
+                "Transmit focus distances. Positive = focused, negative = diverging "
+                "(virtual source behind the array), ``np.inf`` = plane wave (preferred; "
+                "``0`` is also accepted)."
+            ),
+        },
         "transmit_origins": {"unit": "m", "description": "Transmit beam origins (x, y, z)."},
         "polar_angles": {"unit": "rad", "description": "Polar angles of transmit beams."},
         "time_to_next_transmit": {"unit": "s", "description": "Time between transmit events."},

--- a/zea/parameters.py
+++ b/zea/parameters.py
@@ -526,18 +526,19 @@ class Parameters(BaseParameters):
 
         Args:
             selection: Specifies which transmits to select:
-                - None: Use all transmits
-                - "all": Use all transmits
-                - "center": Use only the center transmit
-                - "focused": Use only focused transmits (positive finite
-                  ``focus_distances``)
-                - "diverging": Use only diverging transmits (negative finite
-                  ``focus_distances``)
-                - "plane": Use only plane wave transmits (``np.inf``, the
-                  preferred marker, or ``0``)
-                - int: Select this many evenly spaced transmits
-                - list/array: Use these specific transmit indices
-                - slice: Use transmits specified by the slice (e.g., slice(0, 10, 2))
+
+            - None: Use all transmits
+            - "all": Use all transmits
+            - "center": Use only the center transmit
+            - "focused": Use only focused transmits (positive finite
+                ``focus_distances``)
+            - "diverging": Use only diverging transmits (negative finite
+                ``focus_distances``)
+            - "plane": Use only plane wave transmits (``np.inf``, the
+                preferred marker, or ``0``)
+            - int: Select this many evenly spaced transmits
+            - list/array: Use these specific transmit indices
+            - slice: Use transmits specified by the slice (e.g., slice(0, 10, 2))
 
         Returns:
             The current instance for method chaining.
@@ -562,18 +563,19 @@ class Parameters(BaseParameters):
 
         Args:
             selection: Specifies which transmits to select:
-                - None: Use all transmits
-                - "all": Use all transmits
-                - "center": Use only the center transmit
-                - "focused": Use only focused transmits (positive finite
-                  ``focus_distances``)
-                - "diverging": Use only diverging transmits (negative finite
-                  ``focus_distances``)
-                - "plane": Use only plane wave transmits (``np.inf``, the
-                  preferred marker, or ``0``)
-                - int: Select this many evenly spaced transmits
-                - list/array: Use these specific transmit indices
-                - slice: Use transmits specified by the slice (e.g., slice(0, 10, 2))
+
+            - None: Use all transmits
+            - "all": Use all transmits
+            - "center": Use only the center transmit
+            - "focused": Use only focused transmits (positive finite
+                ``focus_distances``)
+            - "diverging": Use only diverging transmits (negative finite
+                ``focus_distances``)
+            - "plane": Use only plane wave transmits (``np.inf``, the
+                preferred marker, or ``0``)
+            - int: Select this many evenly spaced transmits
+            - list/array: Use these specific transmit indices
+            - slice: Use transmits specified by the slice (e.g., slice(0, 10, 2))
 
         Returns:
             The selected transmit indices.

--- a/zea/parameters.py
+++ b/zea/parameters.py
@@ -529,9 +529,12 @@ class Parameters(BaseParameters):
                 - None: Use all transmits
                 - "all": Use all transmits
                 - "center": Use only the center transmit
-                - "focused": Use only focused transmits
-                - "diverging": Use only diverging transmits
-                - "plane": Use only plane wave transmits
+                - "focused": Use only focused transmits (positive finite
+                  ``focus_distances``)
+                - "diverging": Use only diverging transmits (negative finite
+                  ``focus_distances``)
+                - "plane": Use only plane wave transmits (``np.inf``, the
+                  preferred marker, or ``0``)
                 - int: Select this many evenly spaced transmits
                 - list/array: Use these specific transmit indices
                 - slice: Use transmits specified by the slice (e.g., slice(0, 10, 2))
@@ -562,9 +565,12 @@ class Parameters(BaseParameters):
                 - None: Use all transmits
                 - "all": Use all transmits
                 - "center": Use only the center transmit
-                - "focused": Use only focused transmits
-                - "diverging": Use only diverging transmits
-                - "plane": Use only plane wave transmits
+                - "focused": Use only focused transmits (positive finite
+                  ``focus_distances``)
+                - "diverging": Use only diverging transmits (negative finite
+                  ``focus_distances``)
+                - "plane": Use only plane wave transmits (``np.inf``, the
+                  preferred marker, or ``0``)
                 - int: Select this many evenly spaced transmits
                 - list/array: Use these specific transmit indices
                 - slice: Use transmits specified by the slice (e.g., slice(0, 10, 2))
@@ -735,7 +741,16 @@ class Parameters(BaseParameters):
 
     @cache_with_dependencies("selected_transmits", "n_tx")
     def focus_distances(self):
-        """Focus distances in meters for each event of shape (n_tx,)."""
+        """Focus distances in meters for each event of shape (n_tx,).
+
+        The sign and magnitude encode the transmit type: a positive finite value
+        is a focused transmit (focal point that distance in front of the array),
+        a negative finite value is a diverging transmit (virtual source that
+        distance behind the array), and ``np.inf`` is a plane wave. ``np.inf`` is
+        the preferred, canonical plane-wave value in zea; ``0.0`` is also accepted
+        (see :meth:`find_transmits`). When no focus distances are provided, zeros
+        are used (i.e. treated as plane waves).
+        """
         value = self._params.get("focus_distances")
         if value is None:
             log.warning_once(


### PR DESCRIPTION
Added expected parameter values for `focus_distances` and `tx_apodizations` to documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified transmit timing parameter conventions in scan specifications, including apodization value interpretation within the expected `[-1, 1]` range.
  * Expanded focus-distance guidance: positive vs. negative finite values (focused vs. diverging) and plane-wave markers using `np.inf`, with `0` also accepted.
  * Improved transmit selection documentation by explicitly mapping “focused,” “diverging,” and “plane” behaviors to these conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->