### PR TITLE
Allow transmit-only tracks

### DIFF
--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -216,6 +216,7 @@ def test_create_transmit_only_track(tmp_path):
             {
                 "data": None,
                 "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+                "transmit_only": True,
             }
         ],
         ignore_warnings=True,
@@ -246,6 +247,7 @@ def test_create_multitrack_with_transmit_only_track(tmp_path):
                 "data": None,
                 "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
                 "label": "push",
+                "transmit_only": True,
             },
         ],
         probe=_probe_minimal(n_el=n_el),

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -237,9 +237,7 @@ def test_create_multitrack_with_transmit_only_track(tmp_path):
         tracks=[
             {
                 "data": {
-                    "raw_data": np.zeros(
-                        (n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32
-                    ),
+                    "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32),
                 },
                 "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
                 "label": "focused",

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -206,6 +206,66 @@ def _probe_minimal(name=None, n_el=4):
     return probe
 
 
+def test_create_transmit_only_track(tmp_path):
+    """File.create with a single transmit-only track (scan but no data) works."""
+    n_frames, n_tx, n_el = 3, 2, 4
+    path = tmp_path / "transmit_only.hdf5"
+    File.create(
+        path,
+        tracks=[
+            {
+                "data": None,
+                "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+            }
+        ],
+        ignore_warnings=True,
+    )
+
+    with File(path) as f:
+        assert isinstance(f.scan, ScanSpec), "f.scan should return a ScanSpec"
+        (track,) = f.tracks
+        assert "data" not in track._group, "Transmit-only track should have no data group"
+        assert isinstance(track.scan, ScanSpec)
+
+
+def test_create_multitrack_with_transmit_only_track(tmp_path):
+    """File.create can mix a data track with a transmit-only (scan-only) track."""
+    n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
+    path = tmp_path / "mixed_tracks.hdf5"
+    File.create(
+        path,
+        tracks=[
+            {
+                "data": {
+                    "raw_data": np.zeros(
+                        (n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32
+                    ),
+                },
+                "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+                "label": "focused",
+            },
+            {
+                "data": None,
+                "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+                "label": "push",
+            },
+        ],
+        probe=_probe_minimal(n_el=n_el),
+        ignore_warnings=True,
+    )
+
+    with File(path) as f:
+        assert f.track_labels == ["focused", "push"]
+
+        focused = f.get_track("focused")
+        assert "data" in focused._group, "Data track should have a data group"
+        assert focused.data.raw_data.shape == (n_frames, n_tx, n_ax, n_el, n_ch)
+
+        push = f.get_track("push")
+        assert "data" not in push._group, "Transmit-only track should have no data group"
+        assert isinstance(push.scan, ScanSpec)
+
+
 @pytest.fixture
 def spec_file(tmp_path):
     """Create a spec-format HDF5 file via FileSpec.save()."""

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1759,13 +1759,25 @@ def _image_data(n_frames: int = 3):
 
 
 class TestTransmitOnlyTrack:
-    """A TrackSpec may omit ``data`` (transmit-only track) only when ``scan`` is provided."""
+    """A TrackSpec may omit ``data`` (transmit-only track) only when ``scan`` is provided
+    and ``transmit_only=True`` is explicitly set."""
 
-    def test_data_none_with_scan_is_allowed(self):
-        """A transmit-only track (scan but no data) is valid."""
-        track = TrackSpec(data=None, scan=_scan_minimal())
+    def test_data_none_with_scan_and_transmit_only_is_allowed(self):
+        """A transmit-only track (scan but no data) is valid when explicitly flagged."""
+        track = TrackSpec(data=None, scan=_scan_minimal(), transmit_only=True)
         assert track.data is None
         assert isinstance(track.scan, ScanSpec)
+        assert bool(track.transmit_only) is True
+
+    def test_data_none_with_scan_without_transmit_only_raises(self):
+        """Omitting 'data' without setting 'transmit_only=True' is rejected."""
+        with pytest.raises(ValueError, match="'transmit_only' was not set to True"):
+            TrackSpec(data=None, scan=_scan_minimal())
+
+    def test_transmit_only_with_data_raises(self):
+        """'transmit_only=True' combined with non-None data is rejected."""
+        with pytest.raises(ValueError, match="must not carry data"):
+            TrackSpec(data=_image_data(), scan=None, transmit_only=True)
 
     def test_data_none_without_scan_raises(self):
         """A track with neither data nor scan is invalid."""
@@ -1791,11 +1803,15 @@ class TestTransmitOnlyTrack:
             TrackSpec(data=data, scan=None)
 
     def test_transmit_only_track_roundtrips_through_filespec(self, tmp_path):
-        """A FileSpec with a transmit-only track stores and reloads without raw_data."""
-        spec = FileSpec(tracks=[{"data": None, "scan": _scan_minimal()}])
+        """A FileSpec with a transmit-only track stores and reloads without raw_data,
+        and the 'transmit_only' flag itself is persisted in the file."""
+        spec = FileSpec(tracks=[{"data": None, "scan": _scan_minimal(), "transmit_only": True}])
         path = tmp_path / "transmit_only.hdf5"
         spec.save(str(path), warn_missing_optional_fields=False)
         with File(path) as f:
             assert "scan" in f
             assert "data" not in f
             assert isinstance(f.scan, ScanSpec)
+            (track,) = f.tracks
+            assert "transmit_only" in track._group
+            assert bool(track._group["transmit_only"][()]) is True

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -24,6 +24,7 @@ from zea.data.spec import (
     SosMap,
     Spec,
     Subject,
+    TrackSpec,
 )
 
 
@@ -1744,3 +1745,57 @@ def test_field_metadata_units_are_defined():
         + ", ".join(sorted(undefined))
         + ". Add the symbol to UNITS (it is the source of truth rendered in the docs)."
     )
+
+
+def _image_data(n_frames: int = 3):
+    """Minimal DataSpec dict with only an image map (no raw_data, so no scan required)."""
+    coords = _make_coordinates((n_frames, 16, 12))
+    return {
+        "image": {
+            "values": np.zeros((n_frames, 16, 12, 1), dtype=np.uint8),
+            "coordinates": coords,
+        }
+    }
+
+
+class TestTransmitOnlyTrack:
+    """A TrackSpec may omit ``data`` (transmit-only track) only when ``scan`` is provided."""
+
+    def test_data_none_with_scan_is_allowed(self):
+        """A transmit-only track (scan but no data) is valid."""
+        track = TrackSpec(data=None, scan=_scan_minimal())
+        assert track.data is None
+        assert isinstance(track.scan, ScanSpec)
+
+    def test_data_none_without_scan_raises(self):
+        """A track with neither data nor scan is invalid."""
+        with pytest.raises(ValueError, match="at least one of 'data' or 'scan'"):
+            TrackSpec(data=None, scan=None)
+
+    def test_default_track_has_neither_and_raises(self):
+        """Constructing a TrackSpec with no arguments raises (both default to None)."""
+        with pytest.raises(ValueError, match="at least one of 'data' or 'scan'"):
+            TrackSpec()
+
+    def test_data_without_scan_still_allowed(self):
+        """Data without raw_data does not require a scan."""
+        track = TrackSpec(data=_image_data(), scan=None)
+        assert isinstance(track.data, DataSpec)
+        assert track.scan is None
+
+    def test_raw_data_still_requires_scan(self):
+        """A track whose data contains raw_data requires a scan."""
+        n_frames, n_tx, n_el, n_ax, n_ch = 3, 2, 4, 8, 1
+        data = {"raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)}
+        with pytest.raises(ValueError, match="'scan' is required when 'raw_data'"):
+            TrackSpec(data=data, scan=None)
+
+    def test_transmit_only_track_roundtrips_through_filespec(self, tmp_path):
+        """A FileSpec with a transmit-only track stores and reloads without raw_data."""
+        spec = FileSpec(tracks=[{"data": None, "scan": _scan_minimal()}])
+        path = tmp_path / "transmit_only.hdf5"
+        spec.save(str(path), warn_missing_optional_fields=False)
+        with File(path) as f:
+            assert "scan" in f
+            assert "data" not in f
+            assert isinstance(f.scan, ScanSpec)

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1959,33 +1959,50 @@ class TrackSpec(Spec):
     A track must carry at least one of ``data`` or ``scan``.  ``data`` may be
     left as ``None`` to describe a transmit-only track (one that records the
     transmit sequence via ``scan`` but stores no recorded data), but only when
-    ``scan`` is provided.
+    ``scan`` is provided and ``transmit_only=True`` is explicitly passed.
+
+    A transmit-only track is useful when we want to store information about a
+    transmit event without any corresponding receive data, for example a shear
+    wave push pulse or therapeutic ultrasound.
 
     Args:
         data (DataSpec | dict | None): The data for this track. May be ``None``
             for a transmit-only track (e.g. to store a shear wave push pulse),
-            but only if ``scan`` is provided.
+            but only if ``scan`` is provided and ``transmit_only=True``.
         scan (ScanSpec | dict | None): The scan parameters for this track. Required when raw_data is
             present in *data*, and required when *data* is ``None``.
         label (str | None): Short human-readable name for this track (e.g. ``"focused"``
             or ``"planewave"``).  Required when the parent :class:`FileSpec`
             contains more than one track.
+        transmit_only (bool): Must be explicitly set to ``True`` to construct a
+            transmit-only track (``data=None`` with ``scan`` provided).
     """
 
     data: DataSpec | dict | None = None
     scan: ScanSpec | dict | None = None
     label: str | None = None
+    transmit_only: bool = False
 
     SCHEMA = {
         "data": {"spec": DataSpec},
         "scan": {"spec": ScanSpec},
         "label": {"dtype": str, "shape": ()},
+        "transmit_only": {"dtype": np.bool_, "shape": ()},
     }
 
     FIELD_METADATA = {
         # label is enforced by FileSpec for multi-track (ValueError), and legitimately
         # absent for single-track files — warning here is never useful.
         "label": {"unit": "–", "description": "Short human-readable track name.", "rare": True},
+        "transmit_only": {
+            "unit": "–",
+            "description": (
+                "Whether this track records only the transmit sequence with no "
+                "corresponding receive data (e.g. a shear wave push pulse or "
+                "therapeutic ultrasound)."
+            ),
+            "rare": True,
+        },
     }
 
     def __post_init__(self):
@@ -1994,7 +2011,23 @@ class TrackSpec(Spec):
         if self.data is None and self.scan is None:
             raise ValueError(
                 "A track must have at least one of 'data' or 'scan'. "
-                "'data' may be None (a transmit-only track) only when 'scan' is provided."
+                "'data' may be None (a transmit-only track) only when 'scan' is provided "
+                "and 'transmit_only=True' is explicitly set."
+            )
+
+        if self.data is None and self.scan is not None and not self.transmit_only:
+            raise ValueError(
+                "'data' is None but 'transmit_only' was not set to True. "
+                "Pass 'transmit_only=True' to explicitly create a transmit-only track "
+                "(one that records only the transmit sequence via 'scan', with no "
+                "corresponding receive data, e.g. a shear wave push pulse or "
+                "therapeutic ultrasound exposure)."
+            )
+
+        if self.transmit_only and self.data is not None:
+            raise ValueError(
+                "'transmit_only=True' was set but 'data' is not None. "
+                "A transmit-only track must not carry data."
             )
 
         data = self.data

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1956,16 +1956,22 @@ class TrackSpec(Spec):
     field of the parent :class:`FileSpec`, if necessary.
     Single-track files may omit the label.
 
+    A track must carry at least one of ``data`` or ``scan``.  ``data`` may be
+    left as ``None`` to describe a transmit-only track (one that records the
+    transmit sequence via ``scan`` but stores no recorded data), but only when
+    ``scan`` is provided.
+
     Args:
-        data (DataSpec | dict): The data for this track.
+        data (DataSpec | dict | None): The data for this track. May be ``None``
+            for a transmit-only track, but only if ``scan`` is provided.
         scan (ScanSpec | dict | None): The scan parameters for this track. Required when raw_data is
-            present in *data*.
+            present in *data*, and required when *data* is ``None``.
         label (str | None): Short human-readable name for this track (e.g. ``"focused"``
             or ``"planewave"``).  Required when the parent :class:`FileSpec`
             contains more than one track.
     """
 
-    data: DataSpec | dict
+    data: DataSpec | dict | None = None
     scan: ScanSpec | dict | None = None
     label: str | None = None
 
@@ -1983,6 +1989,12 @@ class TrackSpec(Spec):
 
     def __post_init__(self):
         super().__post_init__()
+
+        if self.data is None and self.scan is None:
+            raise ValueError(
+                "A track must have at least one of 'data' or 'scan'. "
+                "'data' may be None (a transmit-only track) only when 'scan' is provided."
+            )
 
         data = self.data
         has_raw = (isinstance(data, DataSpec) and data.raw_data is not None) or (
@@ -2297,7 +2309,7 @@ class FileSpec(Spec):
         """Pad flat timing arrays and reshape to (n_frames * n_tx) by padding last
         frame with a zero."""
         for i, track in enumerate(self.tracks):
-            raw_data = track.data.raw_data
+            raw_data = track.data.raw_data if track.data is not None else None
             scan = track.scan
             if raw_data is None or scan is None or scan.time_to_next_transmit is None:
                 continue

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1963,7 +1963,8 @@ class TrackSpec(Spec):
 
     Args:
         data (DataSpec | dict | None): The data for this track. May be ``None``
-            for a transmit-only track, but only if ``scan`` is provided.
+            for a transmit-only track (e.g. to store a shear wave push pulse),
+            but only if ``scan`` is provided.
         scan (ScanSpec | dict | None): The scan parameters for this track. Required when raw_data is
             present in *data*, and required when *data* is ``None``.
         label (str | None): Short human-readable name for this track (e.g. ``"focused"``


### PR DESCRIPTION
This PR adds a relaxation to the `TrackSpec`, allowing us to store 'transmit-only' tracks, where we provide a scan but no data.

This could be useful for storing shear-wave elastography datasets (and perhaps other situations in future, e.g. from theranostics) where we want to save some the details of some transmit but don't care about recording the resulting echoes.

Note: we could consider adding extra validation here to make it so that:
(i) transmit-only tracks can only be specified in multi-track files 
(ii) a track_schedule and time_to_next transmit have to be specified if a transmit-only track is used
but I chose to leave the change quite minimal to avoid adding more complex validation logic. Curious what your thoughts are on that.

Example snippet:
```python
"""Create a zea file with B-mode and transmit-only push tracks via File.create."""

import numpy as np

from zea.data.file import File

n_frames, n_el, n_ax = 3, 4, 8

# B-mode: a handful of steered plane-wave transmits used to form an image.
bmode_n_tx = 3
bmode_angles = np.linspace(-5, 5, bmode_n_tx, dtype=np.float32)

# Push: a single, long, tightly-focused transmit (e.g. ARFI/shear-wave push).
push_n_tx = 1
push_focus_distance = np.float32(30e-3)


def bmode_scan():
    return {
        "sampling_frequency": np.float32(30e6),
        "center_frequency": np.float32(5e6),
        "demodulation_frequency": np.float32(5e6),
        "initial_times": np.zeros((bmode_n_tx,), dtype=np.float32),
        "t0_delays": np.zeros((bmode_n_tx, n_el), dtype=np.float32),
        "tx_apodizations": np.ones((bmode_n_tx, n_el), dtype=np.float32),
        "focus_distances": np.zeros((bmode_n_tx,), dtype=np.float32),
        "transmit_origins": np.zeros((bmode_n_tx, 3), dtype=np.float32),
        "polar_angles": np.deg2rad(bmode_angles),
    }


def push_scan():
    return {
        "sampling_frequency": np.float32(30e6),
        "center_frequency": np.float32(1.5e6),
        "demodulation_frequency": np.float32(1.5e6),
        "initial_times": np.zeros((push_n_tx,), dtype=np.float32),
        "t0_delays": np.zeros((push_n_tx, n_el), dtype=np.float32),
        "tx_apodizations": np.ones((push_n_tx, n_el), dtype=np.float32),
        "focus_distances": np.full((push_n_tx,), push_focus_distance, dtype=np.float32),
        "transmit_origins": np.zeros((push_n_tx, 3), dtype=np.float32),
        "polar_angles": np.zeros((push_n_tx,), dtype=np.float32),
    }


File.create(
    "tracks.hdf5",
    tracks=[
        # B-mode track: transmits and records channel data.
        {
            "data": {
                "raw_data": np.zeros((n_frames, bmode_n_tx, n_ax, n_el, 1), np.float32)
            },
            "scan": bmode_scan(),
            "label": "bmode",
        },
        # Push track: transmits only, records no data (data=None + transmit_only=True).
        {
            "data": None,
            "scan": push_scan(),
            "label": "push",
            "transmit_only": True,
        },
    ],
    probe={"probe_geometry": np.zeros((n_el, 3), dtype=np.float32)},
    overwrite=True,
)

with File("tracks.hdf5") as f:
    print("tracks:", f.track_labels)
    for track in f.tracks:
        print(f"  {track.label}: has data group =", "data" in track._group)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for transmit-only tracks in file and track specifications.
  * Track metadata and scan information can now be preserved even when no data payload is present.

* **Bug Fixes**
  * Improved validation so empty track definitions are rejected unless transmit-only mode is explicitly set.
  * Saved files now round-trip transmit-only tracks correctly, including their scan details and labels.

* **Tests**
  * Added coverage for single-track and multi-track transmit-only file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->