### PR TITLE
Add weight and animal strain to subject metadata

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -1099,6 +1099,16 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - scalar
               - Subject sex.
               - |badge-opt|
+            * - ``weight``
+              - ``float32``
+              - scalar
+              - Subject weight.
+              - |badge-opt|
+            * - ``strain``
+              - ``str``
+              - scalar
+              - Animal strain, e.g. C57BL/6N.
+              - |badge-opt|
             * - ``fat_percentage``
               - ``float32``
               - scalar

--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -1104,10 +1104,10 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
               - scalar
               - Subject weight.
               - |badge-opt|
-            * - ``strain``
+            * - ``genetic_strain``
               - ``str``
               - scalar
-              - Animal strain, e.g. C57BL/6N.
+              - Genetic strain of an animal subject, e.g. C57BL/6N.
               - |badge-opt|
             * - ``fat_percentage``
               - ``float32``

--- a/docs/source/_units_ref.rst
+++ b/docs/source/_units_ref.rst
@@ -40,8 +40,8 @@ A unit of ``–`` denotes a unitless (dimensionless) quantity.
      - count
    * - ``%``
      - percent
-   * - ``g``
-     - grams
+   * - ``kg``
+     - kilograms
    * - ``kg/m²``
      - kilograms per square meter
 

--- a/docs/source/_units_ref.rst
+++ b/docs/source/_units_ref.rst
@@ -40,6 +40,8 @@ A unit of ``–`` denotes a unitless (dimensionless) quantity.
      - count
    * - ``%``
      - percent
+   * - ``g``
+     - grams
    * - ``kg/m²``
      - kilograms per square meter
 

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1103,7 +1103,7 @@ class TestMetadataAndMetricsValidationErrors:
         assert any("BMI" in str(c.args[0]) for c in mock_warn.call_args_list)
 
     def test_subject_weight_out_of_range_raises(self):
-        """weight must be a positive, finite number of grams."""
+        """weight must be a positive, finite number of kilograms."""
         with pytest.raises(ValueError, match="weight"):
             Subject(weight=np.float32(0.0))
         with pytest.raises(ValueError, match="weight"):
@@ -1112,22 +1112,29 @@ class TestMetadataAndMetricsValidationErrors:
             Subject(weight=np.float32("nan"))
 
     def test_subject_weight_valid(self):
-        """A mouse-sized weight in grams passes validation without warning."""
+        """A human-sized weight in kg passes validation without warning."""
         with patch("zea.log.warning") as mock_warn:
-            subject = Subject(weight=np.float32(15.0))
-        assert subject.weight == np.float32(15.0)
+            subject = Subject(weight=np.float32(72.0))
+        assert subject.weight == np.float32(72.0)
         assert not any("weight" in str(c.args[0]) for c in mock_warn.call_args_list)
 
-    def test_subject_weight_sub_gram_warns(self):
-        """Sub-gram weights suggest kilograms were passed, but do not raise."""
+    def test_subject_small_animal_weight_valid(self):
+        """A mouse weighs a fraction of a kg and must not warn."""
         with patch("zea.log.warning") as mock_warn:
-            Subject(weight=np.float32(0.075))
-        assert any("grams" in str(c.args[0]) for c in mock_warn.call_args_list)
+            subject = Subject(weight=np.float32(0.015))
+        assert subject.weight == pytest.approx(0.015)
+        assert not any("weight" in str(c.args[0]) for c in mock_warn.call_args_list)
+
+    def test_subject_weight_implausibly_large_warns(self):
+        """A gram value passed into the kg field warns, but does not raise."""
+        with patch("zea.log.warning") as mock_warn:
+            Subject(weight=np.float32(72000.0))
+        assert any("kilograms" in str(c.args[0]) for c in mock_warn.call_args_list)
 
     def test_subject_weight_accepts_python_float(self):
         """Native floats are cast to the float32 declared in SCHEMA."""
