### PR TITLE
Show actual values in File.summary(), not just field descriptions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Sets up a local dev environment for Claude Code on the web so linters, pre-commit,
+# and pytest all work out of the box. Only runs in remote sessions — local
+# contributors are expected to already have their own environment set up (see
+# docs/source/contributing.rst).
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Mirrors `uv sync --extra dev` from docs/source/contributing.rst. --frozen keeps
+# this from touching uv.lock. jax[cpu] is installed separately (not part of the
+# `dev` extra) as the cheapest backend to exercise `zea`, matching the JAX-only
+# jobs in CI.
+export UV_TORCH_BACKEND=cpu
+uv sync --frozen --extra dev
+uv pip install --python .venv/bin/python "jax[cpu]"
+
+uv run --no-sync pre-commit install >/dev/null
+
+# Make the venv (and its console scripts: pytest, ruff, ty, pre-commit, ...)
+# available on PATH for the rest of the session, and select the JAX backend.
+{
+  echo "export VIRTUAL_ENV=\"$CLAUDE_PROJECT_DIR/.venv\""
+  echo "export PATH=\"$CLAUDE_PROJECT_DIR/.venv/bin:\$PATH\""
+  echo "export KERAS_BACKEND=jax"
+} >> "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,11 @@ __pycache__/
 .DS_Store
 /.ideas
 .devcontainer
-.claude
+# Ignore local/personal Claude Code state, but keep shared project config tracked.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+!.claude/hooks/**
 
 # C extensions
 *.so

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -89,8 +89,37 @@ def test_print_hdf5_attrs(complex_h5_file, capsys):
     with File(complex_h5_file) as file:
         file.summary()
 
-    captured = capsys.readouterr()
-    assert "dummy_attr" in captured.out
+    captured = capsys.readouterr().out
+    assert "dummy_attr" in captured
+    # dummy_dataset2 = np.arange(5) is small enough to show its actual values inline.
+    assert "[0, 1, 2, 3, 4]" in captured
+    # dummy_dataset has 200 elements: too big to inline, only shape/dtype are shown.
+    assert "shape=(10, 20)" in captured
+    assert "dtype=float64" in captured
+
+
+def test_print_hdf5_attrs_spec_file(tmp_path, capsys):
+    """Scalar spec fields print their value; large arrays only print shape/dtype;
+    unset unit/description metadata is hidden."""
+    path = tmp_path / "example.hdf5"
+    generate_example_dataset(path, n_tx=3, n_el=4, n_ax=8, n_frames=1)
+
+    with File(path) as file:
+        file.summary()
+
+    captured = capsys.readouterr().out
+    # `sound_speed` is a scalar field: its actual value and unit should be shown.
+    assert "sound_speed" in captured
+    assert "1540" in captured
+    assert "[m/s]" in captured
+    # `t0_delays` is a large array (n_tx * n_el = 12 elements): only its shape/dtype
+    # are shown, not the raw values.
+    assert "t0_delays" in captured
+    assert "shape=(3, 4)" in captured
+    # Fields without curated unit metadata fall back to the "-" placeholder, which
+    # carries no information and should be hidden rather than printed.
+    assert "[-]" not in captured
+    assert "[–]" not in captured
 
 
 def test_file_attributes():

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -2059,8 +2059,8 @@ def _format_hdf5_dataset_line(key, dataset):
             dtype_str = dataset.dtype.name
         body = f"{log.bold(key)} " + log.dim(f"(shape={shape_str}, dtype={dtype_str})")
 
-    unit = dataset.attrs.get("unit", "")
-    description = dataset.attrs.get("description", "")
+    unit = _decode_hdf5_scalar(dataset.attrs.get("unit", ""))
+    description = _decode_hdf5_scalar(dataset.attrs.get("description", ""))
     extras = []
     if unit not in _EMPTY_UNITS:
         extras.append(log.dim(f"[{unit}]"))
@@ -2110,9 +2110,12 @@ def _print_hdf5_attrs(hdf5_obj, prefix=""):
         child = hdf5_obj[key]
         if isinstance(child, h5py.Dataset):
             print(prefix + marker + _format_hdf5_dataset_line(key, child))
-        else:
+        elif isinstance(child, h5py.Group):
             print(prefix + marker + log.bold(key) + "/")
             _print_hdf5_attrs(child, child_prefix)
+        else:
+            # e.g. a committed h5py.Datatype — not a Dataset or Group, nothing to recurse into.
+            print(prefix + marker + log.bold(key))
 
 
 def validate_file(path: str | None = None, file: "File | None" = None):

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -1826,7 +1826,12 @@ class File(h5py.File):
             self.copy(scan_path, dst, name="scan")
 
     def summary(self):
