### PR TITLE
Estimate `t_peak` from waveform

### DIFF
--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -322,6 +322,54 @@ def test_accessing_valid_but_unset_attributes():
     parameters.focus_distances
 
 
+def test_t_peak_default_and_waveform_derived():
+    """t_peak falls back to 1/f0, but is estimated from waveforms_two_way when provided."""
+    center_frequency = 5e6
+    n_tx = 3
+
+    # Default: no waveform or explicit t_peak provided -> falls back to 1 / f0.
+    parameters = Parameters(n_tx=n_tx, center_frequency=center_frequency)
+    parameters.selected_transmits = "all"
+    assert np.allclose(parameters.t_peak, 1 / center_frequency)
+
+    # Build a synthetic pulse-echo waveform with a known envelope peak time.
+    sampling_frequency = 250e6
+    true_t_peak = 1.5e-6
+    t = np.arange(512) / sampling_frequency
+    pulse = np.exp(-((t - true_t_peak) ** 2) / (2 * (0.2e-6) ** 2)) * np.cos(
+        2 * np.pi * center_frequency * (t - true_t_peak)
+    )
+    waveforms_two_way = np.tile(pulse, (n_tx, 1))
+
+    parameters = Parameters(
+        n_tx=n_tx,
+        center_frequency=center_frequency,
+        waveforms_two_way=waveforms_two_way,
+    )
+    parameters.selected_transmits = "all"
+    assert np.allclose(parameters.t_peak, true_t_peak, atol=1e-8)
+
+    # An explicitly provided t_peak still takes priority over the waveform estimate.
+    explicit_t_peak = np.full(n_tx, 9e-7, dtype=np.float32)
+    parameters = Parameters(
+        n_tx=n_tx,
+        center_frequency=center_frequency,
+        waveforms_two_way=waveforms_two_way,
+        t_peak=explicit_t_peak,
+    )
+    parameters.selected_transmits = "all"
+    assert np.allclose(parameters.t_peak, explicit_t_peak)
+
+    # waveforms_one_way alone is not used to derive t_peak.
+    parameters = Parameters(
+        n_tx=n_tx,
+        center_frequency=center_frequency,
+        waveforms_one_way=waveforms_two_way,
+    )
+    parameters.selected_transmits = "all"
+    assert np.allclose(parameters.t_peak, 1 / center_frequency)
+
+
 def test_missing_transmit_defaults_warn_once_on_access(monkeypatch):
     local_scan_args = scan_args.copy()
     local_scan_args.pop("azimuth_angles", None)

--- a/zea/parameters.py
+++ b/zea/parameters.py
@@ -330,6 +330,11 @@ class Parameters(BaseParameters):
     # Add some defaults that are not stored in a file
     VALID_PARAMS["sound_speed"]["default"] = 1540.0
     VALID_PARAMS["probe_bandwidth_percent"]["default"] = 200.0
+    # Give these a default of None (rather than leaving them unset) so that they can be
+    # declared as dependencies of computed properties (e.g. t_peak, n_waveforms) without
+    # tripping MissingDependencyError
+    VALID_PARAMS["waveforms_one_way"]["default"] = None
+    VALID_PARAMS["waveforms_two_way"]["default"] = None
 
     @cache_with_dependencies("probe_geometry")
     def aperture_size(self):
@@ -912,7 +917,7 @@ class Parameters(BaseParameters):
 
         return 1
 
-    @cache_with_dependencies("center_frequency", "selected_transmits")
+    @cache_with_dependencies("center_frequency", "selected_transmits", "waveforms_two_way")
     def t_peak(self):
         """The time of the peak of the pulse in seconds of shape (n_tx,).
 

--- a/zea/parameters.py
+++ b/zea/parameters.py
@@ -114,6 +114,7 @@ from zea.beamform.pixelgrid import (
 )
 from zea.data.spec import ProbeSpec, ScanSpec
 from zea.display import compute_scan_convert_2d_coordinates
+from zea.func.ultrasound import compute_time_to_peak_stack
 from zea.internal.parameters import BaseParameters, MissingDependencyError, cache_with_dependencies
 from zea.internal.utils import deprecated
 from zea.probes import Probe
@@ -913,10 +914,20 @@ class Parameters(BaseParameters):
 
     @cache_with_dependencies("center_frequency", "selected_transmits")
     def t_peak(self):
-        """The time of the peak of the pulse in seconds of shape (n_tx,)."""
+        """The time of the peak of the pulse in seconds of shape (n_tx,).
+
+        If not set explicitly and ``waveforms_two_way`` (the two-way,
+        pulse-echo transmit waveform) is available, this is estimated from it
+        via :func:`~zea.func.ultrasound.compute_time_to_peak_stack`. Otherwise
+        it defaults to ``1 / center_frequency``.
+        """
         t_peak = self._params.get("t_peak")
         if t_peak is None:
-            t_peak = np.full(self.n_tx_total, 1 / self.center_frequency)
+            waveforms = self._params.get("waveforms_two_way")
+            if waveforms is not None:
+                t_peak = np.asarray(compute_time_to_peak_stack(waveforms, self.center_frequency))
+            else:
+                t_peak = np.full(self.n_tx_total, 1 / self.center_frequency)
 
         return t_peak[self.selected_transmits]
 


### PR DESCRIPTION
The default `t_peak` (time to pulse peak) was always `1/center_frequency`, which doesn't match reality for real Verasonics waveforms (they usually ramp up over a few cycles before peaking). 

We already had `compute_time_to_peak_stack` in `func/ultrasound.py`, so now `Parameters.t_peak` uses it when `waveforms_two_way` is available, falling back to `1/f0` otherwise. It is still possible to manually set `Parameters.t_peak`.

## Changes

- `Parameters.t_peak`: derive from `waveforms_two_way` via `compute_time_to_peak_stack` when present
- `waveforms_one_way`/`waveforms_two_way` now default to `None` in `VALID_PARAMS`
- `t_peak` now correctly invalidates its cache when `waveforms_two_way` changes (also fixes the same latent bug in `n_waveforms`)
- Added `test_t_peak_default_and_waveform_derived` in `test_scan.py`