-        subject = Subject(weight=15.0)
-        assert subject.weight == np.float32(15.0)
+        subject = Subject(weight=72.0)
+        assert subject.weight == np.float32(72.0)
         assert subject.weight.dtype == np.float32
 
     def test_subject_weight_wrong_dtype_raises(self):
@@ -1154,14 +1161,14 @@ class TestMetadataAndMetricsValidationErrors:
                     "type": "animal",
                     "strain": "C57BL/6N",
                     "sex": "F",
-                    "weight": np.float32(15.0),
+                    "weight": np.float32(0.015),
                 }
             },
         )
 
         loaded = File(str(path))._to_file_spec().metadata.subject
         assert loaded.strain == "C57BL/6N"
-        assert loaded.weight == np.float32(15.0)
+        assert loaded.weight == pytest.approx(0.015)
         assert loaded.type == "animal"
 
     def test_signal_missing_required_field_raises(self):
@@ -1587,7 +1594,7 @@ class TestSubjectFieldWarnings:
                 type="human",
                 age=np.uint8(42),
                 sex="f",
-                weight=np.float32(72000.0),
+                weight=np.float32(72.0),
                 strain="n/a",
                 fat_percentage=np.float32(17.5),
                 bmi=np.float32(23.4),

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1102,6 +1102,68 @@ class TestMetadataAndMetricsValidationErrors:
             Subject(bmi=np.float32(75.0))
         assert any("BMI" in str(c.args[0]) for c in mock_warn.call_args_list)
 
+    def test_subject_weight_out_of_range_raises(self):
+        """weight must be a positive, finite number of grams."""
+        with pytest.raises(ValueError, match="weight"):
+            Subject(weight=np.float32(0.0))
+        with pytest.raises(ValueError, match="weight"):
+            Subject(weight=np.float32(-1.0))
+        with pytest.raises(ValueError, match="weight"):
+            Subject(weight=np.float32("nan"))
+
+    def test_subject_weight_valid(self):
+        """A mouse-sized weight in grams passes validation without warning."""
+        with patch("zea.log.warning") as mock_warn:
+            subject = Subject(weight=np.float32(15.0))
+        assert subject.weight == np.float32(15.0)
+        assert not any("weight" in str(c.args[0]) for c in mock_warn.call_args_list)
+
+    def test_subject_weight_sub_gram_warns(self):
+        """Sub-gram weights suggest kilograms were passed, but do not raise."""
+        with patch("zea.log.warning") as mock_warn:
+            Subject(weight=np.float32(0.075))
+        assert any("grams" in str(c.args[0]) for c in mock_warn.call_args_list)
+
+    def test_subject_weight_accepts_python_float(self):
+        """Native floats are cast to the float32 declared in SCHEMA."""
+        subject = Subject(weight=15.0)
+        assert subject.weight == np.float32(15.0)
+        assert subject.weight.dtype == np.float32
+
+    def test_subject_weight_wrong_dtype_raises(self):
+        with pytest.raises(TypeError, match="weight"):
+            Subject(weight="fifteen")
+
+    def test_subject_strain_empty_raises(self):
+        with pytest.raises(ValueError, match="strain"):
+            Subject(strain="   ")
+
+    def test_subject_strain_valid(self):
+        assert Subject(strain="C57BL/6N").strain == "C57BL/6N"
+
+    def test_subject_animal_metadata_round_trip_hdf5(self, tmp_path):
+        """An animal subject's strain and weight survive a save/load round trip."""
+        path = tmp_path / "mouse.hdf5"
+        File.create(
+            path,
+            data={"raw_data": np.zeros((2, 2, 8, 4, 1), dtype=np.float32)},
+            scan=_scan_minimal(n_frames=2, n_tx=2, n_el=4),
+            probe=_probe_minimal(n_el=4),
+            metadata={
+                "subject": {
+                    "type": "animal",
+                    "strain": "C57BL/6N",
+                    "sex": "F",
+                    "weight": np.float32(15.0),
+                }
+            },
+        )
+
+        loaded = File(str(path))._to_file_spec().metadata.subject
+        assert loaded.strain == "C57BL/6N"
+        assert loaded.weight == np.float32(15.0)
+        assert loaded.type == "animal"
+
     def test_signal_missing_required_field_raises(self):
         """Signal1D requires either sampling_frequency or timestamps."""
         with pytest.raises(ValueError, match="sampling_frequency|timestamps"):