-        """Print the contents of the file."""
+        """Print a human-readable tree of the file's contents.
+
+        Scalars and small datasets are printed with their actual value; large
+        datasets show their shape and dtype instead. Unit and description
+        metadata is shown inline where available.
+        """
         _print_hdf5_attrs(self)
 
 
@@ -1991,29 +1996,107 @@ def load_file(
         return data, parameters
 
 
+# A dataset with this many elements or fewer has its actual values printed;
+# bigger datasets only show their shape/dtype to avoid dumping large arrays.
+_MAX_INLINE_ELEMENTS = 8
+
+# Placeholder unit/description values written by DataSpec for fields that have
+# no curated metadata (see `_DEFAULT_FIELD_UNIT`/`_DEFAULT_FIELD_DESCRIPTION`
+# in `zea.data.spec`). These carry no information, so the summary hides them.
+_EMPTY_UNITS = {"", "-", "–"}
+
+
+def _decode_hdf5_scalar(value):
+    """Decode a raw scalar read from HDF5 (bytes/np.generic) to a native Python value."""
+    if isinstance(value, np.generic):
+        value = value.item()
+    if isinstance(value, bytes):
+        value = value.decode()
+    return value
+
+
+def _format_hdf5_scalar(value):
+    """Colorize a single decoded scalar value for display."""
+    if isinstance(value, str):
+        return log.cyan(f'"{value}"')
+    if isinstance(value, (bool, np.bool_)):
+        return log.cyan(str(value))
+    if isinstance(value, float):
+        if value != value:  # NaN
+            text = "nan"
+        elif value.is_integer() and abs(value) < 1e15:
+            text = str(int(value))
+        else:
+            text = f"{value:.6g}"
+        return log.cyan(text)
+    return log.cyan(str(value))
+
+
+def _format_hdf5_value(value):
+    """Colorize an HDF5 attribute or (small) dataset value for display."""
+    if isinstance(value, np.ndarray):
+        if value.shape == ():
+            return _format_hdf5_scalar(_decode_hdf5_scalar(value[()]))
+        items = [_decode_hdf5_scalar(item) for item in value.tolist()]
+        return log.cyan(str(items))
+    return _format_hdf5_scalar(_decode_hdf5_scalar(value))
+
+
+def _format_hdf5_attr_line(key, value):
+    """Format a plain HDF5 attribute (e.g. a file- or group-level attribute) as one line."""
+    return f"{log.bold(key)}: {_format_hdf5_value(value)}"
+
+
+def _format_hdf5_dataset_line(key, dataset):
+    """Format a leaf HDF5 dataset as one line: its value (or shape) plus unit/description."""
+    if 0 < dataset.size <= _MAX_INLINE_ELEMENTS:
+        body = f"{log.bold(key)}: {_format_hdf5_value(dataset[()])}"
+    else:
+        shape_str = str(dataset.shape).replace(",)", ")")
+        if h5py.check_string_dtype(dataset.dtype) is not None:
+            dtype_str = "str"
+        else:
+            dtype_str = dataset.dtype.name
+        body = f"{log.bold(key)} " + log.dim(f"(shape={shape_str}, dtype={dtype_str})")
+
+    unit = dataset.attrs.get("unit", "")
+    description = dataset.attrs.get("description", "")
+    extras = []
+    if unit not in _EMPTY_UNITS:
+        extras.append(log.dim(f"[{unit}]"))
+    if description:
+        extras.append(log.dim(description))
+    if extras:
+        body += "  " + "  ".join(extras)
+    return body
+
+
 def _print_hdf5_attrs(hdf5_obj, prefix=""):
-    """Recursively prints all keys, attributes, and shapes in an HDF5 file.
+    """Recursively prints the contents of an HDF5 file in a human-readable tree.
+
+    Scalars and small datasets (up to ``_MAX_INLINE_ELEMENTS`` elements) are printed
+    with their actual value; larger datasets only show their shape and dtype. Unit and
+    description metadata is shown inline, and hidden when unset.
 
     Args:
-        hdf5_obj (h5py.File, h5py.Group, h5py.Dataset): HDF5 object to print.
+        hdf5_obj (h5py.File, h5py.Group): HDF5 object to print.
         prefix (str, optional): Prefix to print before each line. This
             parameter is used in internal recursion and should not be supplied
             by the user.
     """
-    assert isinstance(hdf5_obj, (h5py.File, h5py.Group, h5py.Dataset)), (
-        "ERROR: hdf5_obj must be a File, Group, or Dataset object"
+    assert isinstance(hdf5_obj, (h5py.File, h5py.Group)), (
+        "ERROR: hdf5_obj must be a File or Group object"
     )
 
     if isinstance(hdf5_obj, h5py.File):
         name = "root" if hdf5_obj.name == "/" else hdf5_obj.name
-        print(prefix + name + "/")
+        print(prefix + log.bold(name) + "/")
 
     # Collect all children (attributes first, then sub-groups/datasets) into a
     # single ordered list so ``is_last`` is computed across the full set and the
     # tree connectors line up correctly.
     entries = [("attr", key, val) for key, val in hdf5_obj.attrs.items()]
-    if isinstance(hdf5_obj, h5py.Group):
-        entries += [("item", key, None) for key in hdf5_obj.keys()]
+    entries += [("item", key, None) for key in hdf5_obj.keys()]
 
     for i, (kind, key, val) in enumerate(entries):
         is_last = i == len(entries) - 1
@@ -2021,16 +2104,15 @@ def _print_hdf5_attrs(hdf5_obj, prefix=""):
         child_prefix = prefix + ("    " if is_last else "│   ")
 
         if kind == "attr":
-            print(prefix + marker + key + ": " + str(val))
+            print(prefix + marker + _format_hdf5_attr_line(key, val))
             continue
 
         child = hdf5_obj[key]
         if isinstance(child, h5py.Dataset):
-            shape_str = str(child.shape).replace(",)", ")")
-            print(prefix + marker + key + " (shape=" + shape_str + ")")
+            print(prefix + marker + _format_hdf5_dataset_line(key, child))
         else:
-            print(prefix + marker + key + "/")
-        _print_hdf5_attrs(child, child_prefix)
+            print(prefix + marker + log.bold(key) + "/")
+            _print_hdf5_attrs(child, child_prefix)
 
 
 def validate_file(path: str | None = None, file: "File | None" = None):

--- a/zea/log.py
+++ b/zea/log.py
@@ -120,7 +120,8 @@ def bold(string):
 def dim(string):
     """Adds ANSI escape codes to print a string in a dim/faint style around the string."""
     return "\033[2m" + str(string) + "\033[0m"
-  
+
+
 # Progress bars (other than tqdm, which is handled separately below) that have
 # asked to be redrawn whenever a log message is emitted while they are on screen.
 # A WeakSet so a bar that never explicitly unregisters (e.g. a loop that

--- a/zea/log.py
+++ b/zea/log.py
@@ -55,6 +55,7 @@ def get_format_fn(name_format):
         "orange": orange,
         # Formatting
         "bold": bold,
+        "dim": dim,
     }.get(name_format)
 
 
@@ -111,6 +112,11 @@ def orange(string):
 def bold(string):
     """Adds ANSI escape codes to print a string in bold around the string."""
     return "\033[1m" + str(string) + "\033[0m"
+
+
+def dim(string):
+    """Adds ANSI escape codes to print a string in a dim/faint style around the string."""
+    return "\033[2m" + str(string) + "\033[0m"
 
 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
`File.summary()` (and `zea data summary`) only ever printed a dataset's shape and its spec description — never the actual value. So for scalar fields like `credit` or `probe/name`, you'd see a description telling you what the field *is*, but never what it's actually set to. You had to drop into Python and read the field yourself to find out.

Now scalars and small datasets (≤ 8 elements) print their real value. Large arrays still just print shape (plus dtype now). Units/descriptions with nothing to say (the "not set" placeholder) are hidden instead of printed as noise. Output is colorized (bold keys, cyan values, dim units/descriptions).

### Example

```
zea data summary my_scan.hdf5
```

**Before:**
```
├── metadata/
│   ├── credit (shape=())
│   │   ├── description: Credit or attribution for the dataset.
│   │   └── unit: –
│   └── subject/
│       └── type/
│           ├── /metadata/subject/type (shape=())
│           │   ├── description:
│           │   ├── unit: -
```

**After:**
```
├── metadata/
│   ├── credit: "us4us Ltd."  Credit or attribution for the dataset.
│   └── subject/
│       ├── id: "s8"  Subject ID. Needed for subject-wise splits.
│       └── type: "phantom"  Subject type, e.g. human, phantom, animal.
```

Big arrays like `raw_data` or `t0_delays` are unchanged — still just shape, now with dtype too, so nothing gets dumped to the console:

```
└── raw_data (shape=(10, 1024, 470, 512, 1), dtype=float32)  Raw channel data.
```

Looks pretty too now!

<img width="1017" height="527" alt="image" src="https://github.com/user-attachments/assets/d82a8852-2042-4ff9-8dba-7feaeeb57010" />

## Additionally

Added claude hook, which basically sets up the environment and makes sure it runs `pre-commit run --all` in isolated sessions. Useful for when you would like Claude to solve a well-defined and small issue on its own. It can spin up its own environment etc. Rather it having to figure out installation and linting instructions from the docs it can use the [claude hook](https://code.claude.com/docs/en/hooks). 

