### PR TITLE
Support hf:// paths in `zea data` CLI file operations

### DIFF
--- a/tests/data/test_file_operations.py
+++ b/tests/data/test_file_operations.py
@@ -22,6 +22,9 @@ from zea.data.file_operations import (
 
 from . import generate_dummy_scan, generate_example_dataset
 
+HF_INPUT_PATH = "hf://zeahub/pytest/case_0.hdf5"
+HF_FOLDER_PATH = "hf://zeahub/pytest/folder"
+
 
 @pytest.fixture
 def tmp_hdf5_path(tmp_path) -> Generator[Path, None, None]:
@@ -333,6 +336,54 @@ def test_file_operations_folder_sum(tmp_path):
     with File(output_path) as f:
         raw_data = f["data/raw_data"][:]
         assert raw_data[0, 0, 0, 0, 0] == data0[0, 0, 0, 0, 0] + data1[0, 0, 0, 0, 0]
+
+
+# ── hf:// support (issue #374) ──────────────────────────────────────────────
+
+
+def test_resave_accepts_hf_path(tmp_path, monkeypatch):
+    """resave resolves an 'hf://' input_path via File's existing hf:// resolution logic."""
+    downloaded = tmp_path / "downloaded.hdf5"
+    generate_example_dataset(downloaded, add_optional_dtypes=True)
+    output_path = tmp_path / "resaved.hdf5"
+
+    monkeypatch.setattr(
+        "zea.data.file_operations._hf_resolve_path", lambda hf_path, **kwargs: downloaded
+    )
+
+    resave(HF_INPUT_PATH, output_path)
+
+    validate_file(output_path)
+    _assert_descriptions_and_custom_elements_equal(downloaded, output_path)
+
+
+def test_compound_frames_accepts_hf_folder(tmp_path, monkeypatch):
+    """compound_frames resolves an 'hf://' folder input_path and mirrors it to output_path,
+    just like it already does for local folders."""
+    hf_snapshot_dir = tmp_path / "snapshot"
+    input_paths = [hf_snapshot_dir / "case_0.hdf5", hf_snapshot_dir / "case_1.hdf5"]
+    for path in input_paths:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        generate_example_dataset(path, add_optional_dtypes=True)
+    output_folder = tmp_path / "output"
+
+    monkeypatch.setattr(
+        "zea.data.file_operations._hf_resolve_path", lambda hf_path, **kwargs: hf_snapshot_dir
+    )
+
+    compound_frames(HF_FOLDER_PATH, output_folder)
+
+    for input_path in input_paths:
+        output_path = output_folder / input_path.name
+        assert output_path.is_file()
+        data_dict, _ = load_file_all_data_types(output_path)
+        assert data_dict["raw_data"].shape[0] == 1  # Only one frame should remain
+
+
+def test_save_file_rejects_hf_output_path():
+    """save_file must refuse to write to an 'hf://' path since it is read-only."""
+    with pytest.raises(ValueError, match="hf://"):
+        save_file(path="hf://zeahub/pytest/out.hdf5", parameters=None)
 
 
 def _create_dataset_with_custom(path, n_frames=2, n_tx=4, n_el=8, n_ax=64):

--- a/tests/data/test_file_operations.py
+++ b/tests/data/test_file_operations.py
@@ -338,9 +338,6 @@ def test_file_operations_folder_sum(tmp_path):
         assert raw_data[0, 0, 0, 0, 0] == data0[0, 0, 0, 0, 0] + data1[0, 0, 0, 0, 0]
 
 
-# ── hf:// support (issue #374) ──────────────────────────────────────────────
-
-
 def test_resave_accepts_hf_path(tmp_path, monkeypatch):
     """resave resolves an 'hf://' input_path via File's existing hf:// resolution logic."""
     downloaded = tmp_path / "downloaded.hdf5"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,3 +139,45 @@ def test_app_flags():
     args = cli_args.subcommand
     assert args.share is True
     assert args.server_port == 7861
+
+
+# ── data subcommand: hf:// paths (issue #374) ─────────────────────────────────
+#
+# input_path/input_paths/src are parsed as `str` (not `Path`) specifically so that
+# 'hf://' URIs survive unchanged: `Path("hf://org/repo")` collapses the double
+# slash to `PosixPath('hf:/org/repo')`, which breaks the 'hf://' prefix checks
+# used to resolve Hugging Face paths.
+
+
+@pytest.mark.parametrize(
+    "argv,attr",
+    [
+        (["data", "resave", "hf://zeahub/data/file.h5", "out.hdf5"], "input_path"),
+        (["data", "compound_frames", "hf://zeahub/data/", "out/"], "input_path"),
+        (["data", "compound_transmits", "hf://zeahub/data/file.h5", "out.hdf5"], "input_path"),
+        (["data", "extract", "hf://zeahub/data/file.h5", "out.hdf5"], "input_path"),
+        (["data", "summary", "hf://zeahub/data/file.h5"], "input_path"),
+        (["data", "copy", "hf://zeahub/data/", "out/", "--key", "all"], "src"),
+    ],
+)
+def test_data_subcommands_preserve_hf_paths(argv, attr):
+    args = parse_args(argv).subcommand.subcommand
+    assert getattr(args, attr) == argv[2]
+
+
+def test_data_sum_preserves_hf_paths():
+    cli_args = parse_args(
+        ["data", "sum", "hf://zeahub/a", "hf://zeahub/b", "--output-path", "out.hdf5"]
+    )
+    args = cli_args.subcommand.subcommand
+    assert args.input_paths == ["hf://zeahub/a", "hf://zeahub/b"]
+
+
+def test_data_output_path_rejects_hf():
+    """CLI-level guard: 'hf://' is read-only and cannot be used as an output_path."""
+    from zea.cli_args import _run_data_command
+
+    cli_args = parse_args(["data", "resave", "in.hdf5", "hf://zeahub/out.hdf5"])
+    with pytest.raises(SystemExit) as exc_info:
+        _run_data_command(cli_args.subcommand.subcommand)
+    assert exc_info.value.code != 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -177,3 +177,22 @@ def test_data_output_path_rejects_hf():
     with pytest.raises(SystemExit) as exc_info:
         _run_data_command(cli_args.subcommand.subcommand)
     assert exc_info.value.code != 0
+
+
+def test_data_output_path_local_runs_and_overwrites(tmp_path):
+    """A local (non-'hf://') output_path is unaffected by the 'hf://' guard and,
+    with --overwrite, replaces an existing output file."""
+    from zea.cli_args import _run_data_command
+    from zea.data.file import validate_file
+
+    from .data import generate_example_dataset
+
+    input_path = tmp_path / "in.hdf5"
+    output_path = tmp_path / "out.hdf5"
+    generate_example_dataset(input_path)
+    output_path.write_bytes(b"stale")
+
+    cli_args = parse_args(["data", "resave", str(input_path), str(output_path), "--overwrite"])
+    _run_data_command(cli_args.subcommand.subcommand)
+
+    validate_file(output_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -179,6 +179,16 @@ def test_data_output_path_rejects_hf():
     assert exc_info.value.code != 0
 
 
+def test_data_copy_dst_rejects_hf():
+    """CLI-level guard also applies to `copy`'s dst, which uses a different field name."""
+    from zea.cli_args import _run_data_command
+
+    cli_args = parse_args(["data", "copy", "in.hdf5", "hf://zeahub/out/", "--key", "all"])
+    with pytest.raises(SystemExit) as exc_info:
+        _run_data_command(cli_args.subcommand.subcommand)
+    assert exc_info.value.code != 0
+
+
 def test_data_output_path_local_runs_and_overwrites(tmp_path):
     """A local (non-'hf://') output_path is unaffected by the 'hf://' guard and,
     with --overwrite, replaces an existing output file."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -141,14 +141,6 @@ def test_app_flags():
     assert args.server_port == 7861
 
 
-# ── data subcommand: hf:// paths (issue #374) ─────────────────────────────────
-#
-# input_path/input_paths/src are parsed as `str` (not `Path`) specifically so that
-# 'hf://' URIs survive unchanged: `Path("hf://org/repo")` collapses the double
-# slash to `PosixPath('hf:/org/repo')`, which breaks the 'hf://' prefix checks
-# used to resolve Hugging Face paths.
-
-
 @pytest.mark.parametrize(
     "argv,attr",
     [
@@ -161,11 +153,15 @@ def test_app_flags():
     ],
 )
 def test_data_subcommands_preserve_hf_paths(argv, attr):
+    """'hf://' URIs must survive tyro parsing unchanged: as a `Path`, the double slash
+    collapses to `PosixPath('hf:/org/repo')`, breaking the 'hf://' prefix checks used to
+    resolve Hugging Face paths. These fields are parsed as `str` to avoid that."""
     args = parse_args(argv).subcommand.subcommand
     assert getattr(args, attr) == argv[2]
 
 
 def test_data_sum_preserves_hf_paths():
+    """`sum`'s variadic input_paths must also survive as unmangled 'hf://' strings."""
     cli_args = parse_args(
         ["data", "sum", "hf://zeahub/a", "hf://zeahub/b", "--output-path", "out.hdf5"]
     )

--- a/zea/cli_args.py
+++ b/zea/cli_args.py
@@ -139,9 +139,9 @@ class ProcessArgs:
 class _Sum:
     """Sum the raw data of multiple files or folders."""
 
-    input_paths: tyro.conf.Positional[list[Path]]
-    """Paths to the input files or folders."""
-    output_path: Path
+    input_paths: tyro.conf.Positional[list[str]]
+    """Paths to the input files or folders. Also accepts 'hf://' paths."""
+    output_path: str
     """Output HDF5 file. Passed as ``--output-path`` because the inputs are variadic."""
     overwrite: bool = False
     """Overwrite existing output file."""
@@ -158,9 +158,9 @@ class _Sum:
 class _CompoundFrames:
     """Compound frames to increase SNR."""
 
-    input_path: tyro.conf.Positional[Path]
-    """Input HDF5 file or folder."""
-    output_path: tyro.conf.Positional[Path]
+    input_path: tyro.conf.Positional[str]
+    """Input HDF5 file or folder. Also accepts an 'hf://' path."""
+    output_path: tyro.conf.Positional[str]
     """Output HDF5 file or folder."""
     overwrite: bool = False
     """Overwrite existing output file."""
@@ -177,9 +177,9 @@ class _CompoundFrames:
 class _CompoundTransmits:
     """Compound transmits to increase SNR."""
 
-    input_path: tyro.conf.Positional[Path]
-    """Input HDF5 file or folder."""
-    output_path: tyro.conf.Positional[Path]
+    input_path: tyro.conf.Positional[str]
+    """Input HDF5 file or folder. Also accepts an 'hf://' path."""
+    output_path: tyro.conf.Positional[str]
     """Output HDF5 file or folder."""
     overwrite: bool = False
     """Overwrite existing output file."""
@@ -196,9 +196,9 @@ class _CompoundTransmits:
 class _Resave:
     """Resave a file to change format version."""
 
-    input_path: tyro.conf.Positional[Path]
-    """Input HDF5 file or folder."""
-    output_path: tyro.conf.Positional[Path]
+    input_path: tyro.conf.Positional[str]
+    """Input HDF5 file or folder. Also accepts an 'hf://' path."""
+    output_path: tyro.conf.Positional[str]
     """Output HDF5 file or folder."""
     overwrite: bool = False
     """Overwrite existing output file."""
@@ -223,9 +223,9 @@ class _Resave:
 class _Extract:
     """Extract subset of frames or transmits."""
 
-    input_path: tyro.conf.Positional[Path]
-    """Input HDF5 file or folder."""
-    output_path: tyro.conf.Positional[Path]
+    input_path: tyro.conf.Positional[str]
+    """Input HDF5 file or folder. Also accepts an 'hf://' path."""
+    output_path: tyro.conf.Positional[str]
     """Output HDF5 file or folder."""
     transmits: list[str] = field(default_factory=lambda: ["all"])
     """Target transmits. Can be a list of integers or ranges (e.g. 0-3 7)."""
@@ -250,8 +250,8 @@ class _Extract:
 class _Summary:
     """Print a summary of a zea data file to the console."""
 
-    input_path: tyro.conf.Positional[Path]
-    """Input HDF5 file."""
+    input_path: tyro.conf.Positional[str]
+    """Input HDF5 file. Also accepts an 'hf://' path."""
 
     def run(self):
         from zea.data.file_operations import summary
@@ -268,9 +268,9 @@ class _Copy:
     how the data is written (append, overwrite, etc.).
     """
 
-    src: tyro.conf.Positional[Path]
-    """Source file or folder path."""
-    dst: tyro.conf.Positional[Path]
+    src: tyro.conf.Positional[str]
+    """Source file or folder path. Also accepts an 'hf://' path."""
+    dst: tyro.conf.Positional[str]
     """Destination folder path."""
     key: str
     """Key to access in the HDF5 files."""
@@ -305,6 +305,9 @@ def _run_data_command(command) -> None:
     from zea.log import logger
 
     output_path = getattr(command, "output_path", None)
+    if output_path is not None and str(output_path).startswith("hf://"):
+        logger.error("Output path cannot be an 'hf://' path; 'hf://' is only supported for inputs.")
+        raise SystemExit(1)
     if (
         output_path is not None
         and Path(output_path).is_file()
@@ -321,7 +324,8 @@ class DataArgs:
 
     All operations accept files; folder inputs are also supported. For file-to-file
     operations, each zea file in the input folder is processed and written to a
-    mirrored path in the output folder.
+    mirrored path in the output folder. Inputs also accept ``hf://`` paths (a single
+    file or a folder in a Hugging Face dataset repo); outputs must be local paths.
     """
 
     subcommand: tyro.conf.OmitSubcommandPrefixes[DataCommand]

--- a/zea/cli_args.py
+++ b/zea/cli_args.py
@@ -305,7 +305,10 @@ def _run_data_command(command) -> None:
     from zea.log import logger
 
     output_path = getattr(command, "output_path", None)
-    if output_path is not None and str(output_path).startswith("hf://"):
+    dst = getattr(command, "dst", None)
+    if (output_path is not None and str(output_path).startswith("hf://")) or (
+        dst is not None and str(dst).startswith("hf://")
+    ):
         logger.error("Output path cannot be an 'hf://' path; 'hf://' is only supported for inputs.")
         raise SystemExit(1)
     if (

--- a/zea/data/file_operations.py
+++ b/zea/data/file_operations.py
@@ -7,6 +7,7 @@ command-line usage.
 """
 
 import functools
+from collections.abc import Sequence
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +20,7 @@ from zea.data.file import File, load_file_all_data_types
 from zea.data.spec import DEFAULT_COMPRESSION
 from zea.internal.checks import _IMAGE_DATA_TYPES, _NON_IMAGE_DATA_TYPES
 from zea.internal.core import DataTypes
+from zea.internal.preset_utils import HF_PREFIX, _hf_resolve_path
 from zea.log import logger
 
 ALL_DATA_TYPES_EXCEPT_RAW = set(_IMAGE_DATA_TYPES + _NON_IMAGE_DATA_TYPES) - {"raw_data"}
@@ -53,7 +55,8 @@ def save_file(
     """Saves data to a zea data file (h5py file).
 
     Args:
-        path (str, pathlike): The path to the hdf5 file.
+        path (str, pathlike): The path to the hdf5 file. Must be a local path; ``hf://``
+            paths are read-only and cannot be used as a save destination.
         parameters (Parameters): The parameters object containing acquisition and probe
             parameters.
         raw_data (np.ndarray): The data to save.
@@ -94,6 +97,11 @@ def save_file(
         chunk_frames (bool, optional): Whether to store the data datasets with HDF5
             chunked storage, using one frame per chunk. Defaults to False.
     """
+    if str(path).startswith(HF_PREFIX):
+        raise ValueError(
+            f"Cannot save to an 'hf://' path: {path}. 'hf://' paths are read-only; "
+            "save to a local path instead."
+        )
 
     data = {}
     for key, arr in [
@@ -124,7 +132,7 @@ def save_file(
     )
 
 
-def _iter_folder_io(input_path: Path, output_path: Path):
+def _iter_folder_io(input_path: str | Path, output_path: str | Path):
     """Yields ``(input_file, output_file)`` path pairs for a folder operation.
 
     Uses :class:`zea.Dataset` to iterate over every zea file in ``input_path``. The
@@ -150,10 +158,17 @@ def _supports_folders(operation):
     applied to every zea file in that folder (iterated with :class:`zea.Dataset`),
     writing the results to ``output_path`` and mirroring the input folder structure.
     A single file is processed as before.
+
+    ``input_path`` may also be an ``hf://`` path (pointing at a single file or a
+    folder in a Hugging Face dataset repo); it is downloaded via
+    :func:`zea.internal.preset_utils._hf_resolve_path` before dispatching.
     """
 
     @functools.wraps(operation)
     def wrapper(input_path, output_path, *args, **kwargs):
+        input_path = str(input_path)
+        if input_path.startswith(HF_PREFIX):
+            input_path = _hf_resolve_path(input_path)
         if not Path(input_path).is_dir():
             return operation(input_path, output_path, *args, **kwargs)
         output_path = Path(output_path)
@@ -169,7 +184,7 @@ def _supports_folders(operation):
     return wrapper
 
 
-def sum_data(input_paths: list[Path], output_path: Path, overwrite=False):
+def sum_data(input_paths: Sequence[str | Path], output_path: str | Path, overwrite=False):
     """
     Sums multiple raw data files and saves the result to a new file.
 
@@ -178,9 +193,9 @@ def sum_data(input_paths: list[Path], output_path: Path, overwrite=False):
     averaging in the linear domain.
 
     Args:
-        input_paths (list[Path]): List of paths to the input raw data files. Each path
-            may be a single file or a folder; folders are expanded into all zea files
-            they contain (using :class:`zea.Dataset`).
+        input_paths (list[str, Path]): List of paths to the input raw data files. Each path
+            may be a single file, a folder, or an ``hf://`` path; folders (local or ``hf://``)
+            are expanded into all zea files they contain (using :class:`zea.Dataset`).
         output_path (Path): Path to the output file where the summed data will be saved.
         overwrite (bool, optional): Whether to overwrite the output file if it exists.
             Defaults to False.
@@ -283,12 +298,13 @@ def _assert_shapes_equal(array0, array1, name="array"):
 
 
 @_supports_folders
-def compound_frames(input_path: Path, output_path: Path, overwrite=False):
+def compound_frames(input_path: str | Path, output_path: str | Path, overwrite=False):
     """
     Compounds frames in a raw data file by averaging them.
 
     Args:
-        input_path (Path): Path to the input raw data file, or a folder of files.
+        input_path (str, Path): Path to the input raw data file, or a folder of files.
+            Also accepts an ``hf://`` path (file or folder).
         output_path (Path): Path to the output file (or folder) where the compounded
             data will be saved.
         overwrite (bool, optional): Whether to overwrite the output file if it exists.
@@ -344,7 +360,7 @@ def compound_frames(input_path: Path, output_path: Path, overwrite=False):
 
 
 @_supports_folders
-def compound_transmits(input_path: Path, output_path: Path, overwrite=False):
+def compound_transmits(input_path: str | Path, output_path: str | Path, overwrite=False):
     """
     Compounds transmits in a raw data file by averaging them.
 
@@ -353,7 +369,8 @@ def compound_transmits(input_path: Path, output_path: Path, overwrite=False):
         function will result in incorrect scan parameters.
 
     Args:
-        input_path (Path): Path to the input raw data file, or a folder of files.
+        input_path (str, Path): Path to the input raw data file, or a folder of files.
+            Also accepts an ``hf://`` path (file or folder).
         output_path (Path): Path to the output file (or folder) where the compounded
             data will be saved.
         overwrite (bool, optional): Whether to overwrite the output file if it exists.
@@ -418,8 +435,8 @@ def _check_all_identical(array, axis=0):
 
 @_supports_folders
 def resave(
-    input_path: Path,
-    output_path: Path,
+    input_path: str | Path,
+    output_path: str | Path,
     overwrite=False,
     enable_compression=True,
     chunk_frames=False,
@@ -428,7 +445,8 @@ def resave(
     Resaves a zea data file to a new location.
 
     Args:
-        input_path (Path): Path to the input zea data file, or a folder of files.
+        input_path (str, Path): Path to the input zea data file, or a folder of files.
+            Also accepts an ``hf://`` path (file or folder).
         output_path (Path): Path to the output file (or folder) where the data will be saved.
         overwrite (bool, optional): Whether to overwrite the output file if it exists.
             Defaults to False.
@@ -459,8 +477,8 @@ def resave(
 
 @_supports_folders
 def extract_frames_transmits(
-    input_path: Path,
-    output_path: Path,
+    input_path: str | Path,
+    output_path: str | Path,
     frame_indices=slice(None),
     transmit_indices=slice(None),
     overwrite=False,
@@ -473,7 +491,8 @@ def extract_frames_transmits(
     information on the supported index types.
 
     Args:
-        input_path (Path): Path to the input raw data file, or a folder of files.
+        input_path (str, Path): Path to the input raw data file, or a folder of files.
+            Also accepts an ``hf://`` path (file or folder).
         output_path (Path): Path to the output file (or folder) where the extracted
             data will be saved.
         frame_indices (list, array-like, or slice): Indices of the frames to keep.
@@ -502,21 +521,22 @@ def extract_frames_transmits(
     )
 
 
-def summary(input_path: Path):
+def summary(input_path: str | Path):
     """Prints a summary of a zea data file to the console.
 
     Args:
-        input_path (Path): Path to the zea data file.
+        input_path (str, Path): Path to the zea data file. Also accepts an ``hf://`` path.
     """
     with File(input_path) as f:
         f.summary()
 
 
-def copy(src: Path, dst: Path, key: str, mode: str | None = None):
+def copy(src: str | Path, dst: str | Path, key: str, mode: str | None = None):
     """Copies zea files to a new location using :meth:`zea.Dataset.copy`.
 
     Args:
-        src (Path): Source path. Can be a single file, a list of files, or a folder.
+        src (str, Path): Source path. Can be a single file, a list of files, a folder,
+            or an ``hf://`` path.
         dst (Path): Destination folder path.
         key (str): Key to access in the HDF5 files. Use ``"all"`` or ``"*"`` to copy
             everything.
@@ -528,8 +548,9 @@ def copy(src: Path, dst: Path, key: str, mode: str | None = None):
     dataset.copy(dst, key, mode=mode)
 
 
-def _delete_file_if_exists(path: Path):
+def _delete_file_if_exists(path: str | Path):
     """Deletes a file if it exists."""
+    path = Path(path)
     if path.exists():
         path.unlink()
 


### PR DESCRIPTION
## Summary

Closes #374.

`zea.File` already resolves `hf://` (Hugging Face) paths, but the `zea data` CLI subcommands (`resave`, `compound_frames`, `compound_transmits`, `sum`, `extract`, plus `summary`/`copy`) typed their path arguments as `Path` for tyro. `Path("hf://org/repo")` collapses the double slash into `hf:/org/repo`, silently breaking every `hf://` prefix check downstream — so passing an `hf://` path to these commands either misbehaved or failed with a confusing h5py error.

## What changed

- Path arguments (`input_path`, `input_paths`, `src`) are now typed `str` instead of `Path`, matching the existing pattern already used by `zea process --dataset`. `output_path`/`dst` are also `str` now, so a bad `hf://` output can actually be detected and rejected (previously the mangling hid it from any check).
- `_supports_folders` (used by `resave`, `compound_frames`, `compound_transmits`, `extract`) now resolves an `hf://` `input_path` — file or folder — via the same `_hf_resolve_path` helper `zea.File` already uses, before deciding whether to run in single-file or folder mode. `sum` and `copy` already delegated to `zea.Dataset`, which resolves `hf://` paths on its own, so they only needed the type fix.
- Writing to an `hf://` path is now rejected with a clear error (in `save_file` and at the CLI level), since `hf://` is read-only.

## Try it

```bash
zea data resave hf://zeahub/camus-sample/val/patient0401/patient0401_4CH_half_sequence.hdf5 out.hdf5
zea data compound_frames hf://zeahub/camus-sample/val/patient0401 out/
```

## Tests

Added coverage in `tests/test_main.py` (CLI parsing keeps `hf://` paths intact instead of mangling them, and rejects `hf://` as an output path) and `tests/data/test_file_operations.py` (`resave`/`compound_frames` correctly resolve a mocked `hf://` file/folder; `save_file` rejects an `hf://` output path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for `hf://` paths as inputs across `zea data` commands and related file operations.
  - Enabled `hf://` folder inputs for frame-compounding workflows.
  - Updated CLI guidance to clarify that inputs may be `hf://`, while outputs must be local paths.

- **Bug Fixes**
  - Added validation to reject `hf://` destinations for saving/conversion, returning clear errors.
  - Improved correctness for input resolution and output mirroring during compound workflows.

- **Tests**
  - Expanded CLI and file-operation coverage for `hf://` input handling and rejection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->