@@ -1525,6 +1587,8 @@ class TestSubjectFieldWarnings:
                 type="human",
                 age=np.uint8(42),
                 sex="f",
+                weight=np.float32(72000.0),
+                strain="n/a",
                 fat_percentage=np.float32(17.5),
                 bmi=np.float32(23.4),
             )

--- a/tests/data/test_spec.py
+++ b/tests/data/test_spec.py
@@ -1141,15 +1141,15 @@ class TestMetadataAndMetricsValidationErrors:
         with pytest.raises(TypeError, match="weight"):
             Subject(weight="fifteen")
 
-    def test_subject_strain_empty_raises(self):
-        with pytest.raises(ValueError, match="strain"):
-            Subject(strain="   ")
+    def test_subject_genetic_strain_empty_raises(self):
+        with pytest.raises(ValueError, match="genetic_strain"):
+            Subject(genetic_strain="   ")
 
-    def test_subject_strain_valid(self):
-        assert Subject(strain="C57BL/6N").strain == "C57BL/6N"
+    def test_subject_genetic_strain_valid(self):
+        assert Subject(genetic_strain="C57BL/6N").genetic_strain == "C57BL/6N"
 
     def test_subject_animal_metadata_round_trip_hdf5(self, tmp_path):
-        """An animal subject's strain and weight survive a save/load round trip."""
+        """An animal subject's genetic strain and weight survive a save/load round trip."""
         path = tmp_path / "mouse.hdf5"
         File.create(
             path,
@@ -1159,7 +1159,7 @@ class TestMetadataAndMetricsValidationErrors:
             metadata={
                 "subject": {
                     "type": "animal",
-                    "strain": "C57BL/6N",
+                    "genetic_strain": "C57BL/6N",
                     "sex": "F",
                     "weight": np.float32(0.015),
                 }
@@ -1167,7 +1167,7 @@ class TestMetadataAndMetricsValidationErrors:
         )
 
         loaded = File(str(path))._to_file_spec().metadata.subject
-        assert loaded.strain == "C57BL/6N"
+        assert loaded.genetic_strain == "C57BL/6N"
         assert loaded.weight == pytest.approx(0.015)
         assert loaded.type == "animal"
 
@@ -1595,7 +1595,7 @@ class TestSubjectFieldWarnings:
                 age=np.uint8(42),
                 sex="f",
                 weight=np.float32(72.0),
-                strain="n/a",
+                genetic_strain="n/a",
                 fat_percentage=np.float32(17.5),
                 bmi=np.float32(23.4),
             )

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -37,7 +37,7 @@ UNITS = {
     "dB/m/Hz": "decibels per meter per hertz",
     "#": "count",
     "%": "percent",
-    "g": "grams",
+    "kg": "kilograms",
     "kg/m²": "kilograms per square meter",
 }
 
@@ -1786,7 +1786,8 @@ class Subject(Spec):
         type: Subject type, e.g. human, phantom, animal.
         age: Subject age in years.
         sex: Subject sex.
-        weight: Subject weight in grams.s.
+        weight: Subject weight in kg. Small-animal subjects are fractional
+            (a mouse is ~0.015-0.030 kg).
         strain: Animal strain, e.g. C57BL/6N. Only meaningful for animal subjects.
         fat_percentage: Subject fat percentage.
         bmi: Subject body mass index in kg/m².
