### PR TITLE
Fixes for shape consistency across data types and tracks

### DIFF
--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1131,15 +1131,43 @@ class TestMetadataAndMetricsValidationErrors:
                 },
             )
 
-    def test_annotations_n_frames_mismatch_against_later_track_raises(self):
-        """Metadata may agree with track 0 but conflict with a later track.
+    def test_annotations_may_match_one_of_several_tracks(self):
+        """Metadata annotates one acquisition, so it only needs to match one track.
 
-        Exercises the multi-track loop in ``FileSpec.__post_init__``: the
-        per-track consistency check must keep iterating past the matching
-        track and report which track disagrees.
+        A single-frame auxiliary track (e.g. a reference map) may coexist with a
+        multi-frame main track whose n_frames matches the annotations. Only the
+        main track needs to agree with the per-frame metadata.
         """
         n_tx, n_el, n_ax, n_ch = 2, 4, 8, 1
-        n_frames_match, n_frames_conflict = 3, 5
+        n_frames_main, n_frames_aux = 5, 1
+
+        def _track(n_frames):
+            return {
+                "data": {
+                    "raw_data": np.zeros((n_frames, n_tx, n_ax, n_el, n_ch), dtype=np.float32)
+                },
+                "scan": _scan_minimal(n_frames=n_frames, n_tx=n_tx, n_el=n_el),
+                "label": f"track_{n_frames}",
+            }
+
+        # Annotations match the main track (n_frames_main); the auxiliary track
+        # has a different n_frames and must not cause a failure.
+        spec = FileSpec(
+            tracks=[_track(n_frames_main), _track(n_frames_aux)],
+            track_schedule=np.zeros(1, dtype=np.int32),
+            probe=_probe_minimal(n_el=n_el),
+            metadata={
+                "annotations": {
+                    "view": np.array(["a4c"] * n_frames_main, dtype=np.str_),
+                }
+            },
+        )
+        assert len(spec.tracks) == 2
+
+    def test_annotations_matching_no_track_raises(self):
+        """Metadata whose n_frames matches none of the tracks is still an error."""
+        n_tx, n_el, n_ax, n_ch = 2, 4, 8, 1
+        n_frames_a, n_frames_b, n_frames_ann = 3, 1, 5
 
         def _track(n_frames):
             return {
@@ -1152,22 +1180,22 @@ class TestMetadataAndMetricsValidationErrors:
 
         with pytest.raises(ValueError) as exc_info:
             FileSpec(
-                tracks=[_track(n_frames_match), _track(n_frames_conflict)],
+                tracks=[_track(n_frames_a), _track(n_frames_b)],
+                track_schedule=np.zeros(1, dtype=np.int32),
                 probe=_probe_minimal(n_el=n_el),
                 metadata={
                     "annotations": {
-                        "view": np.array(["a4c"] * n_frames_match, dtype=np.str_),
+                        "view": np.array(["a4c"] * n_frames_ann, dtype=np.str_),
                     }
                 },
             )
 
         message = str(exc_info.value)
         assert message.startswith("Dimension 'n_frames' has inconsistent sizes:")
-        # The message attributes the sizes to the metadata field and the
-        # conflicting track (not track 0, which matched the metadata).
+        # The message lists the metadata field and every track carrying the dim.
         assert "metadata.annotations.view" in message
+        assert "tracks[0]." in message
         assert "tracks[1]." in message
-        assert "tracks[0]." not in message
 
 
 class TestProbePoseValidation:

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -10,6 +10,7 @@ from zea.data.file import File
 from zea.data.spec import (
     Annotations,
     AttenuationMap,
+    BeamformedData,
     DataSpec,
     FileSpec,
     Image,
@@ -306,6 +307,69 @@ def test_inconsistent_dimension_error_groups_fields_by_size():
     assert "t0_delays" in message and "tx_apodizations" in message
     size_2_line = next(line for line in message.splitlines() if line.strip().startswith("size 2:"))
     assert "t0_delays" in size_2_line
+
+
+def test_n_ch_is_independent_across_data_products():
+    """RF raw_data (n_ch=1) may coexist with IQ beamformed_data (n_ch=2).
+
+    The channel dimension is semantically independent between data products, so
+    it must not be cross-checked at the DataSpec level.
+    """
+    n_frames, n_tx, n_ax, n_el, z, x = 2, 4, 64, 8, 16, 16
+    data = DataSpec(
+        raw_data=np.zeros((n_frames, n_tx, n_ax, n_el, 1), dtype=np.float32),
+        beamformed_data={
+            "values": np.zeros((n_frames, z, x, 2), dtype=np.float32),
+            "coordinates": np.zeros((n_frames, z, x, 3), dtype=np.float32),
+        },
+    )
+    assert data.raw_data.shape[-1] == 1
+    assert data.beamformed_data.values.shape[-1] == 2
+    assert list(data.beamformed_data.labels) == ["I", "Q"]
+
+
+def test_n_spatial_ch_is_independent_across_maps():
+    """Two maps in the same DataSpec may have different channel counts."""
+    n_frames, z, x = 2, 16, 16
+    coordinates = np.zeros((n_frames, z, x, 3), dtype=np.float32)
+    data = DataSpec(
+        segmentation={
+            "values": np.zeros((n_frames, z, x, 3), dtype=np.bool_),
+            "labels": np.array(["a", "b", "c"], dtype=np.str_),
+            "coordinates": coordinates,
+        },
+        sos_map={
+            "values": np.zeros((n_frames, z, x, 2), dtype=np.float32),
+            "labels": np.array(["lo", "hi"], dtype=np.str_),
+            "coordinates": coordinates,
+        },
+    )
+    assert data.segmentation.values.shape[-1] == 3
+    assert data.sos_map.values.shape[-1] == 2
+
+
+def test_n_ch_still_consistent_within_a_single_map():
+    """values and labels within one Map must still agree on n_ch."""
+    n_frames, z, x = 2, 16, 16
+    with pytest.raises(ValueError, match="Dimension 'n_ch' has inconsistent sizes"):
+        BeamformedData(
+            values=np.zeros((n_frames, z, x, 2), dtype=np.float32),
+            coordinates=np.zeros((n_frames, z, x, 3), dtype=np.float32),
+            labels=np.array(["only_one"], dtype=np.str_),
+        )
+
+
+def test_shared_dimensions_still_cross_checked_across_data_products():
+    """Non-channel dimensions (e.g. n_frames) must still agree across products."""
+    z, x = 16, 16
+    with pytest.raises(ValueError, match="Dimension 'n_frames' has inconsistent sizes"):
+        DataSpec(
+            raw_data=np.zeros((2, 4, 64, 8, 1), dtype=np.float32),
+            beamformed_data={
+                "values": np.zeros((3, z, x, 1), dtype=np.float32),
+                "coordinates": np.zeros((3, z, x, 3), dtype=np.float32),
+            },
+        )
 
 
 def test_signal_nd_accepts_variable_trailing_dimensions_with_ellipsis():

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -14,7 +14,13 @@ import numpy as np
 from zea import log
 from zea.internal.typing import Scalar
 
+# Named dimensions whose sizes must agree wherever they appear.
 CONSISTENCY_DIMENSIONS = {"n_frames", "n_tx", "n_ax", "n_el", "n_ch", "n_spatial_ch"}
+
+# Subset that must only agree within a single spec, not across sibling data
+# products: channel counts are independent between products (e.g. RF raw_data
+# next to IQ beamformed_data), so they are not propagated across spec boundaries.
+LOCAL_CONSISTENCY_DIMENSIONS = {"n_ch", "n_spatial_ch"}
 
 UNITS = {
     "m/s": "meters per second",
@@ -188,6 +194,10 @@ class Spec:
         nested_dim_to_field_sizes: defaultdict[str, dict[str, int]],
     ) -> None:
         for dim_name, nested_field_sizes in nested_dim_to_field_sizes.items():
+            # Channel dimensions are only consistent within a single spec, not
+            # across data products, so they are not propagated to the parent.
+            if dim_name in LOCAL_CONSISTENCY_DIMENSIONS:
+                continue
             dim_to_field_sizes[dim_name].update(nested_field_sizes)
 
     @staticmethod

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1929,15 +1929,15 @@ class Annotations(Spec):
     """Frame-level annotations, either per frame or broadcast labels.
 
     Args:
