### PR TITLE
Don't warn about missing `azimuth_angles` for 2D grids

### DIFF
--- a/zea/parameters.py
+++ b/zea/parameters.py
@@ -437,7 +437,7 @@ class Parameters(BaseParameters):
         radius = max(self.zlims)
         ylims_azimuth = (
             (0.0, 0.0)  # avoid numerical imprecision with np.cos(np.pi/2)
-            if self.azimuth_limits[0] == self.azimuth_limits[1]
+            if self.azimuth_limits is None or self.azimuth_limits[0] == self.azimuth_limits[1]
             else (
                 radius * np.cos(-np.pi / 2 + self.azimuth_limits[0]),
                 radius * np.cos(-np.pi / 2 + self.azimuth_limits[1]),
@@ -695,12 +695,20 @@ class Parameters(BaseParameters):
 
         return value[self.selected_transmits]
 
-    @cache_with_dependencies("azimuth_angles")
+    @cache_with_dependencies("selected_transmits", "n_tx")
     def azimuth_limits(self):
-        """The limits of the azimuth angles."""
+        """The limits of the azimuth angles.
+
+        Returns ``None`` if azimuth angles were
+        not provided (e.g. standard 2D imaging).
+
+        The presence check uses the raw parameter to avoid triggering the
+        :attr:`azimuth_angles` "using zeros" fallback warning for 2D data.
+        """
         value = self._params.get("azimuth_limits")
-        if value is None and self.azimuth_angles is not None:
-            value = self.azimuth_angles.min(), self.azimuth_angles.max()
+        if value is None and self._params.get("azimuth_angles") is not None:
+            azimuth_angles = self.azimuth_angles
+            value = azimuth_angles.min(), azimuth_angles.max()
             diff = value[1] - value[0]
             # add 15% margin to the limits
             value = (value[0] - 0.15 * diff, value[1] + 0.15 * diff)


### PR DESCRIPTION
`azimuth_limits` now checks for the raw `azimuth_angles` parameter before falling back, so computing a 2D beamforming grid no longer emits the `No azimuth_angles provided, using zeros` warning. When azimuth angles *are* provided, they're still read through the `azimuth_angles` property.

## Why

The warning fired via `grid → ylims → azimuth_limits → azimuth_angles` for every 2D reconstruction that (correctly) omits azimuth angles — pure noise. Beamforming uses `polar_angles`, not `azimuth_angles`, so nothing meaningful was missing. The `azimuth_angles` property keeps its zeros-fallback-with-warning behaviour for genuine consumers (e.g. 3D/out-of-plane delay computation).

## Repro (warned before, silent now)

```python
import numpy as np
from zea import Parameters

# 2D scan parameters without azimuth_angles
params = Parameters(
    probe_geometry=np.stack(
        [np.linspace(-0.019, 0.019, 128), np.zeros(128), np.zeros(128)], axis=-1
    ).astype("float32"),
    polar_angles=np.zeros(1, dtype="float32"),
    sound_speed=1540.0,
    sampling_frequency=40e6,
    center_frequency=6e6,
    n_ax=2048,
    n_tx=1,
    n_el=128,
)

_ = params.grid  # previously logged "No azimuth_angles provided, using zeros"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing azimuth settings by treating `azimuth_limits=None` as a safe case that avoids numerical precision issues.
  * Updated azimuth limit computation so limits are only derived from azimuth angles when those angles were explicitly provided; otherwise, it stays unset to prevent misleading fallbacks and warnings.
  * Refreshed when azimuth limits update by tying recalculation to transmit selection and the number of transmits, reducing unexpected limit changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->