@@ -1817,7 +1818,7 @@ class Subject(Spec):
         "type": {"unit": "–", "description": "Subject type, e.g. human, phantom, animal."},
         "age": {"unit": "–", "description": "Subject age in years.", "rare": True},
         "sex": {"unit": "–", "description": "Subject sex.", "rare": True},
-        "weight": {"unit": "g", "description": "Subject weight.", "rare": True},
+        "weight": {"unit": "kg", "description": "Subject weight.", "rare": True},
         "strain": {"unit": "–", "description": "Animal strain, e.g. C57BL/6N.", "rare": True},
         "fat_percentage": {"unit": "%", "description": "Subject fat percentage.", "rare": True},
         "bmi": {"unit": "kg/m²", "description": "Subject body mass index.", "rare": True},
@@ -1843,11 +1844,11 @@ class Subject(Spec):
             if not np.isfinite(self.weight):
                 raise ValueError(f"Subject weight must be finite, got {self.weight}")
             if self.weight <= 0:
-                raise ValueError(f"Subject weight must be positive, got {self.weight} g")
-            if self.weight < 1:
+                raise ValueError(f"Subject weight must be positive, got {self.weight} kg")
+            if self.weight > 1000:
                 log.warning(
-                    f"Subject weight of {self.weight} g is implausibly small. Please verify "
-                    "the value and that it is in grams, not kilograms."
+                    f"Subject weight was specified as {self.weight} kg."
+                    "Please verify the value and that it is in kilograms, not grams."
                 )
 
         if self.bmi is not None:

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1786,8 +1786,7 @@ class Subject(Spec):
         type: Subject type, e.g. human, phantom, animal.
         age: Subject age in years.
         sex: Subject sex.
-        weight: Subject weight in kg. Small-animal subjects are fractional
-            (a mouse is ~0.015-0.030 kg).
+        weight: Subject weight in kg.
         strain: Animal strain, e.g. C57BL/6N. Only meaningful for animal subjects.
         fat_percentage: Subject fat percentage.
         bmi: Subject body mass index in kg/m².

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1787,7 +1787,7 @@ class Subject(Spec):
         age: Subject age in years.
         sex: Subject sex.
         weight: Subject weight in kg.
-        strain: Animal strain, e.g. C57BL/6N. Only meaningful for animal subjects.
+        genetic_strain: Genetic strain of an animal subject, e.g. C57BL/6N.
         fat_percentage: Subject fat percentage.
         bmi: Subject body mass index in kg/m².
     """
@@ -1797,7 +1797,7 @@ class Subject(Spec):
     age: np.uint8 | None = None
     sex: str | None = None
     weight: np.float32 | None = None
-    strain: str | None = None
+    genetic_strain: str | None = None
     fat_percentage: np.float32 | None = None
     bmi: np.float32 | None = None
 
@@ -1807,7 +1807,7 @@ class Subject(Spec):
         "age": {"dtype": np.uint8, "shape": ()},
         "sex": {"dtype": str, "shape": ()},
         "weight": {"dtype": np.float32, "shape": ()},
-        "strain": {"dtype": str, "shape": ()},
+        "genetic_strain": {"dtype": str, "shape": ()},
         "fat_percentage": {"dtype": np.float32, "shape": ()},
         "bmi": {"dtype": np.float32, "shape": ()},
     }
@@ -1818,7 +1818,11 @@ class Subject(Spec):
         "age": {"unit": "–", "description": "Subject age in years.", "rare": True},
         "sex": {"unit": "–", "description": "Subject sex.", "rare": True},
         "weight": {"unit": "kg", "description": "Subject weight.", "rare": True},
-        "strain": {"unit": "–", "description": "Animal strain, e.g. C57BL/6N.", "rare": True},
+        "genetic_strain": {
+            "unit": "–",
+            "description": "Genetic strain (inbred line) of an animal subject, e.g. C57BL/6N.",
+            "rare": True,
+        },
         "fat_percentage": {"unit": "%", "description": "Subject fat percentage.", "rare": True},
         "bmi": {"unit": "kg/m²", "description": "Subject body mass index.", "rare": True},
     }
@@ -1836,8 +1840,8 @@ class Subject(Spec):
                 f"Subject fat percentage must be between 0 and 100, got {self.fat_percentage}"
             )
 
-        if self.strain is not None and not self.strain.strip():
-            raise ValueError("Subject strain cannot be an empty string")
+        if self.genetic_strain is not None and not self.genetic_strain.strip():
+            raise ValueError("Subject genetic_strain cannot be an empty string")
 
         if self.weight is not None:
             if not np.isfinite(self.weight):

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -37,6 +37,7 @@ UNITS = {
     "dB/m/Hz": "decibels per meter per hertz",
     "#": "count",
     "%": "percent",
+    "g": "grams",
     "kg/m²": "kilograms per square meter",
 }
 
@@ -1785,6 +1786,8 @@ class Subject(Spec):
         type: Subject type, e.g. human, phantom, animal.
         age: Subject age in years.
         sex: Subject sex.
+        weight: Subject weight in grams.s.
+        strain: Animal strain, e.g. C57BL/6N. Only meaningful for animal subjects.
         fat_percentage: Subject fat percentage.
         bmi: Subject body mass index in kg/m².
     """
