### PR TITLE
Improved warnings when reading HDF5 files

### DIFF
--- a/tests/data/test_chunk_reader.py
+++ b/tests/data/test_chunk_reader.py
@@ -27,6 +27,8 @@ from zea.data.chunk_reader import (
     MIN_BYTES,
     HTTPFetcher,
     LocalFetcher,
+    _display_path,
+    _human_bytes,
     eligible,
     fetcher_for,
     read,
@@ -369,6 +371,46 @@ class TestFallbackNotes:
             got = file.data.raw_data[selection]
             assert got.nbytes < MIN_BYTES
             np.testing.assert_array_equal(got, file[RAW][selection])
+
+
+class TestHumanBytes:
+    @pytest.mark.parametrize(
+        ("n", "expected"),
+        [
+            (0, "0 B"),
+            (1023, "1023 B"),
+            (1024, "1.0 KB"),
+            (1536, "1.5 KB"),
+            (1024**2, "1.0 MB"),
+            (1024**3, "1.0 GB"),
+            (1024**4, "1.0 TB"),
+            (1024**5, "1024.0 TB"),
+        ],
+    )
+    def test_units(self, n, expected):
+        assert _human_bytes(n) == expected
+
+
+class TestDisplayPath:
+    def test_strips_track_prefix_for_single_track_file(self, structured_file):
+        with File(structured_file) as file:
+            assert _display_path(file[RAW]) == "/data/raw_data"
+
+    def test_keeps_track_prefix_for_multi_track_file(self, tmp_path):
+        path = tmp_path / "multi_track.hdf5"
+
+        def _track(label):
+            return {"data": {"raw_data": _structured()}, "scan": _scan(), "label": label}
+
+        File.create(
+            path,
+            tracks=[_track("a"), _track("b")],
+            probe={"name": "generic", "probe_geometry": np.zeros((N_EL, 3), np.float32)},
+            ignore_warnings=True,
+        )
+        with File(path) as file:
+            dset = file["tracks/track_0/data/raw_data"]
+            assert _display_path(dset) == "/tracks/track_0/data/raw_data"
 
 
 @pytest.fixture

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -517,6 +517,14 @@ class TestGroupProxy:
             assert isinstance(proxy, _GroupProxy)
             assert proxy.values.shape == (n_frames, 16, 12, 1)
 
+    def test_slicing_group_raises_helpful_type_error(self, spec_file):
+        """Slicing a group directly (e.g. f.data.envelope_data[:]) should point to '.values'."""
+        path, *_ = spec_file
+
+        with File(path) as f:
+            with pytest.raises(TypeError, match=r"envelope_data\.values\[:\]"):
+                f.data.envelope_data[:]
+
     def test_missing_key_raises_attribute_error(self, spec_file):
         path, *_ = spec_file
 

--- a/tests/data/test_file.py
+++ b/tests/data/test_file.py
@@ -13,6 +13,7 @@ from zea.data.file import (
     CustomElement,
     File,
     Track,
+    _format_selection,
     _GroupProxy,
     _StringDataset,
     load_file,
@@ -473,6 +474,24 @@ class TestStringDataset:
             result = labels_ds[:]
             assert result.dtype.kind == "U"
             np.testing.assert_array_equal(result, seg_labels)
+
+
+class TestFormatSelection:
+    @pytest.mark.parametrize(
+        ("selection", "expected"),
+        [
+            (slice(None), ":"),
+            (slice(1, 5), "1:5"),
+            (slice(None, None, 2), "::2"),
+            (slice(1, 5, 2), "1:5:2"),
+            (Ellipsis, "..."),
+            (0, "0"),
+            ((0, slice(None), slice(1, 5)), "0, :, 1:5"),
+            ((Ellipsis, 0), "..., 0"),
+        ],
+    )
+    def test_formats_selection_as_source_would_read(self, selection, expected):
+        assert _format_selection(selection) == expected
 
 
 class TestGroupProxy:

--- a/zea/data/chunk_reader.py
+++ b/zea/data/chunk_reader.py
@@ -370,6 +370,20 @@ def _human_bytes(n: int) -> str:
     return f"{size:.1f} TB"
 
 
+def _display_path(dset: h5py.Dataset) -> str:
+    """Dataset path as the user indexes it, not the raw internal HDF5 path.
+
+    Single-track files resolve paths without the tracks prefix (``f.data.raw_data``
+    rather than ``f.tracks[0].data.raw_data`` — see :class:`zea.data.file.File`), so
+    when ``track_0`` is the only track, drop ``/tracks/track_0`` from the path.
+    """
+    path = dset.name
+    prefix = "/tracks/track_0/"
+    if path.startswith(prefix) and len(dset.file["tracks"]) == 1:
+        return path[len(prefix) - 1 :]
+    return path
+
+
 def _fallback_note(
     dset: h5py.Dataset, fetcher: Fetcher | None, kind: str, cause: str, fix: str
 ) -> None:
@@ -378,17 +392,19 @@ def _fallback_note(
     Serial reads happen locally too, not only when streaming, so this fires whether or not
     progress was requested. ``cause`` completes "Reading '{name}' {cause}" and ``fix`` says how
     to avoid it; ``kind`` scopes the once-only dedupe so the resave and selection notes do not
-    silence each other. The name is the file, not the dataset's internal HDF5 path — that is
-    what a user would actually act on. Anything that could break here is swallowed; a message
-    is never worth failing a read over.
+    silence each other. The name is the file — that is what a user would actually act on —
+    with the dataset's path in brackets (as the user indexes it, see :func:`_display_path`),
+    so notes for different datasets of the same file read as distinct rather than as repeats.
+    Anything that could break here is swallowed; a message is never worth failing a read over.
     """
     try:
         from zea import log
 
         name = fetcher.source if fetcher is not None else dset.name
         size = _human_bytes(dset.nbytes)
+        detail = log.dim(f"({_display_path(dset)}, {size})")
         log.warning_once(
-            f"Reading '{name}' ({size}) {cause} — falling back to a serial h5py read "
+            f"Reading '{name}' {detail} {cause} — falling back to a serial h5py read "
             f"(slower). {fix}",
             key=(dset.name, kind),
         )

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -188,6 +188,25 @@ class ChunkedDataset:
         return f"<ChunkedDataset {self._dset.name} shape={self.shape} dtype={self.dtype}>"
 
 
+def _format_selection(selection) -> str:
+    """Formats a __getitem__ argument as it would appear in source, e.g. slice(None) -> ':'."""
+
+    def _format_one(part) -> str:
+        if isinstance(part, slice):
+            start = "" if part.start is None else part.start
+            stop = "" if part.stop is None else part.stop
+            if part.step is None:
+                return f"{start}:{stop}"
+            return f"{start}:{stop}:{part.step}"
+        if part is Ellipsis:
+            return "..."
+        return repr(part)
+
+    if isinstance(selection, tuple):
+        return ", ".join(_format_one(part) for part in selection)
+    return _format_one(selection)
+
+
 class _GroupProxy:
     """Lazy proxy for an h5py.Group that exposes children as attributes.
 
@@ -243,6 +262,16 @@ class _GroupProxy:
 
     def __iter__(self):
         return iter(self._group)
+
+    def __getitem__(self, selection):
+        attr_path = "f." + self._group.name.strip("/").replace("/", ".")
+        hint = ""
+        if "values" in self._group:
+            hint = f" Did you mean '{attr_path}.values[{_format_selection(selection)}]'?"
+        raise TypeError(
+            f"'{attr_path}' is a group, not a dataset, so it can't be sliced directly."
+            f"{hint} Available keys: {list(self._group.keys())}"
+        )
 
 
 def assert_key(file: h5py.File, key: str):


### PR DESCRIPTION
Two small quality-of-life fixes for reading zea files.

### 1. Slicing a group now tells you what to do instead

Slicing a group (instead of its `values` dataset) used to fail with an unhelpful h5py error. It now raises a `TypeError` that spells out the fix:

```python
import zea

version = "v0.1.0"

path = "hf://zeahub/camus/train/patient0001/patient0001_2CH_half_sequence.hdf5"

with zea.File(path, revision=version, stream=True) as f:
    data = f.data.image.values[0]  # correct
    data = f.data.image[0]  # incorrect, now improved error
```

```
TypeError: 'f.tracks.track_0.data.image' is a group, not a dataset, so it can't be sliced directly. Did you mean 'f.tracks.track_0.data.image.values[0]'? Available keys: ['coordinates', 'values']
```

### 2. Serial-read warnings now say which dataset they are about

The "falling back to a serial h5py read" warning only printed the file name, so a file with several affected datasets looked like it repeated the same warning four times. It now includes the dataset path (dimmed) and its size, so the warnings are distinguishable and the costly read is obvious:

```python
path = "hf://zeahub/zea-carotid-2023/data/10_cross_2cm_L_0000.hdf5"

version = "v0.1.0"

with zea.File(path, revision=version) as f:
    # should now warn you, prints both file and dataset path
    # helps distinguish between warnings when you load multiple datasets in the file
    data = f.data.raw_data[:10]
    print(data.shape)
```

```
WARNING Reading 'hf://zeahub/zea-carotid-2023/data/10_cross_2cm_L_0000.hdf5'
(/data/raw_data, 216.8 MB) compressed with lzf, which zea cannot decode concurrently —
falling back to a serial h5py read (slower). Re-save with the `zea data resave` CLI
(or zea.File.create) to read it concurrently, with a progress bar.
```

The dataset path is shown the way you would index it: for single-track files the `/tracks/track_0` prefix is dropped (`/data/raw_data`), multi-track files keep the full path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warnings for serial data reads by showing user-facing dataset paths and readable dataset sizes.
  * Added clearer error messages when attempting to slice a data group, including guidance to use its `values` dataset and the requested selection.

* **Tests**
  * Added coverage for dataset path display, human-readable byte formatting, selection formatting, and helpful group-slicing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->