### PR TITLE
Fix: guard z=0 division-by-zero in lens-corrected delay computation

### DIFF
--- a/tests/test_beamformer.py
+++ b/tests/test_beamformer.py
@@ -754,3 +754,23 @@ def test_lens_correction_known_vertical_path():
     expected = lens_thickness / c_lens + (z_pixel - lens_thickness) / c_medium
     np.testing.assert_allclose(tt[0, 0], expected, rtol=1e-4)
     return tt
+
+
+@backend_equality_check()
+def test_lens_correction_z_zero_no_nan(probe_geometry):
+    """A pixel row at z=0 (level with the elements, e.g. the top row of a grid that
+    starts at the transducer face) must not produce NaN/Inf, including for the
+    on-axis pixel-element pair (pixel x exactly equal to an element x), which is
+    the exact 0/0 case the Newton-Raphson initial guess divides by."""
+    pixel_pos = keras.ops.convert_to_tensor(probe_geometry)  # same x's, z=0 -> worst case
+    tt = keras.ops.convert_to_numpy(
+        compute_lens_corrected_travel_times(
+            keras.ops.convert_to_tensor(probe_geometry),
+            pixel_pos,
+            lens_thickness=1e-3,
+            c_lens=1000.0,
+            c_medium=SOUND_SPEED,
+        )
+    )
+    assert np.isfinite(tt).all()
+    return tt

--- a/zea/beamform/lens_correction.py
+++ b/zea/beamform/lens_correction.py
@@ -113,8 +113,15 @@ def compute_xl(element_pos_2d, pixel_pos_2d, lens_thickness, c_lens, c_medium, n
 
     # Apply Newton-Raphson method to find the lateral point on the lens that the shortest
     # path goes through
-    xl_init = lens_thickness * (xs - xe) / (zs - ze) + xe
-    xl = xl_init
+    eps = 1e-6
+    # zs == ze whenever a pixel sits level with the element -- most notably the whole
+    # top row of a grid that starts at z=0, the transducer face. Without the eps guard
+    # this is a division by zero (0/0 for on-axis pixels, x/0 elsewhere), producing a
+    # NaN/Inf that a single Newton step's nan_to_num can't undo once it's the seed value.
+    xl_init = lens_thickness * (xs - xe) / (zs - ze + eps) + xe
+    # Clip immediately: for zs == ze the raw ratio can still blow up to +/-inf even with
+    # the eps guard (finite / eps), so bring it into the valid range before it's used.
+    xl = ops.clip(xl_init, ops.minimum(xs, xe), ops.maximum(xs, xe))
     for _ in range(n_iter):
         xl = xl + dxl(xe, ze, xl, xs, zs, lens_thickness, c_lens, c_medium)
 


### PR DESCRIPTION
## Summary

`compute_xl`'s Newton-Raphson initial guess divides by `zs - ze`, which is exactly `0` whenever a pixel sits level with an array element -- e.g. the top row of any imaging grid that starts at the transducer face (z=0). For an on-axis pixel/element pair this is a literal `0/0`, producing a NaN that a single Newton step's `nan_to_num` can't recover from since it poisons the seed value, not just the update step.

Guard the ratio with the same `eps` already used elsewhere in this module, and clip the initial guess into the valid `[xe, xs]` range before the first Newton iteration so the `+/-inf` case (off-axis, `zs==ze`) doesn't slip through either.

Downstream, this NaN silently blacks out entire reconstructed images: `normalize()` takes a global min/max over the whole frame, and a single NaN pixel poisons that reduction for every pixel in the image.

See snippet below (try with / without fix):

<details>
<summary>Snippet</summary>
```python
import os

os.environ["MPLBACKEND"] = "Agg"

import matplotlib.pyplot as plt
import numpy as np

import zea
from zea import Config, File, Pipeline

path = (
    "hf://zeahub/picmus/database/experiments/resolution_distorsion/"
    "resolution_distorsion_expe_dataset_rf/resolution_distorsion_expe_dataset_rf.hdf5"
)
config = Config.from_path("hf://zeahub/picmus/config_rf.yaml")

with File(path) as f:
    probe_geometry = f.probe.get_parameters()["probe_geometry"]

# Force the top row (z=0) of the grid to land exactly on the element x-positions --
# this is the 0/0 case in compute_xl's Newton-Raphson seed. With the default grid
# (400 pixels over +/-20mm) none of the pixel x's exactly match one of the 128
# element x's, so the bug goes unnoticed; it happens whenever grid_size_x
# is chosen to match the element pitch, or simply for the on-axis pixel at x=0 when
# the array has an odd number of elements.
config.parameters.apply_lens_correction = True
config.parameters.zlims = [0.0, 0.055]  # grid starts exactly at the transducer face
config.parameters.xlims = [float(probe_geometry[:, 0].min()), float(probe_geometry[:, 0].max())]
config.parameters.grid_size_x = probe_geometry.shape[0]
config.parameters.dynamic_range = [-60, 0]

with File(path) as f:
    parameters = f.load_parameters(**config.parameters)
    raw = f.data.raw_data[:1]

pipeline = Pipeline.from_config(config)
inputs = pipeline.prepare_parameters(parameters)
outputs = pipeline(data=raw, **inputs, return_numpy=True)
recon = outputs["data"][0]

print("any nan:", np.isnan(recon).any())  # False -- wire targets reconstruct cleanly

image = zea.display.to_8bit(recon, dynamic_range=(-60, 0), pillow=False)
extent_mm = [v * 1e3 for v in parameters.extent_imshow]

zea.visualize.set_mpl_style()
plt.imshow(image, extent=extent_mm, cmap="gray", vmin=0, vmax=255)
plt.xlabel("X (mm)")
plt.ylabel("Z (mm)")
plt.title("PICMUS resolution_distorsion, lens correction on, grid z starts at 0")
out_path = os.path.join(os.path.dirname(__file__), "snippet_reconstruction.png")
plt.savefig(out_path, bbox_inches="tight", dpi=100)
print("saved", out_path)

```
</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved travel-time calculations for pixels located directly at the transducer face.
  * Prevented invalid or non-finite results in lens-corrected beamforming calculations for edge-case geometry.

* **Tests**
  * Added regression coverage to verify finite travel times when pixel and element heights are equal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->