-        anatomy: Anatomy label.
-        view: View label of shape (n_frames,).
-        label: Pathology or classification label of shape (n_frames,).
-        image_quality: Image quality label, e.g. low, mid, high.
+        anatomy (str): Anatomy label.
+        view (str): View label.
+        label (str): Pathology or classification label.
+        image_quality (str): Image quality label, e.g. low, mid, high.
     """
 
     anatomy: np.ndarray | str | None = None
-    view: np.ndarray | None = None
-    label: np.ndarray | None = None
+    view: np.ndarray | str | None = None
+    label: np.ndarray | str | None = None
     image_quality: np.ndarray | str | None = None
 
     SCHEMA = {
@@ -2451,17 +2451,37 @@ class FileSpec(Spec):
         # Run base SCHEMA validation (metadata, metrics, scalars, track_schedule)
         super().__post_init__()
 
-        # Validate that dimensions which are present in both metadata and tracks
-        # are consistent across all tracks.
+        # Per-frame metadata (e.g. annotations) describes one acquisition, so for
+        # each shared dimension it must match at least one track - auxiliary tracks may
+        # legitimately differ.
         if isinstance(self.metadata, MetadataSpec):
             meta_dim_field_sizes = self.metadata._collect_dimension_info("metadata.")
-            for i, track in enumerate(self.tracks):
-                track_dim_field_sizes = track._collect_dimension_info(f"tracks[{i}].")
-                for dim in CONSISTENCY_DIMENSIONS:
-                    if dim in meta_dim_field_sizes and dim in track_dim_field_sizes:
-                        field_sizes = {**meta_dim_field_sizes[dim], **track_dim_field_sizes[dim]}
-                        if len(set(field_sizes.values())) > 1:
-                            raise ValueError(self._format_inconsistent_dimension(dim, field_sizes))
+            per_track_dim_field_sizes = [
+                track._collect_dimension_info(f"tracks[{i}].")
+                for i, track in enumerate(self.tracks)
+            ]
+            for dim in CONSISTENCY_DIMENSIONS:
+                # Nothing to validate if the metadata doesn't use this dimension.
+                if dim not in meta_dim_field_sizes:
+                    continue
+
+                # Nor if no track carries it - there's nothing to match against.
+                tracks_with_dim = [t[dim] for t in per_track_dim_field_sizes if dim in t]
+                if not tracks_with_dim:
+                    continue
+
+                # Metadata is internally consistent, so meta_values is a single
+                # size; it must match at least one track that carries this dim.
+                meta_sizes = meta_dim_field_sizes[dim]
+                meta_values = set(meta_sizes.values())
+                if any(meta_values == set(track_sizes.values()) for track_sizes in tracks_with_dim):
+                    continue
+                # No track matched: report the metadata field(s) alongside every
+                # track that carries the dimension.
+                field_sizes = dict(meta_sizes)
+                for track_sizes in tracks_with_dim:
+                    field_sizes.update(track_sizes)
+                raise ValueError(self._format_inconsistent_dimension(dim, field_sizes))
 
         # Validate custom elements are CustomElement instances (lazy import to
         # avoid a circular dependency with zea.data.file).


### PR DESCRIPTION
Allow n_ch to be globally different but locally consistent in a zea file. This arose in #474, where IQ and RF data where stored in the same file, which should be allowed.

Also fixes that the shapes in "annotations" must match at least one track, not all (since tracks can have different shapes in general)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dimension validation: channel-related counts are now checked only within the appropriate data product/map scope, while non-channel dimensions still remain consistent across the overall specification.
  * Allowed differing spatial channel counts across different map types within the same spec.
  * Kept raw vs beamformed channel counts independent, with errors still raised for mismatches within a single map where required.

* **Tests**
  * Extended unit coverage for the updated dimension-consistency and multi-track annotation validation rules.

* **Documentation**
  * Updated accepted annotation `view`/`label` inputs to allow either arrays or strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->