### PR TITLE
Fix flaky backend-equality check in `test_prepare_parameters_pfield_all_backends`

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1218,14 +1218,8 @@ def test_prepare_parameters_pfield_all_backends():
     )
     parameters.grid_size_x = 8
     parameters.grid_size_z = 8
-    # compute_pfield's default downsample=10 collapses this 8x8 grid to a single
-    # downsampled point, so the (bilinear-upsampled) field is constant to within
-    # backend rounding noise. The per-pixel quantile threshold in
-    # normalize_pressure_field is then computed from that same near-constant array,
-    # so a sub-ULP difference between backends can tip individual pixels across the
-    # threshold and get amplified by the cross-transmit renormalization (flaky
-    # backend mismatch). Use a downsample factor that keeps multiple distinct
-    # downsampled points so the field isn't degenerate.
+    # default downsample=10 collapses this 8x8 grid to 1 point, making the field
+    # constant up to backend rounding noise, which flakes the quantile threshold.
     parameters.pfield_kwargs = {"downsample": 2}
 
     # Disable the on-disk result cache so ops are actually executed in each backend

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1218,6 +1218,15 @@ def test_prepare_parameters_pfield_all_backends():
     )
     parameters.grid_size_x = 8
     parameters.grid_size_z = 8
+    # compute_pfield's default downsample=10 collapses this 8x8 grid to a single
+    # downsampled point, so the (bilinear-upsampled) field is constant to within
+    # backend rounding noise. The per-pixel quantile threshold in
+    # normalize_pressure_field is then computed from that same near-constant array,
+    # so a sub-ULP difference between backends can tip individual pixels across the
+    # threshold and get amplified by the cross-transmit renormalization (flaky
+    # backend mismatch). Use a downsample factor that keeps multiple distinct
+    # downsampled points so the field isn't degenerate.
+    parameters.pfield_kwargs = {"downsample": 2}
 
     # Disable the on-disk result cache so ops are actually executed in each backend
     # subprocess (the cache would serve a stale pickle and hide crashes).


### PR DESCRIPTION
## Summary

`test_prepare_parameters_pfield_all_backends` was intermittently failing in CI with a torch-vs-numpy mismatch. It surfaced on an unrelated branch (`feature/minimum-variance`) and isn't caused by any recent change to `pfield.py`, the test itself is unchanged on `main`, so this is a pre-existing flake, not a regression.

**Root cause:** the test's grid is 8x8, but `compute_pfield`'s default `downsample=10` collapses that down to a single downsampled point (`grid[::10, ::10]` on an 8x8 array gives a 1x1 result). The pressure field is then bilinear-resized back up to 8x8, so all 64 output pixels should be mathematically identical — but only to within backend floating-point rounding. `normalize_pressure_field`'s per-pixel quantile threshold is computed from that same near-constant array, so a sub-ULP difference between backends (torch's threaded reduction vs. numpy's) can tip an individual pixel across its own threshold. Because the field is renormalized across the 2 transmits, a flipped pixel jumps from `0.8/0.2` to `1.0/0.0`, which is large enough to fail the `decimal=2` comparison.

**Fix:** pass `pfield_kwargs={"downsample": 2}` in the test so the downsampled grid keeps multiple distinct points (16 instead of 1), avoiding the degenerate constant-field edge case that made the threshold comparison a coin flip.

## Verification

- Reproduced the underlying instability directly: with the original settings, numpy vs. torch outputs for `flat_pfield` differ by ~1 ULP (1.19e-07), consistent with an occasional threshold flip.
- Confirmed the downsampled grid is 1x1 with the original settings and 4x4 with `downsample=2`.
- With the fix, ran the test 3x locally — passed every time with a stable, tiny (~6e-08) cross-backend diff and no threshold flips.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability for pfield parameter preparation across different backends.
  * Added explicit downsampling settings to ensure consistent results and avoid flaky quantile thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->