@@ -1793,6 +1796,8 @@ class Subject(Spec):
     type: str | None = None
     age: np.uint8 | None = None
     sex: str | None = None
+    weight: np.float32 | None = None
+    strain: str | None = None
     fat_percentage: np.float32 | None = None
     bmi: np.float32 | None = None
 
@@ -1801,6 +1806,8 @@ class Subject(Spec):
         "type": {"dtype": str, "shape": ()},
         "age": {"dtype": np.uint8, "shape": ()},
         "sex": {"dtype": str, "shape": ()},
+        "weight": {"dtype": np.float32, "shape": ()},
+        "strain": {"dtype": str, "shape": ()},
         "fat_percentage": {"dtype": np.float32, "shape": ()},
         "bmi": {"dtype": np.float32, "shape": ()},
     }
@@ -1810,6 +1817,8 @@ class Subject(Spec):
         "type": {"unit": "–", "description": "Subject type, e.g. human, phantom, animal."},
         "age": {"unit": "–", "description": "Subject age in years.", "rare": True},
         "sex": {"unit": "–", "description": "Subject sex.", "rare": True},
+        "weight": {"unit": "g", "description": "Subject weight.", "rare": True},
+        "strain": {"unit": "–", "description": "Animal strain, e.g. C57BL/6N.", "rare": True},
         "fat_percentage": {"unit": "%", "description": "Subject fat percentage.", "rare": True},
         "bmi": {"unit": "kg/m²", "description": "Subject body mass index.", "rare": True},
     }
@@ -1826,6 +1835,20 @@ class Subject(Spec):
             raise ValueError(
                 f"Subject fat percentage must be between 0 and 100, got {self.fat_percentage}"
             )
+
+        if self.strain is not None and not self.strain.strip():
+            raise ValueError("Subject strain cannot be an empty string")
+
+        if self.weight is not None:
+            if not np.isfinite(self.weight):
+                raise ValueError(f"Subject weight must be finite, got {self.weight}")
+            if self.weight <= 0:
+                raise ValueError(f"Subject weight must be positive, got {self.weight} g")
+            if self.weight < 1:
+                log.warning(
+                    f"Subject weight of {self.weight} g is implausibly small. Please verify "
+                    "the value and that it is in grams, not kilograms."
+                )
 
         if self.bmi is not None:
             if not np.isfinite(self.bmi):


### PR DESCRIPTION
ULMShare stores the weight and strain of each mouse subject. I thought these might be general enough to include as optional in `MetadataSpec.Subject`.

