### PR TITLE
Use complex-valued transpose for tissue suppression

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1417,6 +1417,11 @@ def _complex_clutter_movie(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     baseband IQ), which is what distinguishes the Hermitian Gram matrix from the
     plain-transpose one -- for tissue that is merely a constant real map repeated
     across frames, both give the same answer.
+
+    Returns the movie both as a complex array (n_frames, n_z, n_x) -- for testing
+    :func:`zea.func.ultrasound.suppress_tissue` directly -- and as real IQ
+    channels (n_frames, n_z, n_x, 2), the shape :class:`zea.ops.TissueSuppression`
+    with ``filter_type="svd_complex"`` actually expects on its dict boundary.
     """
     rng = np.random.default_rng(seed)
 
@@ -1429,11 +1434,18 @@ def _complex_clutter_movie(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     phase = np.exp(1j * 2 * np.pi * 0.02 * np.arange(n_frames)).astype(np.complex64)
     tissue = (phase[:, None, None] * spatial[None]).astype(np.complex64)
     blood = (_complex_normal((n_frames, n_z, n_x)) * 0.1).astype(np.complex64)
-    return (tissue + blood).astype(np.complex64), tissue
+    data = (tissue + blood).astype(np.complex64)
+    data_channels = np.stack([data.real, data.imag], axis=-1).astype(np.float32)
+    return data, data_channels
 
 
 def test_tissue_suppression_complex():
     """TissueSuppression with filter_type='svd_complex' suppresses complex IQ clutter.
+
+    The op takes IQ data as two real channels (n_frames, ..., 2) -- the zea
+    convention, matching e.g. Beamform's output -- and converts to/from complex
+    internally with view_as_complex/view_as_real, the same pattern
+    DelayMultiplyAndSum uses, so it composes with the rest of a Pipeline.
 
     Deliberately not a ``backend_equality_check``: what survives the filter is the
     near-null-space residual, and different backends' SVD implementations pick
@@ -1446,23 +1458,19 @@ def test_tissue_suppression_complex():
 
     from zea import ops
 
-    data, _ = _complex_clutter_movie()
+    _, data_channels = _complex_clutter_movie()
 
     op = ops.TissueSuppression(cutoff=2, filter_type="svd_complex")
-    output = keras.ops.convert_to_numpy(
-        op(data=keras.ops.convert_to_tensor(data))["data"]
-    )
+    output = keras.ops.convert_to_numpy(op(data=keras.ops.convert_to_tensor(data_channels))["data"])
 
-    assert output.shape == data.shape
-    assert output.dtype == data.dtype, (
-        f"Expected dtype {data.dtype}, got {output.dtype}"
+    assert output.shape == data_channels.shape
+    assert output.dtype == data_channels.dtype, (
+        f"Expected dtype {data_channels.dtype}, got {output.dtype}"
     )
 
     # The clutter dominates the energy, so removing it must remove nearly all of it.
-    energy_ratio = np.mean(np.abs(output) ** 2) / np.mean(np.abs(data) ** 2)
-    assert energy_ratio < 0.01, (
-        f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
-    )
+    energy_ratio = np.mean(output**2) / np.mean(data_channels**2)
+    assert energy_ratio < 0.01, f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
 
 
 def test_tissue_suppression_complex_needs_conjugate():
@@ -1478,7 +1486,7 @@ def test_tissue_suppression_complex_needs_conjugate():
     """
     from zea.func.ultrasound import suppress_tissue
 
-    data, _ = _complex_clutter_movie()
+    data, _ = _complex_clutter_movie()  # complex array, not the real-channel one
 
     def _energy_ratio(conjugate):
         output = np.asarray(suppress_tissue(data, 2, conjugate=conjugate))
@@ -1489,8 +1497,13 @@ def test_tissue_suppression_complex_needs_conjugate():
     assert _energy_ratio(conjugate=False) > 0.5
 
 
-def test_tissue_suppression_conjugate_matches_plain_on_real_data():
-    """For real input the conjugate transpose is a no-op, so both filters agree.
+def test_tissue_suppression_conjugate_matches_plain_on_zero_imag_data():
+    """With a zero imaginary part, the conjugate transpose is a no-op.
+
+    ``svd_complex`` on IQ channels ``[real, 0]`` (i.e. genuinely real data,
+    just carried in the two-channel convention) must agree with ``svd``
+    applied to the real channel directly, since ``conj()`` is the identity on
+    real numbers.
 
     The tolerance is loose because the two do not necessarily run through the same
     code path: on TensorFlow ``svd_complex`` is forced eager (there is no complex
@@ -1503,18 +1516,22 @@ def test_tissue_suppression_conjugate_matches_plain_on_real_data():
     from zea import ops
 
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
-    data = rng.standard_normal((10, 8, 8)).astype(np.float32)
-    data_tensor = keras.ops.convert_to_tensor(data)
+    real_data = rng.standard_normal((10, 8, 8)).astype(np.float32)
+    channel_data = np.stack([real_data, np.zeros_like(real_data)], axis=-1)
 
-    outputs = [
-        keras.ops.convert_to_numpy(
-            ops.TissueSuppression(cutoff=3, filter_type=filter_type)(data=data_tensor)[
-                "data"
-            ]
-        )
-        for filter_type in ("svd", "svd_complex")
-    ]
-    np.testing.assert_allclose(outputs[0], outputs[1], atol=1e-2)
+    real_output = keras.ops.convert_to_numpy(
+        ops.TissueSuppression(cutoff=3, filter_type="svd")(
+            data=keras.ops.convert_to_tensor(real_data)
+        )["data"]
+    )
+    complex_output = keras.ops.convert_to_numpy(
+        ops.TissueSuppression(cutoff=3, filter_type="svd_complex")(
+            data=keras.ops.convert_to_tensor(channel_data)
+        )["data"]
+    )
+
+    np.testing.assert_allclose(real_output, complex_output[..., 0], atol=1e-2)
+    np.testing.assert_allclose(complex_output[..., 1], 0, atol=1e-2)
 
 
 def test_tissue_suppression_fractional_cutoff():

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -12,8 +12,6 @@ import numpy as np
 import pytest
 from scipy.ndimage import gaussian_filter
 from scipy.signal import hilbert as hilbert_scipy
-
-from zea import ops
 from zea.func.ultrasound import (
     channels_to_complex,
     complex_to_channels,
@@ -22,6 +20,8 @@ from zea.func.ultrasound import (
 )
 from zea.ops import Pipeline, Simulate, beamformer_registry
 from zea.parameters import Parameters
+
+from zea import ops
 
 from . import DEFAULT_TEST_SEED, backend_equality_check
 
@@ -103,7 +103,10 @@ def test_converting_to_image(size, dynamic_range, input_range):
         _input_range = input_range
 
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
-    data = rng.standard_normal(size) * (_input_range[1] - _input_range[0]) + _input_range[0]
+    data = (
+        rng.standard_normal(size) * (_input_range[1] - _input_range[0])
+        + _input_range[0]
+    )
     output_range = (0, 1)
     normalize = ops.Normalize(output_range, input_range)
     log_compress = ops.LogCompress()
@@ -219,9 +222,9 @@ def test_complex_channels_operations(size, axis):
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
     complex_data = (rng.random(size) + 1j * rng.random(size)).astype("complex64")
 
-    channels = ops.ComplexToChannels(axis=axis)(data=keras.ops.convert_to_tensor(complex_data))[
-        "data"
-    ]
+    channels = ops.ComplexToChannels(axis=axis)(
+        data=keras.ops.convert_to_tensor(complex_data)
+    )["data"]
     channels = keras.ops.convert_to_numpy(channels)
     assert channels.shape[axis] == 2, "Real/imaginary channels should live on `axis`."
 
@@ -574,7 +577,9 @@ def test_lee_filter(sigma, spiral_image):
     ],
 )
 @backend_equality_check()
-def test_threshold_op(spiral_image, threshold_type, below_threshold, fill_value, threshold_param):
+def test_threshold_op(
+    spiral_image, threshold_type, below_threshold, fill_value, threshold_param
+):
     """Test `ops.Threshold` operation on a synthetic spiral image."""
     import keras
 
@@ -593,7 +598,9 @@ def test_threshold_op(spiral_image, threshold_type, below_threshold, fill_value,
     percentile = threshold_param.get("percentile", None)
     threshold_value = threshold_param.get("threshold", None)
 
-    out = threshold(data=spiral_tensor, percentile=percentile, threshold=threshold_value)
+    out = threshold(
+        data=spiral_tensor, percentile=percentile, threshold=threshold_value
+    )
     out_np = keras.ops.convert_to_numpy(out["data"])
 
     # Quantitative: check that thresholding changes the image
@@ -652,7 +659,9 @@ def test_compute_time_to_peak():
 
     t_peak = compute_time_to_peak_stack(waveforms, center_frequencies, 250e6)
 
-    assert np.allclose(t_peak, 1e-6, atol=1e-8), f"t_peak should be close to 1e-6, got {t_peak}"
+    assert np.allclose(t_peak, 1e-6, atol=1e-8), (
+        f"t_peak should be close to 1e-6, got {t_peak}"
+    )
 
 
 @pytest.mark.parametrize("beamformer_name", beamformer_registry.registered_names())
@@ -661,7 +670,6 @@ def test_beamformers(beamformer_name):
     """All beamformer operations produce the correct output shape and agree across backends."""
 
     import keras
-
     from zea.ops import beamformer_registry
 
     n_tx, n_pix, n_el, n_ch = 3, 7, 4, 2
@@ -746,8 +754,12 @@ def test_generalized_coherence_factor_m_zero_passthrough():
     )
 
     # m_zero=2 at init vs. m_zero=2 at call time should give identical results
-    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)["data"]
-    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)["data"]
+    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)[
+        "data"
+    ]
+    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)[
+        "data"
+    ]
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(out_init),
         keras.ops.convert_to_numpy(out_call),
@@ -756,7 +768,9 @@ def test_generalized_coherence_factor_m_zero_passthrough():
 
     # Different m_zero values should produce different results
     out_default = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data)["data"]
-    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)["data"]
+    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)[
+        "data"
+    ]
     assert not np.allclose(
         keras.ops.convert_to_numpy(out_default),
         keras.ops.convert_to_numpy(out_m0),
@@ -777,10 +791,11 @@ def test_apply_window(axis, size, start, end, window_type):
     """Test ApplyWindow operation."""
 
     import keras
-
     from zea.ops.ultrasound import ApplyWindow
 
-    operation = ApplyWindow(axis=axis, size=size, start=start, end=end, window_type=window_type)
+    operation = ApplyWindow(
+        axis=axis, size=size, start=start, end=end, window_type=window_type
+    )
 
     data = keras.ops.ones((256, 128, 64))
     data_out = operation(data=data)["data"]
@@ -855,11 +870,19 @@ def test_band_pass_filter():
     result_demod_frequency = keras.ops.convert_to_numpy(result_demod_frequency)
 
     # Compare the three passband-related modes.
-    assert np.allclose(result_init_passband, result_demod_frequency, rtol=rtol, atol=atol)
-    assert not np.allclose(result_init_passband, result_call_passband, rtol=rtol, atol=atol)
-    assert not np.allclose(result_demod_frequency, result_call_passband, rtol=rtol, atol=atol)
+    assert np.allclose(
+        result_init_passband, result_demod_frequency, rtol=rtol, atol=atol
+    )
+    assert not np.allclose(
+        result_init_passband, result_call_passband, rtol=rtol, atol=atol
+    )
+    assert not np.allclose(
+        result_demod_frequency, result_call_passband, rtol=rtol, atol=atol
+    )
 
-    with pytest.raises(ValueError, match="passband must be an iterable of two numeric values"):
+    with pytest.raises(
+        ValueError, match="passband must be an iterable of two numeric values"
+    ):
         operation(
             data=data,
             sampling_frequency=40e6,
@@ -916,14 +939,20 @@ def test_make_tgc_curve():
     )
 
     # Check output shape
-    assert tgc_curve.shape == (n_ax,), f"Expected shape ({n_ax},), got {tgc_curve.shape}"
+    assert tgc_curve.shape == (n_ax,), (
+        f"Expected shape ({n_ax},), got {tgc_curve.shape}"
+    )
 
     # Check output dtype
-    assert tgc_curve.dtype == np.float32, f"Expected dtype float32, got {tgc_curve.dtype}"
+    assert tgc_curve.dtype == np.float32, (
+        f"Expected dtype float32, got {tgc_curve.dtype}"
+    )
 
     # Check that the curve is monotonically increasing (TGC should increase with depth)
     differences = np.diff(tgc_curve)
-    assert np.all(differences >= 0), "TGC curve should be monotonically increasing with depth"
+    assert np.all(differences >= 0), (
+        "TGC curve should be monotonically increasing with depth"
+    )
 
     # Check that the first value is 1 (no gain at zero depth)
     assert np.isclose(tgc_curve[0], 1.0, rtol=1e-5), (
@@ -962,7 +991,9 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     # Add random phase variations to simulate realistic ultrasound data
     # IQ data has 2 channels (I and Q)
     phase = rng.random((n_tx, n_pix, n_rx)) * 2 * np.pi
-    amplitude = rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5  # Amplitude between 0.5 and 1
+    amplitude = (
+        rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5
+    )  # Amplitude between 0.5 and 1
 
     # Convert to IQ format
     data = np.stack(
@@ -1012,7 +1043,9 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     )
 
     # Check for NaN values
-    assert not np.any(np.isnan(phase_error_np)), "Phase errors should not contain NaN values"
+    assert not np.any(np.isnan(phase_error_np)), (
+        "Phase errors should not contain NaN values"
+    )
 
     if with_batch:
         # Check that the two batches are not identical (due to different phase patterns)
@@ -1064,10 +1097,14 @@ def test_common_midpoint_phase_error_with_zeros():
     phase_error = keras.ops.convert_to_numpy(output["data"])
 
     # Check that computation doesn't crash and produces valid output
-    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
+    assert phase_error.shape == (n_pix,), (
+        f"Expected shape ({n_pix},), got {phase_error.shape}"
+    )
 
     # Check for inf values (should never occur)
-    assert not np.any(np.isinf(phase_error)), "Phase errors should not contain infinities"
+    assert not np.any(np.isinf(phase_error)), (
+        "Phase errors should not contain infinities"
+    )
 
     # NaNs are acceptable where all subapertures are invalid (division by zero)
     # but not all values should be NaN
@@ -1118,7 +1155,9 @@ def test_common_midpoint_phase_error_coherent_data():
     )
 
     # Check shape
-    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
+    assert phase_error.shape == (n_pix,), (
+        f"Expected shape ({n_pix},), got {phase_error.shape}"
+    )
 
     return phase_error
 
@@ -1141,7 +1180,9 @@ def test_apply_aligned_apodization(with_batch_dim):
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
 
-    out = keras.ops.convert_to_numpy(apply_aligned_apodization(data, apodization, with_batch_dim))
+    out = keras.ops.convert_to_numpy(
+        apply_aligned_apodization(data, apodization, with_batch_dim)
+    )
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1175,7 +1216,9 @@ def test_aligned_apodization_op(with_batch_dim):
     apodization = keras.ops.convert_to_tensor(
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
-    out = keras.ops.convert_to_numpy(op(data=data, flat_aligned_apodization=apodization)["data"])
+    out = keras.ops.convert_to_numpy(
+        op(data=data, flat_aligned_apodization=apodization)["data"]
+    )
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1203,10 +1246,14 @@ def test_apply_receive_apodization(with_batch_dim):
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
 
-    out = keras.ops.convert_to_numpy(apply_receive_apodization(data, apodization, with_batch_dim))
+    out = keras.ops.convert_to_numpy(
+        apply_receive_apodization(data, apodization, with_batch_dim)
+    )
 
     # Broadcast the (n_pix, n_el) weight over n_tx (leading) and n_ch (trailing).
-    expected = np.broadcast_to(apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)).copy()
+    expected = np.broadcast_to(
+        apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)
+    ).copy()
     if with_batch_dim:
         expected = expected[None]
 
@@ -1240,13 +1287,17 @@ def test_receive_apodization_op(with_batch_dim):
     ones = keras.ops.ones((n_pix, n_el))
     out_ones = op(data=data, flat_receive_apodization=ones)["data"]
     np.testing.assert_allclose(
-        keras.ops.convert_to_numpy(out_ones), keras.ops.convert_to_numpy(data), rtol=1e-5
+        keras.ops.convert_to_numpy(out_ones),
+        keras.ops.convert_to_numpy(data),
+        rtol=1e-5,
     )
 
     # Per-element taper -> scales the expected elements
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
-    out = keras.ops.convert_to_numpy(op(data=data, flat_receive_apodization=apodization)["data"])
+    out = keras.ops.convert_to_numpy(
+        op(data=data, flat_receive_apodization=apodization)["data"]
+    )
 
     expected = data_np * apod_np[None, :, :, None]
     if with_batch_dim:
@@ -1265,7 +1316,6 @@ def test_prepare_parameters_pfield_all_backends():
     """
 
     import keras
-
     from zea.beamform.delays import compute_t0_delays_planewave
     from zea.internal.cache import cache_disabled
     from zea.ops import Pipeline
@@ -1341,10 +1391,14 @@ def test_tissue_suppression():
     output = keras.ops.convert_to_numpy(op(data=data_tensor)["data"])
 
     assert output.shape == shape, f"Expected shape {shape}, got {output.shape}"
-    assert output.dtype == data.dtype, f"Expected dtype {data.dtype}, got {output.dtype}"
+    assert output.dtype == data.dtype, (
+        f"Expected dtype {data.dtype}, got {output.dtype}"
+    )
 
     # After suppression, energy should be lower than the original tissue-dominated signal
-    assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
+    assert np.mean(output**2) < np.mean(data**2), (
+        "Tissue suppression should reduce signal energy"
+    )
 
     correlation_across_frames = np.corrcoef(output.reshape(n_frames, -1))
     # The correlation across frames should be reduced after tissue suppression
@@ -1354,3 +1408,133 @@ def test_tissue_suppression():
     )
 
     return output
+
+
+def _complex_clutter_movie(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
+    """Complex IQ movie: strong phase-rotating tissue clutter + weak blood.
+
+    The tissue rotates in phase over time (as moving tissue does in real
+    baseband IQ), which is what distinguishes the Hermitian Gram matrix from the
+    plain-transpose one -- for tissue that is merely a constant real map repeated
+    across frames, both give the same answer.
+    """
+    rng = np.random.default_rng(seed)
+
+    def _complex_normal(shape):
+        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(
+            np.complex64
+        )
+
+    spatial = _complex_normal((n_z, n_x)) * 10
+    phase = np.exp(1j * 2 * np.pi * 0.02 * np.arange(n_frames)).astype(np.complex64)
+    tissue = (phase[:, None, None] * spatial[None]).astype(np.complex64)
+    blood = (_complex_normal((n_frames, n_z, n_x)) * 0.1).astype(np.complex64)
+    return (tissue + blood).astype(np.complex64), tissue
+
+
+def test_tissue_suppression_complex():
+    """TissueSuppression with filter_type='svd_complex' suppresses complex IQ clutter.
+
+    Deliberately not a ``backend_equality_check``: what survives the filter is the
+    near-null-space residual, and different backends' SVD implementations pick
+    different (equally valid) bases for the discarded subspace, so the residual is
+    not comparable elementwise across backends. For this reason,
+    the ratio of the energy before and after filtering is asserted as a
+    regression test.
+    """
+    import keras
+
+    from zea import ops
+
+    data, _ = _complex_clutter_movie()
+
+    op = ops.TissueSuppression(cutoff=2, filter_type="svd_complex")
+    output = keras.ops.convert_to_numpy(
+        op(data=keras.ops.convert_to_tensor(data))["data"]
+    )
+
+    assert output.shape == data.shape
+    assert output.dtype == data.dtype, (
+        f"Expected dtype {data.dtype}, got {output.dtype}"
+    )
+
+    # The clutter dominates the energy, so removing it must remove nearly all of it.
+    energy_ratio = np.mean(np.abs(output) ** 2) / np.mean(np.abs(data) ** 2)
+    assert energy_ratio < 0.01, (
+        f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
+    )
+
+
+def test_tissue_suppression_complex_needs_conjugate():
+    """The plain-transpose 'svd' filter fails on complex IQ; 'svd_complex' is required.
+
+    This is the reason filter_type exists: on complex data the plain transpose
+    builds X^T X rather than the temporal covariance X^H X, so the dominant
+    components it finds are not the tissue subspace and the clutter survives.
+
+    This is a property of the maths, not of any backend, so it is checked against
+    the reference (numpy) implementation directly rather than through the op --
+    TensorFlow cannot XLA-compile a complex SVD at all.
+    """
+    from zea.func.ultrasound import suppress_tissue
+
+    data, _ = _complex_clutter_movie()
+
+    def _energy_ratio(conjugate):
+        output = np.asarray(suppress_tissue(data, 2, conjugate=conjugate))
+        return np.mean(np.abs(output) ** 2) / np.mean(np.abs(data) ** 2)
+
+    assert _energy_ratio(conjugate=True) < 0.01
+    # The plain transpose leaves the phase-rotating clutter essentially intact.
+    assert _energy_ratio(conjugate=False) > 0.5
+
+
+def test_tissue_suppression_conjugate_matches_plain_on_real_data():
+    """For real input the conjugate transpose is a no-op, so both filters agree.
+
+    The tolerance is loose because the two do not necessarily run through the same
+    code path: on TensorFlow ``svd_complex`` is forced eager (there is no complex
+    XLA ``Svd`` kernel) while ``svd`` is XLA-compiled, and XLA's float32 SVD
+    differs from the eager one by ~1e-3 on a matrix with near-degenerate singular
+    values. The point here is that the maths is equivalent, not bit-exactness.
+    """
+    import keras
+
+    from zea import ops
+
+    rng = np.random.default_rng(DEFAULT_TEST_SEED)
+    data = rng.standard_normal((10, 8, 8)).astype(np.float32)
+    data_tensor = keras.ops.convert_to_tensor(data)
+
+    outputs = [
+        keras.ops.convert_to_numpy(
+            ops.TissueSuppression(cutoff=3, filter_type=filter_type)(data=data_tensor)[
+                "data"
+            ]
+        )
+        for filter_type in ("svd", "svd_complex")
+    ]
+    np.testing.assert_allclose(outputs[0], outputs[1], atol=1e-2)
+
+
+def test_tissue_suppression_fractional_cutoff():
+    """A float cutoff is resolved as a fraction of the number of frames."""
+    from zea import ops
+
+    assert ops.TissueSuppression(cutoff=0.05).resolve_cutoff(400) == 20
+    assert ops.TissueSuppression(cutoff=0.1).resolve_cutoff(95) == 10
+    # An int cutoff is used as-is, independent of the frame count.
+    assert ops.TissueSuppression(cutoff=5).resolve_cutoff(400) == 5
+
+
+def test_tissue_suppression_invalid_arguments():
+    """Invalid filter_type / cutoff are rejected at construction time."""
+    import pytest
+
+    from zea import ops
+
+    with pytest.raises(ValueError, match="Unknown filter_type"):
+        ops.TissueSuppression(filter_type="not_a_filter")
+
+    with pytest.raises(ValueError, match="fraction of the frames"):
+        ops.TissueSuppression(cutoff=1.5)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1548,6 +1548,48 @@ def test_tissue_suppression_fractional_cutoff():
     assert ops.TissueSuppression(cutoff=5).resolve_cutoff(400) == 5
 
 
+def test_tissue_suppression_filter_type_autodetect():
+    """filter_type=None picks svd_complex for IQ (n_ch=2) and svd otherwise.
+
+    This is zea's channel convention (n_ch=1 -> RF/real, n_ch=2 -> IQ), the same
+    ``shape[-1] == 2`` test envelope_detect and Upmix use.
+    """
+    import keras
+
+    from zea import ops
+
+    def _resolve(shape, filter_type=None):
+        data = keras.ops.convert_to_tensor(np.zeros(shape, dtype=np.float32))
+        return ops.TissueSuppression(cutoff=2, filter_type=filter_type).resolve_filter_type(data)
+
+    assert _resolve((10, 8, 8, 2)) == "svd_complex"  # IQ
+    assert _resolve((10, 8, 8, 1)) == "svd"  # RF
+    assert _resolve((10, 8, 8)) == "svd"  # real, no channel axis
+    assert _resolve((10,)) == "svd"  # 1-D, no channel axis to read
+
+    # An explicit filter_type always wins over auto-detection.
+    assert _resolve((10, 8, 8, 2), filter_type="svd") == "svd"
+    assert _resolve((10, 8, 8), filter_type="svd_complex") == "svd_complex"
+
+
+def test_tissue_suppression_autodetect_matches_explicit():
+    """Auto-detected IQ input gives the same result as filter_type='svd_complex'."""
+    import keras
+
+    from zea import ops
+
+    _, data_channels = _complex_clutter_video()
+    data_tensor = keras.ops.convert_to_tensor(data_channels)
+
+    outputs = [
+        keras.ops.convert_to_numpy(
+            ops.TissueSuppression(cutoff=2, filter_type=filter_type)(data=data_tensor)["data"]
+        )
+        for filter_type in (None, "svd_complex")
+    ]
+    np.testing.assert_allclose(outputs[0], outputs[1], atol=1e-5)
+
+
 def test_tissue_suppression_invalid_arguments():
     """Invalid filter_type / cutoff are rejected at construction time."""
     import pytest

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1432,7 +1432,7 @@ def test_tissue_suppression_complex_needs_conjugate():
     data, _ = _complex_clutter_video()  # complex array, not the real-channel one
 
     def _energy_ratio(conjugate):
-        output = np.asarray(suppress_tissue(data, 2, conjugate=conjugate))
+        output = keras.ops.convert_to_numpy(suppress_tissue(data, 2, conjugate=conjugate))
         return np.mean(np.abs(output) ** 2) / np.mean(np.abs(data) ** 2)
 
     assert _energy_ratio(conjugate=True) < 0.01

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -103,10 +103,7 @@ def test_converting_to_image(size, dynamic_range, input_range):
         _input_range = input_range
 
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
-    data = (
-        rng.standard_normal(size) * (_input_range[1] - _input_range[0])
-        + _input_range[0]
-    )
+    data = rng.standard_normal(size) * (_input_range[1] - _input_range[0]) + _input_range[0]
     output_range = (0, 1)
     normalize = ops.Normalize(output_range, input_range)
     log_compress = ops.LogCompress()
@@ -222,9 +219,9 @@ def test_complex_channels_operations(size, axis):
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
     complex_data = (rng.random(size) + 1j * rng.random(size)).astype("complex64")
 
-    channels = ops.ComplexToChannels(axis=axis)(
-        data=keras.ops.convert_to_tensor(complex_data)
-    )["data"]
+    channels = ops.ComplexToChannels(axis=axis)(data=keras.ops.convert_to_tensor(complex_data))[
+        "data"
+    ]
     channels = keras.ops.convert_to_numpy(channels)
     assert channels.shape[axis] == 2, "Real/imaginary channels should live on `axis`."
 
@@ -577,9 +574,7 @@ def test_lee_filter(sigma, spiral_image):
     ],
 )
 @backend_equality_check()
-def test_threshold_op(
-    spiral_image, threshold_type, below_threshold, fill_value, threshold_param
-):
+def test_threshold_op(spiral_image, threshold_type, below_threshold, fill_value, threshold_param):
     """Test `ops.Threshold` operation on a synthetic spiral image."""
     import keras
 
@@ -598,9 +593,7 @@ def test_threshold_op(
     percentile = threshold_param.get("percentile", None)
     threshold_value = threshold_param.get("threshold", None)
 
-    out = threshold(
-        data=spiral_tensor, percentile=percentile, threshold=threshold_value
-    )
+    out = threshold(data=spiral_tensor, percentile=percentile, threshold=threshold_value)
     out_np = keras.ops.convert_to_numpy(out["data"])
 
     # Quantitative: check that thresholding changes the image
@@ -659,9 +652,7 @@ def test_compute_time_to_peak():
 
     t_peak = compute_time_to_peak_stack(waveforms, center_frequencies, 250e6)
 
-    assert np.allclose(t_peak, 1e-6, atol=1e-8), (
-        f"t_peak should be close to 1e-6, got {t_peak}"
-    )
+    assert np.allclose(t_peak, 1e-6, atol=1e-8), f"t_peak should be close to 1e-6, got {t_peak}"
 
 
 @pytest.mark.parametrize("beamformer_name", beamformer_registry.registered_names())
@@ -754,12 +745,8 @@ def test_generalized_coherence_factor_m_zero_passthrough():
     )
 
     # m_zero=2 at init vs. m_zero=2 at call time should give identical results
-    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)[
-        "data"
-    ]
-    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)[
-        "data"
-    ]
+    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)["data"]
+    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)["data"]
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(out_init),
         keras.ops.convert_to_numpy(out_call),
@@ -768,9 +755,7 @@ def test_generalized_coherence_factor_m_zero_passthrough():
 
     # Different m_zero values should produce different results
     out_default = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data)["data"]
-    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)[
-        "data"
-    ]
+    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)["data"]
     assert not np.allclose(
         keras.ops.convert_to_numpy(out_default),
         keras.ops.convert_to_numpy(out_m0),
@@ -793,9 +778,7 @@ def test_apply_window(axis, size, start, end, window_type):
     import keras
     from zea.ops.ultrasound import ApplyWindow
 
-    operation = ApplyWindow(
-        axis=axis, size=size, start=start, end=end, window_type=window_type
-    )
+    operation = ApplyWindow(axis=axis, size=size, start=start, end=end, window_type=window_type)
 
     data = keras.ops.ones((256, 128, 64))
     data_out = operation(data=data)["data"]
@@ -870,19 +853,11 @@ def test_band_pass_filter():
     result_demod_frequency = keras.ops.convert_to_numpy(result_demod_frequency)
 
     # Compare the three passband-related modes.
-    assert np.allclose(
-        result_init_passband, result_demod_frequency, rtol=rtol, atol=atol
-    )
-    assert not np.allclose(
-        result_init_passband, result_call_passband, rtol=rtol, atol=atol
-    )
-    assert not np.allclose(
-        result_demod_frequency, result_call_passband, rtol=rtol, atol=atol
-    )
+    assert np.allclose(result_init_passband, result_demod_frequency, rtol=rtol, atol=atol)
+    assert not np.allclose(result_init_passband, result_call_passband, rtol=rtol, atol=atol)
+    assert not np.allclose(result_demod_frequency, result_call_passband, rtol=rtol, atol=atol)
 
-    with pytest.raises(
-        ValueError, match="passband must be an iterable of two numeric values"
-    ):
+    with pytest.raises(ValueError, match="passband must be an iterable of two numeric values"):
         operation(
             data=data,
             sampling_frequency=40e6,
@@ -939,20 +914,14 @@ def test_make_tgc_curve():
     )
 
     # Check output shape
-    assert tgc_curve.shape == (n_ax,), (
-        f"Expected shape ({n_ax},), got {tgc_curve.shape}"
-    )
+    assert tgc_curve.shape == (n_ax,), f"Expected shape ({n_ax},), got {tgc_curve.shape}"
 
     # Check output dtype
-    assert tgc_curve.dtype == np.float32, (
-        f"Expected dtype float32, got {tgc_curve.dtype}"
-    )
+    assert tgc_curve.dtype == np.float32, f"Expected dtype float32, got {tgc_curve.dtype}"
 
     # Check that the curve is monotonically increasing (TGC should increase with depth)
     differences = np.diff(tgc_curve)
-    assert np.all(differences >= 0), (
-        "TGC curve should be monotonically increasing with depth"
-    )
+    assert np.all(differences >= 0), "TGC curve should be monotonically increasing with depth"
 
     # Check that the first value is 1 (no gain at zero depth)
     assert np.isclose(tgc_curve[0], 1.0, rtol=1e-5), (
@@ -991,9 +960,7 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     # Add random phase variations to simulate realistic ultrasound data
     # IQ data has 2 channels (I and Q)
     phase = rng.random((n_tx, n_pix, n_rx)) * 2 * np.pi
-    amplitude = (
-        rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5
-    )  # Amplitude between 0.5 and 1
+    amplitude = rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5  # Amplitude between 0.5 and 1
 
     # Convert to IQ format
     data = np.stack(
@@ -1043,9 +1010,7 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     )
 
     # Check for NaN values
-    assert not np.any(np.isnan(phase_error_np)), (
-        "Phase errors should not contain NaN values"
-    )
+    assert not np.any(np.isnan(phase_error_np)), "Phase errors should not contain NaN values"
 
     if with_batch:
         # Check that the two batches are not identical (due to different phase patterns)
@@ -1097,14 +1062,10 @@ def test_common_midpoint_phase_error_with_zeros():
     phase_error = keras.ops.convert_to_numpy(output["data"])
 
     # Check that computation doesn't crash and produces valid output
-    assert phase_error.shape == (n_pix,), (
-        f"Expected shape ({n_pix},), got {phase_error.shape}"
-    )
+    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
 
     # Check for inf values (should never occur)
-    assert not np.any(np.isinf(phase_error)), (
-        "Phase errors should not contain infinities"
-    )
+    assert not np.any(np.isinf(phase_error)), "Phase errors should not contain infinities"
 
     # NaNs are acceptable where all subapertures are invalid (division by zero)
     # but not all values should be NaN
@@ -1155,9 +1116,7 @@ def test_common_midpoint_phase_error_coherent_data():
     )
 
     # Check shape
-    assert phase_error.shape == (n_pix,), (
-        f"Expected shape ({n_pix},), got {phase_error.shape}"
-    )
+    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
 
     return phase_error
 
@@ -1180,9 +1139,7 @@ def test_apply_aligned_apodization(with_batch_dim):
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
 
-    out = keras.ops.convert_to_numpy(
-        apply_aligned_apodization(data, apodization, with_batch_dim)
-    )
+    out = keras.ops.convert_to_numpy(apply_aligned_apodization(data, apodization, with_batch_dim))
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1216,9 +1173,7 @@ def test_aligned_apodization_op(with_batch_dim):
     apodization = keras.ops.convert_to_tensor(
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
-    out = keras.ops.convert_to_numpy(
-        op(data=data, flat_aligned_apodization=apodization)["data"]
-    )
+    out = keras.ops.convert_to_numpy(op(data=data, flat_aligned_apodization=apodization)["data"])
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1246,14 +1201,10 @@ def test_apply_receive_apodization(with_batch_dim):
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
 
-    out = keras.ops.convert_to_numpy(
-        apply_receive_apodization(data, apodization, with_batch_dim)
-    )
+    out = keras.ops.convert_to_numpy(apply_receive_apodization(data, apodization, with_batch_dim))
 
     # Broadcast the (n_pix, n_el) weight over n_tx (leading) and n_ch (trailing).
-    expected = np.broadcast_to(
-        apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)
-    ).copy()
+    expected = np.broadcast_to(apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)).copy()
     if with_batch_dim:
         expected = expected[None]
 
@@ -1295,9 +1246,7 @@ def test_receive_apodization_op(with_batch_dim):
     # Per-element taper -> scales the expected elements
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
-    out = keras.ops.convert_to_numpy(
-        op(data=data, flat_receive_apodization=apodization)["data"]
-    )
+    out = keras.ops.convert_to_numpy(op(data=data, flat_receive_apodization=apodization)["data"])
 
     expected = data_np * apod_np[None, :, :, None]
     if with_batch_dim:
@@ -1391,14 +1340,10 @@ def test_tissue_suppression():
     output = keras.ops.convert_to_numpy(op(data=data_tensor)["data"])
 
     assert output.shape == shape, f"Expected shape {shape}, got {output.shape}"
-    assert output.dtype == data.dtype, (
-        f"Expected dtype {data.dtype}, got {output.dtype}"
-    )
+    assert output.dtype == data.dtype, f"Expected dtype {data.dtype}, got {output.dtype}"
 
     # After suppression, energy should be lower than the original tissue-dominated signal
-    assert np.mean(output**2) < np.mean(data**2), (
-        "Tissue suppression should reduce signal energy"
-    )
+    assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
 
     correlation_across_frames = np.corrcoef(output.reshape(n_frames, -1))
     # The correlation across frames should be reduced after tissue suppression
@@ -1426,9 +1371,7 @@ def _complex_clutter_video(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     rng = np.random.default_rng(seed)
 
     def _complex_normal(shape):
-        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(
-            np.complex64
-        )
+        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(np.complex64)
 
     spatial = _complex_normal((n_z, n_x)) * 10
     phase = np.exp(1j * 2 * np.pi * 0.02 * np.arange(n_frames)).astype(np.complex64)
@@ -1461,9 +1404,7 @@ def test_tissue_suppression_complex():
     _, data_channels = _complex_clutter_video()
 
     op = ops.TissueSuppression(cutoff=2, filter_type="svd_complex")
-    output = keras.ops.convert_to_numpy(
-        op(data=keras.ops.convert_to_tensor(data_channels))["data"]
-    )
+    output = keras.ops.convert_to_numpy(op(data=keras.ops.convert_to_tensor(data_channels))["data"])
 
     assert output.shape == data_channels.shape
     assert output.dtype == data_channels.dtype, (
@@ -1472,9 +1413,7 @@ def test_tissue_suppression_complex():
 
     # The clutter dominates the energy, so removing it must remove nearly all of it.
     energy_ratio = np.mean(output**2) / np.mean(data_channels**2)
-    assert energy_ratio < 0.01, (
-        f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
-    )
+    assert energy_ratio < 0.01, f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
 
 
 def test_tissue_suppression_complex_needs_conjugate():

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -103,10 +103,7 @@ def test_converting_to_image(size, dynamic_range, input_range):
         _input_range = input_range
 
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
-    data = (
-        rng.standard_normal(size) * (_input_range[1] - _input_range[0])
-        + _input_range[0]
-    )
+    data = rng.standard_normal(size) * (_input_range[1] - _input_range[0]) + _input_range[0]
     output_range = (0, 1)
     normalize = ops.Normalize(output_range, input_range)
     log_compress = ops.LogCompress()
@@ -222,9 +219,9 @@ def test_complex_channels_operations(size, axis):
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
     complex_data = (rng.random(size) + 1j * rng.random(size)).astype("complex64")
 
-    channels = ops.ComplexToChannels(axis=axis)(
-        data=keras.ops.convert_to_tensor(complex_data)
-    )["data"]
+    channels = ops.ComplexToChannels(axis=axis)(data=keras.ops.convert_to_tensor(complex_data))[
+        "data"
+    ]
     channels = keras.ops.convert_to_numpy(channels)
     assert channels.shape[axis] == 2, "Real/imaginary channels should live on `axis`."
 
@@ -577,9 +574,7 @@ def test_lee_filter(sigma, spiral_image):
     ],
 )
 @backend_equality_check()
-def test_threshold_op(
-    spiral_image, threshold_type, below_threshold, fill_value, threshold_param
-):
+def test_threshold_op(spiral_image, threshold_type, below_threshold, fill_value, threshold_param):
     """Test `ops.Threshold` operation on a synthetic spiral image."""
     import keras
 
@@ -598,9 +593,7 @@ def test_threshold_op(
     percentile = threshold_param.get("percentile", None)
     threshold_value = threshold_param.get("threshold", None)
 
-    out = threshold(
-        data=spiral_tensor, percentile=percentile, threshold=threshold_value
-    )
+    out = threshold(data=spiral_tensor, percentile=percentile, threshold=threshold_value)
     out_np = keras.ops.convert_to_numpy(out["data"])
 
     # Quantitative: check that thresholding changes the image
@@ -659,9 +652,7 @@ def test_compute_time_to_peak():
 
     t_peak = compute_time_to_peak_stack(waveforms, center_frequencies, 250e6)
 
-    assert np.allclose(t_peak, 1e-6, atol=1e-8), (
-        f"t_peak should be close to 1e-6, got {t_peak}"
-    )
+    assert np.allclose(t_peak, 1e-6, atol=1e-8), f"t_peak should be close to 1e-6, got {t_peak}"
 
 
 @pytest.mark.parametrize("beamformer_name", beamformer_registry.registered_names())
@@ -754,12 +745,8 @@ def test_generalized_coherence_factor_m_zero_passthrough():
     )
 
     # m_zero=2 at init vs. m_zero=2 at call time should give identical results
-    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)[
-        "data"
-    ]
-    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)[
-        "data"
-    ]
+    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)["data"]
+    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)["data"]
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(out_init),
         keras.ops.convert_to_numpy(out_call),
@@ -768,9 +755,7 @@ def test_generalized_coherence_factor_m_zero_passthrough():
 
     # Different m_zero values should produce different results
     out_default = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data)["data"]
-    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)[
-        "data"
-    ]
+    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)["data"]
     assert not np.allclose(
         keras.ops.convert_to_numpy(out_default),
         keras.ops.convert_to_numpy(out_m0),
@@ -793,9 +778,7 @@ def test_apply_window(axis, size, start, end, window_type):
     import keras
     from zea.ops.ultrasound import ApplyWindow
 
-    operation = ApplyWindow(
-        axis=axis, size=size, start=start, end=end, window_type=window_type
-    )
+    operation = ApplyWindow(axis=axis, size=size, start=start, end=end, window_type=window_type)
 
     data = keras.ops.ones((256, 128, 64))
     data_out = operation(data=data)["data"]
@@ -870,19 +853,11 @@ def test_band_pass_filter():
     result_demod_frequency = keras.ops.convert_to_numpy(result_demod_frequency)
 
     # Compare the three passband-related modes.
-    assert np.allclose(
-        result_init_passband, result_demod_frequency, rtol=rtol, atol=atol
-    )
-    assert not np.allclose(
-        result_init_passband, result_call_passband, rtol=rtol, atol=atol
-    )
-    assert not np.allclose(
-        result_demod_frequency, result_call_passband, rtol=rtol, atol=atol
-    )
+    assert np.allclose(result_init_passband, result_demod_frequency, rtol=rtol, atol=atol)
+    assert not np.allclose(result_init_passband, result_call_passband, rtol=rtol, atol=atol)
+    assert not np.allclose(result_demod_frequency, result_call_passband, rtol=rtol, atol=atol)
 
-    with pytest.raises(
-        ValueError, match="passband must be an iterable of two numeric values"
-    ):
+    with pytest.raises(ValueError, match="passband must be an iterable of two numeric values"):
         operation(
             data=data,
             sampling_frequency=40e6,
@@ -939,20 +914,14 @@ def test_make_tgc_curve():
     )
 
     # Check output shape
-    assert tgc_curve.shape == (n_ax,), (
-        f"Expected shape ({n_ax},), got {tgc_curve.shape}"
-    )
+    assert tgc_curve.shape == (n_ax,), f"Expected shape ({n_ax},), got {tgc_curve.shape}"
 
     # Check output dtype
-    assert tgc_curve.dtype == np.float32, (
-        f"Expected dtype float32, got {tgc_curve.dtype}"
-    )
+    assert tgc_curve.dtype == np.float32, f"Expected dtype float32, got {tgc_curve.dtype}"
 
     # Check that the curve is monotonically increasing (TGC should increase with depth)
     differences = np.diff(tgc_curve)
-    assert np.all(differences >= 0), (
-        "TGC curve should be monotonically increasing with depth"
-    )
+    assert np.all(differences >= 0), "TGC curve should be monotonically increasing with depth"
 
     # Check that the first value is 1 (no gain at zero depth)
     assert np.isclose(tgc_curve[0], 1.0, rtol=1e-5), (
@@ -991,9 +960,7 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     # Add random phase variations to simulate realistic ultrasound data
     # IQ data has 2 channels (I and Q)
     phase = rng.random((n_tx, n_pix, n_rx)) * 2 * np.pi
-    amplitude = (
-        rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5
-    )  # Amplitude between 0.5 and 1
+    amplitude = rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5  # Amplitude between 0.5 and 1
 
     # Convert to IQ format
     data = np.stack(
@@ -1043,9 +1010,7 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     )
 
     # Check for NaN values
-    assert not np.any(np.isnan(phase_error_np)), (
-        "Phase errors should not contain NaN values"
-    )
+    assert not np.any(np.isnan(phase_error_np)), "Phase errors should not contain NaN values"
 
     if with_batch:
         # Check that the two batches are not identical (due to different phase patterns)
@@ -1097,14 +1062,10 @@ def test_common_midpoint_phase_error_with_zeros():
     phase_error = keras.ops.convert_to_numpy(output["data"])
 
     # Check that computation doesn't crash and produces valid output
-    assert phase_error.shape == (n_pix,), (
-        f"Expected shape ({n_pix},), got {phase_error.shape}"
-    )
+    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
 
     # Check for inf values (should never occur)
-    assert not np.any(np.isinf(phase_error)), (
-        "Phase errors should not contain infinities"
-    )
+    assert not np.any(np.isinf(phase_error)), "Phase errors should not contain infinities"
 
     # NaNs are acceptable where all subapertures are invalid (division by zero)
     # but not all values should be NaN
@@ -1155,9 +1116,7 @@ def test_common_midpoint_phase_error_coherent_data():
     )
 
     # Check shape
-    assert phase_error.shape == (n_pix,), (
-        f"Expected shape ({n_pix},), got {phase_error.shape}"
-    )
+    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
 
     return phase_error
 
@@ -1180,9 +1139,7 @@ def test_apply_aligned_apodization(with_batch_dim):
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
 
-    out = keras.ops.convert_to_numpy(
-        apply_aligned_apodization(data, apodization, with_batch_dim)
-    )
+    out = keras.ops.convert_to_numpy(apply_aligned_apodization(data, apodization, with_batch_dim))
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1216,9 +1173,7 @@ def test_aligned_apodization_op(with_batch_dim):
     apodization = keras.ops.convert_to_tensor(
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
-    out = keras.ops.convert_to_numpy(
-        op(data=data, flat_aligned_apodization=apodization)["data"]
-    )
+    out = keras.ops.convert_to_numpy(op(data=data, flat_aligned_apodization=apodization)["data"])
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1246,14 +1201,10 @@ def test_apply_receive_apodization(with_batch_dim):
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
 
-    out = keras.ops.convert_to_numpy(
-        apply_receive_apodization(data, apodization, with_batch_dim)
-    )
+    out = keras.ops.convert_to_numpy(apply_receive_apodization(data, apodization, with_batch_dim))
 
     # Broadcast the (n_pix, n_el) weight over n_tx (leading) and n_ch (trailing).
-    expected = np.broadcast_to(
-        apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)
-    ).copy()
+    expected = np.broadcast_to(apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)).copy()
     if with_batch_dim:
         expected = expected[None]
 
@@ -1295,9 +1246,7 @@ def test_receive_apodization_op(with_batch_dim):
     # Per-element taper -> scales the expected elements
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
-    out = keras.ops.convert_to_numpy(
-        op(data=data, flat_receive_apodization=apodization)["data"]
-    )
+    out = keras.ops.convert_to_numpy(op(data=data, flat_receive_apodization=apodization)["data"])
 
     expected = data_np * apod_np[None, :, :, None]
     if with_batch_dim:
@@ -1391,14 +1340,10 @@ def test_tissue_suppression():
     output = keras.ops.convert_to_numpy(op(data=data_tensor)["data"])
 
     assert output.shape == shape, f"Expected shape {shape}, got {output.shape}"
-    assert output.dtype == data.dtype, (
-        f"Expected dtype {data.dtype}, got {output.dtype}"
-    )
+    assert output.dtype == data.dtype, f"Expected dtype {data.dtype}, got {output.dtype}"
 
     # After suppression, energy should be lower than the original tissue-dominated signal
-    assert np.mean(output**2) < np.mean(data**2), (
-        "Tissue suppression should reduce signal energy"
-    )
+    assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
 
     correlation_across_frames = np.corrcoef(output.reshape(n_frames, -1))
     # The correlation across frames should be reduced after tissue suppression
@@ -1426,9 +1371,7 @@ def _complex_clutter_movie(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     rng = np.random.default_rng(seed)
 
     def _complex_normal(shape):
-        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(
-            np.complex64
-        )
+        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(np.complex64)
 
     spatial = _complex_normal((n_z, n_x)) * 10
     phase = np.exp(1j * 2 * np.pi * 0.02 * np.arange(n_frames)).astype(np.complex64)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -12,6 +12,8 @@ import numpy as np
 import pytest
 from scipy.ndimage import gaussian_filter
 from scipy.signal import hilbert as hilbert_scipy
+
+from zea import ops
 from zea.func.ultrasound import (
     channels_to_complex,
     complex_to_channels,
@@ -20,8 +22,6 @@ from zea.func.ultrasound import (
 )
 from zea.ops import Pipeline, Simulate, beamformer_registry
 from zea.parameters import Parameters
-
-from zea import ops
 
 from . import DEFAULT_TEST_SEED, backend_equality_check
 
@@ -661,6 +661,7 @@ def test_beamformers(beamformer_name):
     """All beamformer operations produce the correct output shape and agree across backends."""
 
     import keras
+
     from zea.ops import beamformer_registry
 
     n_tx, n_pix, n_el, n_ch = 3, 7, 4, 2
@@ -776,6 +777,7 @@ def test_apply_window(axis, size, start, end, window_type):
     """Test ApplyWindow operation."""
 
     import keras
+
     from zea.ops.ultrasound import ApplyWindow
 
     operation = ApplyWindow(axis=axis, size=size, start=start, end=end, window_type=window_type)
@@ -1265,6 +1267,7 @@ def test_prepare_parameters_pfield_all_backends():
     """
 
     import keras
+
     from zea.beamform.delays import compute_t0_delays_planewave
     from zea.internal.cache import cache_disabled
     from zea.ops import Pipeline
@@ -1358,15 +1361,11 @@ def test_tissue_suppression():
 def _complex_clutter_video(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     """Complex IQ video: strong phase-rotating tissue clutter + weak blood.
 
-    The tissue rotates in phase over time (as moving tissue does in real
-    baseband IQ), which is what distinguishes the Hermitian Gram matrix from the
-    plain-transpose one -- for tissue that is merely a constant real map repeated
-    across frames, both give the same answer.
+    The tissue rotates in phase over time, which is what distinguishes the
+    Hermitian Gram matrix from the plain-transpose one.
 
-    Returns the video both as a complex array (n_frames, n_z, n_x) -- for testing
-    :func:`zea.func.ultrasound.suppress_tissue` directly -- and as real IQ
-    channels (n_frames, n_z, n_x, 2), the shape :class:`zea.ops.TissueSuppression`
-    with ``filter_type="svd_complex"`` actually expects on its dict boundary.
+    Returns the video as a complex array (n_frames, n_z, n_x) and as real IQ
+    channels (n_frames, n_z, n_x, 2).
     """
     rng = np.random.default_rng(seed)
 
@@ -1382,20 +1381,12 @@ def _complex_clutter_video(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     return data, data_channels
 
 
+@backend_equality_check(allow_none=True)
 def test_tissue_suppression_complex():
     """TissueSuppression with filter_type='svd_complex' suppresses complex IQ clutter.
 
-    The op takes IQ data as two real channels (n_frames, ..., 2) -- the zea
-    convention, matching e.g. Beamform's output -- and converts to/from complex
-    internally with view_as_complex/view_as_real, the same pattern
-    DelayMultiplyAndSum uses, so it composes with the rest of a Pipeline.
-
-    Deliberately not a ``backend_equality_check``: what survives the filter is the
-    near-null-space residual, and different backends' SVD implementations pick
-    different (equally valid) bases for the discarded subspace, so the residual is
-    not comparable elementwise across backends. For this reason,
-    the ratio of the energy before and after filtering is asserted as a
-    regression test.
+    The op takes IQ data as two real channels (n_frames, ..., 2), the zea
+    convention, and converts to/from complex internally.
     """
     import keras
 
@@ -1419,14 +1410,12 @@ def test_tissue_suppression_complex():
 def test_tissue_suppression_complex_needs_conjugate():
     """The plain-transpose 'svd' filter fails on complex IQ; 'svd_complex' is required.
 
-    This is the reason filter_type exists: on complex data the plain transpose
-    builds X^T X rather than the temporal covariance X^H X, so the dominant
-    components it finds are not the tissue subspace and the clutter survives.
-
-    This is a property of the maths, not of any backend, so it is checked against
-    the reference (numpy) implementation directly rather than through the op --
-    TensorFlow cannot XLA-compile a complex SVD at all.
+    On complex data the plain transpose builds X^T X rather than the temporal
+    covariance X^H X, so the components it finds are not the tissue subspace.
+    Checked against the reference implementation: this is maths, not backend behaviour.
     """
+    import keras
+
     from zea.func.ultrasound import suppress_tissue
 
     data, _ = _complex_clutter_video()  # complex array, not the real-channel one
@@ -1440,20 +1429,9 @@ def test_tissue_suppression_complex_needs_conjugate():
     assert _energy_ratio(conjugate=False) > 0.5
 
 
+@backend_equality_check(allow_none=True)
 def test_tissue_suppression_conjugate_matches_plain_on_zero_imag_data():
-    """With a zero imaginary part, the conjugate transpose is a no-op.
-
-    ``svd_complex`` on IQ channels ``[real, 0]`` (i.e. genuinely real data,
-    just carried in the two-channel convention) must agree with ``svd``
-    applied to the real channel directly, since ``conj()`` is the identity on
-    real numbers.
-
-    The tolerance is loose because the two do not necessarily run through the same
-    code path: on TensorFlow ``svd_complex`` is forced eager (there is no complex
-    XLA ``Svd`` kernel) while ``svd`` is XLA-compiled, and XLA's float32 SVD
-    differs from the eager one by ~1e-3 on a matrix with near-degenerate singular
-    values. The point here is that the maths is equivalent, not bit-exactness.
-    """
+    """With a zero imaginary part, the conjugate transpose is a no-op."""
     import keras
 
     from zea import ops
@@ -1488,11 +1466,7 @@ def test_tissue_suppression_fractional_cutoff():
 
 
 def test_tissue_suppression_filter_type_autodetect():
-    """filter_type=None picks svd_complex for IQ (n_ch=2) and svd otherwise.
-
-    This is zea's channel convention (n_ch=1 -> RF/real, n_ch=2 -> IQ), the same
-    ``shape[-1] == 2`` test envelope_detect and Upmix use.
-    """
+    """filter_type=None picks svd_complex for IQ (n_ch=2) and svd otherwise."""
     import keras
 
     from zea import ops
@@ -1511,6 +1485,7 @@ def test_tissue_suppression_filter_type_autodetect():
     assert _resolve((10, 8, 8), filter_type="svd_complex") == "svd_complex"
 
 
+@backend_equality_check(allow_none=True)
 def test_tissue_suppression_autodetect_matches_explicit():
     """Auto-detected IQ input gives the same result as filter_type='svd_complex'."""
     import keras

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -103,7 +103,10 @@ def test_converting_to_image(size, dynamic_range, input_range):
         _input_range = input_range
 
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
-    data = rng.standard_normal(size) * (_input_range[1] - _input_range[0]) + _input_range[0]
+    data = (
+        rng.standard_normal(size) * (_input_range[1] - _input_range[0])
+        + _input_range[0]
+    )
     output_range = (0, 1)
     normalize = ops.Normalize(output_range, input_range)
     log_compress = ops.LogCompress()
@@ -219,9 +222,9 @@ def test_complex_channels_operations(size, axis):
     rng = np.random.default_rng(DEFAULT_TEST_SEED)
     complex_data = (rng.random(size) + 1j * rng.random(size)).astype("complex64")
 
-    channels = ops.ComplexToChannels(axis=axis)(data=keras.ops.convert_to_tensor(complex_data))[
-        "data"
-    ]
+    channels = ops.ComplexToChannels(axis=axis)(
+        data=keras.ops.convert_to_tensor(complex_data)
+    )["data"]
     channels = keras.ops.convert_to_numpy(channels)
     assert channels.shape[axis] == 2, "Real/imaginary channels should live on `axis`."
 
@@ -574,7 +577,9 @@ def test_lee_filter(sigma, spiral_image):
     ],
 )
 @backend_equality_check()
-def test_threshold_op(spiral_image, threshold_type, below_threshold, fill_value, threshold_param):
+def test_threshold_op(
+    spiral_image, threshold_type, below_threshold, fill_value, threshold_param
+):
     """Test `ops.Threshold` operation on a synthetic spiral image."""
     import keras
 
@@ -593,7 +598,9 @@ def test_threshold_op(spiral_image, threshold_type, below_threshold, fill_value,
     percentile = threshold_param.get("percentile", None)
     threshold_value = threshold_param.get("threshold", None)
 
-    out = threshold(data=spiral_tensor, percentile=percentile, threshold=threshold_value)
+    out = threshold(
+        data=spiral_tensor, percentile=percentile, threshold=threshold_value
+    )
     out_np = keras.ops.convert_to_numpy(out["data"])
 
     # Quantitative: check that thresholding changes the image
@@ -652,7 +659,9 @@ def test_compute_time_to_peak():
 
     t_peak = compute_time_to_peak_stack(waveforms, center_frequencies, 250e6)
 
-    assert np.allclose(t_peak, 1e-6, atol=1e-8), f"t_peak should be close to 1e-6, got {t_peak}"
+    assert np.allclose(t_peak, 1e-6, atol=1e-8), (
+        f"t_peak should be close to 1e-6, got {t_peak}"
+    )
 
 
 @pytest.mark.parametrize("beamformer_name", beamformer_registry.registered_names())
@@ -745,8 +754,12 @@ def test_generalized_coherence_factor_m_zero_passthrough():
     )
 
     # m_zero=2 at init vs. m_zero=2 at call time should give identical results
-    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)["data"]
-    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)["data"]
+    out_init = ops.GeneralizedCoherenceFactor(m_zero=2, with_batch_dim=True)(data=data)[
+        "data"
+    ]
+    out_call = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=2)[
+        "data"
+    ]
     np.testing.assert_allclose(
         keras.ops.convert_to_numpy(out_init),
         keras.ops.convert_to_numpy(out_call),
@@ -755,7 +768,9 @@ def test_generalized_coherence_factor_m_zero_passthrough():
 
     # Different m_zero values should produce different results
     out_default = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data)["data"]
-    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)["data"]
+    out_m0 = ops.GeneralizedCoherenceFactor(with_batch_dim=True)(data=data, m_zero=0)[
+        "data"
+    ]
     assert not np.allclose(
         keras.ops.convert_to_numpy(out_default),
         keras.ops.convert_to_numpy(out_m0),
@@ -778,7 +793,9 @@ def test_apply_window(axis, size, start, end, window_type):
     import keras
     from zea.ops.ultrasound import ApplyWindow
 
-    operation = ApplyWindow(axis=axis, size=size, start=start, end=end, window_type=window_type)
+    operation = ApplyWindow(
+        axis=axis, size=size, start=start, end=end, window_type=window_type
+    )
 
     data = keras.ops.ones((256, 128, 64))
     data_out = operation(data=data)["data"]
@@ -853,11 +870,19 @@ def test_band_pass_filter():
     result_demod_frequency = keras.ops.convert_to_numpy(result_demod_frequency)
 
     # Compare the three passband-related modes.
-    assert np.allclose(result_init_passband, result_demod_frequency, rtol=rtol, atol=atol)
-    assert not np.allclose(result_init_passband, result_call_passband, rtol=rtol, atol=atol)
-    assert not np.allclose(result_demod_frequency, result_call_passband, rtol=rtol, atol=atol)
+    assert np.allclose(
+        result_init_passband, result_demod_frequency, rtol=rtol, atol=atol
+    )
+    assert not np.allclose(
+        result_init_passband, result_call_passband, rtol=rtol, atol=atol
+    )
+    assert not np.allclose(
+        result_demod_frequency, result_call_passband, rtol=rtol, atol=atol
+    )
 
-    with pytest.raises(ValueError, match="passband must be an iterable of two numeric values"):
+    with pytest.raises(
+        ValueError, match="passband must be an iterable of two numeric values"
+    ):
         operation(
             data=data,
             sampling_frequency=40e6,
@@ -914,14 +939,20 @@ def test_make_tgc_curve():
     )
 
     # Check output shape
-    assert tgc_curve.shape == (n_ax,), f"Expected shape ({n_ax},), got {tgc_curve.shape}"
+    assert tgc_curve.shape == (n_ax,), (
+        f"Expected shape ({n_ax},), got {tgc_curve.shape}"
+    )
 
     # Check output dtype
-    assert tgc_curve.dtype == np.float32, f"Expected dtype float32, got {tgc_curve.dtype}"
+    assert tgc_curve.dtype == np.float32, (
+        f"Expected dtype float32, got {tgc_curve.dtype}"
+    )
 
     # Check that the curve is monotonically increasing (TGC should increase with depth)
     differences = np.diff(tgc_curve)
-    assert np.all(differences >= 0), "TGC curve should be monotonically increasing with depth"
+    assert np.all(differences >= 0), (
+        "TGC curve should be monotonically increasing with depth"
+    )
 
     # Check that the first value is 1 (no gain at zero depth)
     assert np.isclose(tgc_curve[0], 1.0, rtol=1e-5), (
@@ -960,7 +991,9 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     # Add random phase variations to simulate realistic ultrasound data
     # IQ data has 2 channels (I and Q)
     phase = rng.random((n_tx, n_pix, n_rx)) * 2 * np.pi
-    amplitude = rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5  # Amplitude between 0.5 and 1
+    amplitude = (
+        rng.random((n_tx, n_pix, n_rx)) * 0.5 + 0.5
+    )  # Amplitude between 0.5 and 1
 
     # Convert to IQ format
     data = np.stack(
@@ -1010,7 +1043,9 @@ def test_common_midpoint_phase_error(n_tx, n_pix, n_rx, with_batch):
     )
 
     # Check for NaN values
-    assert not np.any(np.isnan(phase_error_np)), "Phase errors should not contain NaN values"
+    assert not np.any(np.isnan(phase_error_np)), (
+        "Phase errors should not contain NaN values"
+    )
 
     if with_batch:
         # Check that the two batches are not identical (due to different phase patterns)
@@ -1062,10 +1097,14 @@ def test_common_midpoint_phase_error_with_zeros():
     phase_error = keras.ops.convert_to_numpy(output["data"])
 
     # Check that computation doesn't crash and produces valid output
-    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
+    assert phase_error.shape == (n_pix,), (
+        f"Expected shape ({n_pix},), got {phase_error.shape}"
+    )
 
     # Check for inf values (should never occur)
-    assert not np.any(np.isinf(phase_error)), "Phase errors should not contain infinities"
+    assert not np.any(np.isinf(phase_error)), (
+        "Phase errors should not contain infinities"
+    )
 
     # NaNs are acceptable where all subapertures are invalid (division by zero)
     # but not all values should be NaN
@@ -1116,7 +1155,9 @@ def test_common_midpoint_phase_error_coherent_data():
     )
 
     # Check shape
-    assert phase_error.shape == (n_pix,), f"Expected shape ({n_pix},), got {phase_error.shape}"
+    assert phase_error.shape == (n_pix,), (
+        f"Expected shape ({n_pix},), got {phase_error.shape}"
+    )
 
     return phase_error
 
@@ -1139,7 +1180,9 @@ def test_apply_aligned_apodization(with_batch_dim):
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
 
-    out = keras.ops.convert_to_numpy(apply_aligned_apodization(data, apodization, with_batch_dim))
+    out = keras.ops.convert_to_numpy(
+        apply_aligned_apodization(data, apodization, with_batch_dim)
+    )
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1173,7 +1216,9 @@ def test_aligned_apodization_op(with_batch_dim):
     apodization = keras.ops.convert_to_tensor(
         np.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0]], dtype=np.float32)
     )
-    out = keras.ops.convert_to_numpy(op(data=data, flat_aligned_apodization=apodization)["data"])
+    out = keras.ops.convert_to_numpy(
+        op(data=data, flat_aligned_apodization=apodization)["data"]
+    )
 
     expected = np.zeros((n_tx, n_pix, n_el, n_ch), dtype=np.float32)
     expected[0, 0] = 1.0
@@ -1201,10 +1246,14 @@ def test_apply_receive_apodization(with_batch_dim):
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
 
-    out = keras.ops.convert_to_numpy(apply_receive_apodization(data, apodization, with_batch_dim))
+    out = keras.ops.convert_to_numpy(
+        apply_receive_apodization(data, apodization, with_batch_dim)
+    )
 
     # Broadcast the (n_pix, n_el) weight over n_tx (leading) and n_ch (trailing).
-    expected = np.broadcast_to(apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)).copy()
+    expected = np.broadcast_to(
+        apod_np[None, :, :, None], (n_tx, n_pix, n_el, n_ch)
+    ).copy()
     if with_batch_dim:
         expected = expected[None]
 
@@ -1246,7 +1295,9 @@ def test_receive_apodization_op(with_batch_dim):
     # Per-element taper -> scales the expected elements
     apod_np = np.array([[1.0, 0.5, 0.0, 0.0], [0.0, 0.0, 0.5, 1.0]], dtype=np.float32)
     apodization = keras.ops.convert_to_tensor(apod_np)
-    out = keras.ops.convert_to_numpy(op(data=data, flat_receive_apodization=apodization)["data"])
+    out = keras.ops.convert_to_numpy(
+        op(data=data, flat_receive_apodization=apodization)["data"]
+    )
 
     expected = data_np * apod_np[None, :, :, None]
     if with_batch_dim:
@@ -1340,10 +1391,14 @@ def test_tissue_suppression():
     output = keras.ops.convert_to_numpy(op(data=data_tensor)["data"])
 
     assert output.shape == shape, f"Expected shape {shape}, got {output.shape}"
-    assert output.dtype == data.dtype, f"Expected dtype {data.dtype}, got {output.dtype}"
+    assert output.dtype == data.dtype, (
+        f"Expected dtype {data.dtype}, got {output.dtype}"
+    )
 
     # After suppression, energy should be lower than the original tissue-dominated signal
-    assert np.mean(output**2) < np.mean(data**2), "Tissue suppression should reduce signal energy"
+    assert np.mean(output**2) < np.mean(data**2), (
+        "Tissue suppression should reduce signal energy"
+    )
 
     correlation_across_frames = np.corrcoef(output.reshape(n_frames, -1))
     # The correlation across frames should be reduced after tissue suppression
@@ -1355,15 +1410,15 @@ def test_tissue_suppression():
     return output
 
 
-def _complex_clutter_movie(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
-    """Complex IQ movie: strong phase-rotating tissue clutter + weak blood.
+def _complex_clutter_video(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
+    """Complex IQ video: strong phase-rotating tissue clutter + weak blood.
 
     The tissue rotates in phase over time (as moving tissue does in real
     baseband IQ), which is what distinguishes the Hermitian Gram matrix from the
     plain-transpose one -- for tissue that is merely a constant real map repeated
     across frames, both give the same answer.
 
-    Returns the movie both as a complex array (n_frames, n_z, n_x) -- for testing
+    Returns the video both as a complex array (n_frames, n_z, n_x) -- for testing
     :func:`zea.func.ultrasound.suppress_tissue` directly -- and as real IQ
     channels (n_frames, n_z, n_x, 2), the shape :class:`zea.ops.TissueSuppression`
     with ``filter_type="svd_complex"`` actually expects on its dict boundary.
@@ -1371,7 +1426,9 @@ def _complex_clutter_movie(n_frames=40, n_z=16, n_x=16, seed=DEFAULT_TEST_SEED):
     rng = np.random.default_rng(seed)
 
     def _complex_normal(shape):
-        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(np.complex64)
+        return (rng.standard_normal(shape) + 1j * rng.standard_normal(shape)).astype(
+            np.complex64
+        )
 
     spatial = _complex_normal((n_z, n_x)) * 10
     phase = np.exp(1j * 2 * np.pi * 0.02 * np.arange(n_frames)).astype(np.complex64)
@@ -1401,10 +1458,12 @@ def test_tissue_suppression_complex():
 
     from zea import ops
 
-    _, data_channels = _complex_clutter_movie()
+    _, data_channels = _complex_clutter_video()
 
     op = ops.TissueSuppression(cutoff=2, filter_type="svd_complex")
-    output = keras.ops.convert_to_numpy(op(data=keras.ops.convert_to_tensor(data_channels))["data"])
+    output = keras.ops.convert_to_numpy(
+        op(data=keras.ops.convert_to_tensor(data_channels))["data"]
+    )
 
     assert output.shape == data_channels.shape
     assert output.dtype == data_channels.dtype, (
@@ -1413,7 +1472,9 @@ def test_tissue_suppression_complex():
 
     # The clutter dominates the energy, so removing it must remove nearly all of it.
     energy_ratio = np.mean(output**2) / np.mean(data_channels**2)
-    assert energy_ratio < 0.01, f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
+    assert energy_ratio < 0.01, (
+        f"Expected clutter to be suppressed, energy ratio {energy_ratio}"
+    )
 
 
 def test_tissue_suppression_complex_needs_conjugate():
@@ -1429,7 +1490,7 @@ def test_tissue_suppression_complex_needs_conjugate():
     """
     from zea.func.ultrasound import suppress_tissue
 
-    data, _ = _complex_clutter_movie()  # complex array, not the real-channel one
+    data, _ = _complex_clutter_video()  # complex array, not the real-channel one
 
     def _energy_ratio(conjugate):
         output = np.asarray(suppress_tissue(data, 2, conjugate=conjugate))

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -1011,24 +1011,37 @@ def dehaze_nuclear_diffusion(
     return tissue_frames, haze_frames
 
 
-def suppress_tissue(data, cutoff: int = 5):
+def suppress_tissue(data, cutoff: int = 5, conjugate: bool = False):
     """
     Suppresses tissue using Direct SVD.
+
+    Builds the Casorati matrix (frames x pixels), takes the SVD of its temporal
+    Gram matrix, and projects the data onto the subspace orthogonal to the
+    ``cutoff`` strongest (tissue) components.
 
     Args:
         data (ops.Tensor): Shape (n_frames, ...)
         cutoff (int): Number of principal components (tissue) to reject.
+        conjugate (bool): Whether to use the conjugate (Hermitian) transpose when
+            forming the Gram matrix and the projector. Leave ``False`` for
+            real-valued input. Set to ``True`` for complex (baseband IQ) input:
+            the plain transpose builds ``XᵀX`` rather than ``XᴴX``, which is not
+            the temporal covariance of a complex signal and does not suppress the
+            tissue. Ignored for real input, where the two are identical.
     """
     if cutoff <= 0:
         return data
     if cutoff >= data.shape[0]:
         raise ValueError(f"Cutoff must be between 0 and n_frames-1, got {cutoff}.")
 
+    def _transpose(x):
+        return ops.conj(ops.transpose(x)) if conjugate else ops.transpose(x)
+
     original_shape = data.shape
     n_frames = original_shape[0]
     data_2d = ops.reshape(data, (n_frames, -1))
 
-    casorati_matrix = ops.matmul(data_2d, ops.transpose(data_2d))
+    casorati_matrix = ops.matmul(data_2d, _transpose(data_2d))
 
     # We call the data X
     # X = U @ S @ Vh
@@ -1038,9 +1051,9 @@ def suppress_tissue(data, cutoff: int = 5):
     V, S, _ = ops.linalg.svd(casorati_matrix)
 
     # Remove the right singular vectors
-    reconstructed = ops.matmul(ops.transpose(data_2d), V)
+    reconstructed = ops.matmul(_transpose(data_2d), V)
 
     # Reconstruct with only part of the vectors
-    reconstructed = ops.matmul(reconstructed[:, cutoff:], ops.transpose(V[:, cutoff:]))
+    reconstructed = ops.matmul(reconstructed[:, cutoff:], _transpose(V[:, cutoff:]))
 
-    return ops.reshape(ops.transpose(reconstructed), original_shape)
+    return ops.reshape(_transpose(reconstructed), original_shape)

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1386,7 +1386,8 @@ class CommonMidpointPhaseError(Operation):
 
 @ops_registry("tissue_suppression")
 class TissueSuppression(Operation):
-    """Tissue suppression using SVD-based clutter filtering.
+    """Tissue suppression using SVD-based clutter filtering. Typically applied
+    after beamforming but before envelope detection, on beamformed RF or IQ data.
 
     Removes stationary tissue components from multi-frame ultrasound data
     by zeroing the dominant singular values of the Casorati matrix.
@@ -1396,18 +1397,11 @@ class TissueSuppression(Operation):
     * ``"svd"`` -- the real-valued Direct SVD filter, building the temporal Gram
       matrix with a plain transpose (``XᵀX``). For real data.
     * ``"svd_complex"`` -- the same filter using the conjugate (Hermitian)
-      transpose (``XᴴX``, the true temporal covariance), for IQ data. The op
-      converts the ``[I, Q]`` channels to a complex tensor internally with
-      ``keras.ops.view_as_complex`` and back with ``view_as_real`` before
-      returning, so the op's inputs and outputs stay real-valued and compose in
-      a :class:`Pipeline` like any other operation. This is the filter used for
-      Power-Doppler / ULM processing (as in MUST's ``process.m``).
+      transpose (``XᴴX``, the true temporal covariance), for IQ data.
 
     By default ``filter_type=None`` picks between them from the channel axis --
-    ``n_ch=2`` means IQ and selects ``"svd_complex"``, anything else selects
-    ``"svd"`` -- the same ``shape[-1] == 2`` test
-    :func:`zea.func.ultrasound.envelope_detect` and :class:`Upmix` use. Pass
-    ``filter_type`` explicitly to override this.
+    ``n_ch=2`` means IQ and selects ``"svd_complex"``, otherwise
+    ``"svd"``.
 
     .. note::
         On the TensorFlow backend the ``"svd_complex"`` path runs eagerly:
@@ -1425,8 +1419,7 @@ class TissueSuppression(Operation):
             cutoff (int or float): Number of principal (tissue) components to
                 reject. An ``int`` is a component count. A ``float`` in ``[0, 1)``
                 is a fraction of the number of frames, resolved at call time as
-                ``round(n_frames * cutoff)`` (matching the ULM convention of
-                specifying the clutter cutoff as a percentage of frames).
+                ``round(n_frames * cutoff)``.
             filter_type (str or None): Which clutter filter to use, one of
                 :attr:`FILTER_TYPES`. Defaults to ``None``, which selects
                 ``"svd_complex"`` for IQ input (``n_ch=2``) and ``"svd"``
@@ -1496,9 +1489,7 @@ class TissueSuppression(Operation):
             data (ops.Tensor): Shape (n_frames, ...). Complex for the
                 ``"svd_complex"`` filter type, real otherwise.
             filter_type (str or None): Filter to apply. Defaults to ``None``,
-                which resolves it from ``data`` via :meth:`resolve_filter_type`
-                (note that by then the IQ channels have already been merged into
-                a complex axis, so callers inside :meth:`call` pass it in).
+                which resolves it from ``data`` via :meth:`resolve_filter_type`.
 
         """
         if filter_type is None:
@@ -1514,10 +1505,6 @@ class TissueSuppression(Operation):
         filter_type = self.resolve_filter_type(data)
         is_complex = filter_type == "svd_complex"
 
-        # Real IQ-channel input ((n_frames, ..., 2)) <-> complex ((n_frames, ...))
-        # conversion happens inside the op, same as DelayMultiplyAndSum, so the
-        # op's dict-boundary contract stays real-valued and composes in a
-        # Pipeline like any other op.
         array = ops.view_as_complex(ops.array(data)) if is_complex else ops.array(data)
         filtered = self.suppress_tissue(array, filter_type=filter_type)
         if is_complex:

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1434,7 +1434,7 @@ class TissueSuppression(Operation):
             int: Number of principal components to reject.
         """
         if isinstance(self.cutoff, float):
-            return int(round(n_frames * self.cutoff))
+            return min(int(round(n_frames * self.cutoff)), n_frames - 1)
         return self.cutoff
 
     def suppress_tissue(self, data, filter_type=None):

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1362,6 +1362,12 @@ class TissueSuppression(Operation):
     ``"svd"``.
 
     .. note::
+        Unlike most operations, this one is temporal: axis 0 of the input is the
+        frame axis and is consumed jointly, so ``with_batch_dim`` does not apply
+        and is ignored. Input is always ``(n_frames, ...)``. To process several
+        acquisitions, loop the pipeline over them.
+
+    .. note::
         On the TensorFlow backend the ``"svd_complex"`` path runs eagerly:
         TensorFlow registers no XLA ``Svd`` kernel for complex dtypes. The other
         backends JIT it.

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1348,11 +1348,77 @@ class TissueSuppression(Operation):
 
     Removes stationary tissue components from multi-frame ultrasound data
     by zeroing the dominant singular values of the Casorati matrix.
+
+    Two filter types are available, selected with ``filter_type``:
+
+    * ``"svd"`` (default) -- the real-valued Direct SVD filter. Builds the Gram
+      matrix with a plain transpose.
+    * ``"svd_complex"`` -- the same filter with a conjugate (Hermitian)
+      transpose, for complex baseband IQ input. This is the filter used for
+      Power-Doppler / ULM processing (as in MUST's ``process.m``). On complex
+      input ``"svd"`` builds ``XᵀX`` instead of the temporal covariance ``XᴴX``
+      and will not suppress the tissue.
+
+    .. note::
+        On the TensorFlow backend ``"svd_complex"`` runs eagerly: TensorFlow
+        registers no XLA ``Svd`` kernel for complex dtypes. The other backends
+        JIT it.
     """
 
-    def __init__(self, cutoff: int = 5, **kwargs):
-        super().__init__(**kwargs)
+    FILTER_TYPES = ("svd", "svd_complex")
+
+    def __init__(self, cutoff: int | float = 5, filter_type: str = "svd", **kwargs):
+        """
+        Args:
+            cutoff (int or float): Number of principal (tissue) components to
+                reject. An ``int`` is a component count. A ``float`` in ``[0, 1)``
+                is a fraction of the number of frames, resolved at call time as
+                ``round(n_frames * cutoff)`` (matching the ULM convention of
+                specifying the clutter cutoff as a percentage of frames).
+            filter_type (str): Which clutter filter to use, one of
+                :attr:`FILTER_TYPES`. Use ``"svd_complex"`` for complex IQ input.
+        """
+        if filter_type not in self.FILTER_TYPES:
+            raise ValueError(
+                f"Unknown filter_type {filter_type!r}, expected one of "
+                f"{', '.join(map(repr, self.FILTER_TYPES))}."
+            )
+        if isinstance(cutoff, float) and not 0 <= cutoff < 1:
+            raise ValueError(
+                f"A float cutoff is a fraction of the frames and must be in [0, 1), got {cutoff}."
+            )
+        # Set before super().__init__(), which calls set_jit() -> reads self.jittable.
         self.cutoff = cutoff
+        self.filter_type = filter_type
+        super().__init__(**kwargs)
+
+    @property
+    def jittable(self):
+        """Whether this operation can be JIT compiled.
+
+        TensorFlow registers no XLA ``Svd`` kernel for complex dtypes, so on that
+        backend the filter has to run eagerly. ``svd_complex`` only ever makes
+        sense on complex input, so it is never jitted there. Plain ``svd`` is
+        meant for real data and stays jittable (feeding it complex data on
+        TensorFlow raises, but that combination does not suppress the tissue
+        anyway -- use ``svd_complex`` for complex input).
+        """
+        if self.filter_type == "svd_complex" and keras.backend.backend() == "tensorflow":
+            return False
+        return super().jittable
+
+    def resolve_cutoff(self, n_frames: int) -> int:
+        """Resolve a fractional ``cutoff`` into a component count.
+
+        Args:
+            n_frames (int): Number of frames in the data.
+
+        Returns:
+            int: Number of principal components to reject.
+        """
+        if isinstance(self.cutoff, float):
+            return int(round(n_frames * self.cutoff))
+        return self.cutoff
 
     def suppress_tissue(self, data):
         """
@@ -1362,7 +1428,11 @@ class TissueSuppression(Operation):
             data (ops.Tensor): Shape (n_frames, ...)
 
         """
-        return suppress_tissue(data, self.cutoff)
+        return suppress_tissue(
+            data,
+            self.resolve_cutoff(data.shape[0]),
+            conjugate=self.filter_type == "svd_complex",
+        )
 
     def call(self, **kwargs):
         data = kwargs[self.key]

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -245,7 +245,9 @@ class PfieldWeighting(Operation):
         if flat_pfield is None:
             return {self.output_key: data}
 
-        weighted_data = apply_aligned_apodization(data, flat_pfield, self.with_batch_dim)
+        weighted_data = apply_aligned_apodization(
+            data, flat_pfield, self.with_batch_dim
+        )
 
         return {self.output_key: weighted_data}
 
@@ -332,7 +334,9 @@ class ReceiveApodization(Operation):
         Returns:
             dict: Dictionary containing weighted data
         """
-        data = kwargs[self.key]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
+        data = kwargs[
+            self.key
+        ]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
 
         if flat_receive_apodization is None:
             return {self.output_key: data}
@@ -372,7 +376,8 @@ class ScanConvert(Operation):
         if order > 1:
             jittable = False
             log.warning(
-                "GPU support for order > 1 is not available. " + "Disabling jit for ScanConvert."
+                "GPU support for order > 1 is not available. "
+                + "Disabling jit for ScanConvert."
             )
         else:
             jittable = True
@@ -583,7 +588,9 @@ class LowPassFilterIQ(FirFilter):
                 Odd will result in a type I filter, even in a type II filter.
         """
         if "jittable" in kwargs:
-            raise ValueError("LowPassFilterIQ is not jittable, so jittable must be set to False.")
+            raise ValueError(
+                "LowPassFilterIQ is not jittable, so jittable must be set to False."
+            )
         if "complex_channels" in kwargs and not kwargs["complex_channels"]:
             raise ValueError(
                 "LowPassFilterIQ operates on IQ data, so complex_channels must be True."
@@ -721,7 +728,8 @@ class BandPassFilter(FirFilter):
             raise ValueError(passband_error_message)
 
         if not all(
-            isinstance(f, (int, float, np.number)) and not isinstance(f, bool) for f in (f1, f2)
+            isinstance(f, (int, float, np.number)) and not isinstance(f, bool)
+            for f in (f1, f2)
         ):
             raise ValueError(passband_error_message)
 
@@ -874,9 +882,13 @@ class Companding(Operation):
             raise ValueError("comp_type must be 'mu' or 'a'.")
 
         if self.comp_type == "mu":
-            self._compand_func = self._mu_law_expand if self.expand else self._mu_law_compress
+            self._compand_func = (
+                self._mu_law_expand if self.expand else self._mu_law_compress
+            )
         else:
-            self._compand_func = self._a_law_expand if self.expand else self._a_law_compress
+            self._compand_func = (
+                self._a_law_expand if self.expand else self._a_law_compress
+            )
 
     @staticmethod
     def _mu_law_compress(x, mu=255, **kwargs):
@@ -987,7 +999,9 @@ class AnisotropicDiffusion(Operation):
         results = []
         for i in range(batch_size):
             image = data[i]
-            image_out = self._anisotropic_diffusion_single(image, niter, lmbda, rect, eps)
+            image_out = self._anisotropic_diffusion_single(
+                image, niter, lmbda, rect, eps
+            )
             results.append(image_out)
 
         result = ops.stack(results, axis=0)
@@ -1003,15 +1017,25 @@ class AnisotropicDiffusion(Operation):
         M, N = image.shape
 
         for _ in range(niter):
-            iN = ops.concatenate([image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0)
-            iS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0)
-            jW = ops.concatenate([image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1)
-            jE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1)
+            iN = ops.concatenate(
+                [image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0
+            )
+            iS = ops.concatenate(
+                [ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0
+            )
+            jW = ops.concatenate(
+                [image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1
+            )
+            jE = ops.concatenate(
+                [ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1
+            )
 
             if rect is not None:
                 x1, y1, x2, y2 = rect
                 imageuniform = image[x1:x2, y1:y2]
-                q0_squared = (ops.std(imageuniform) / (ops.mean(imageuniform) + eps)) ** 2
+                q0_squared = (
+                    ops.std(imageuniform) / (ops.mean(imageuniform) + eps)
+                ) ** 2
 
             dN = iN - image
             dS = iS - image
@@ -1028,7 +1052,9 @@ class AnisotropicDiffusion(Operation):
                 den = (q_squared - q0_squared) / (q0_squared * (1 + q0_squared) + eps)
             c = 1.0 / (1 + den)
             cS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), c[:-1]], axis=0)
-            cE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1)
+            cE = ops.concatenate(
+                [ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1
+            )
 
             D = (cS * dS) + (c * dN) + (cE * dE) + (c * dW)
             image = image + (lmbda / 4) * D
@@ -1091,7 +1117,9 @@ class UpMix(Operation):
         elif data.shape[-1] == 2:
             data = ops.view_as_complex(data)
 
-        data = upmix(data, sampling_frequency, demodulation_frequency, self.upsampling_rate)
+        data = upmix(
+            data, sampling_frequency, demodulation_frequency, self.upsampling_rate
+        )
         data = ops.expand_dims(data, axis=-1)
         return {self.output_key: data}
 
@@ -1130,7 +1158,9 @@ class LogCompress(Operation):
 
         compressed_data = log_compress(data)
         if self.clip:
-            compressed_data = ops.clip(compressed_data, dynamic_range[0], dynamic_range[1])
+            compressed_data = ops.clip(
+                compressed_data, dynamic_range[0], dynamic_range[1]
+            )
 
         return {self.output_key: compressed_data}
 
@@ -1151,7 +1181,9 @@ class ReshapeGrid(Operation):
             - reshaped_data (Tensor): The reshaped data of shape (..., grid.shape, ...).
         """
         data = kwargs[self.key]
-        reshaped_data = reshape_axis(data, grid.shape[:-1], self.axis + int(self.with_batch_dim))
+        reshaped_data = reshape_axis(
+            data, grid.shape[:-1], self.axis + int(self.with_batch_dim)
+        )
         return {self.output_key: reshaped_data}
 
 
@@ -1166,7 +1198,9 @@ class ApplyWindow(Operation):
     [start (zero)] - [size (window)] - [middle (unmodified)] - [size (window)] - [end (zero)]
     """
 
-    def __init__(self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs):
+    def __init__(
+        self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs
+    ):
         """
         Args:
             axis (int): Axis along which to apply the window.
@@ -1278,7 +1312,9 @@ class CommonMidpointPhaseError(Operation):
         n_tx, n_pix, n_rx, n_ch = data.shape
         receive_subaps = ops.zeros((n_rx, n_tx))
         for diag in range(-halfsa, halfsa + 1):
-            receive_subaps = receive_subaps + ops.diag(ops.ones((n_rx - abs(diag),)), diag)
+            receive_subaps = receive_subaps + ops.diag(
+                ops.ones((n_rx - abs(diag),)), diag
+            )
         receive_subaps = receive_subaps[halfsa : receive_subaps.shape[0] - halfsa : dx]
         transmit_subaps = ops.flip(receive_subaps, axis=0)
         return transmit_subaps, receive_subaps
@@ -1294,7 +1330,9 @@ class CommonMidpointPhaseError(Operation):
         """
 
         transmit_subaps, receive_subaps = self.create_subapertures(data, 8, 1)
-        complex_data = ops.view_as_complex(data)  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
+        complex_data = ops.view_as_complex(
+            data
+        )  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
         complex_data = ops.transpose(complex_data, (2, 0, 1))  # [n_rx, n_tx, n_pix]
         rx_zero_count = ops.matmul(receive_subaps, ops.cast(complex_data == 0, "int32"))
 
@@ -1302,8 +1340,12 @@ class CommonMidpointPhaseError(Operation):
         rx_valid = rx_zero_count <= 1
         complex_data_rx = ops.matmul(receive_subaps, complex_data)
         complex_data_rx = ops.where(rx_valid, complex_data_rx, 0)
-        complex_data_rx = ops.transpose(complex_data_rx, (1, 0, 2))  # [n_tx, n_subap_rx, n_pix]
-        tx_zero_count = ops.matmul(transmit_subaps, ops.cast(complex_data_rx == 0, "int32"))
+        complex_data_rx = ops.transpose(
+            complex_data_rx, (1, 0, 2)
+        )  # [n_tx, n_subap_rx, n_pix]
+        tx_zero_count = ops.matmul(
+            transmit_subaps, ops.cast(complex_data_rx == 0, "int32")
+        )
 
         # Mask out subapertures with point outside fov in transmit
         tx_valid = tx_zero_count <= 1
@@ -1349,14 +1391,6 @@ class TissueSuppression(Operation):
     Removes stationary tissue components from multi-frame ultrasound data
     by zeroing the dominant singular values of the Casorati matrix.
 
-    Input
-    -----
-    Data of shape ``(n_frames, ..., n_ch)``, following zea's channel convention:
-    ``n_ch=1`` (or no channel axis) for RF / real-valued data, ``n_ch=2`` for IQ
-    data carried as two real ``[I, Q]`` channels (e.g. the output of
-    :class:`Beamform` on baseband data). Output has the same shape and dtype as
-    the input.
-
     Two filter types are available:
 
     * ``"svd"`` -- the real-valued Direct SVD filter, building the temporal Gram
@@ -1383,7 +1417,9 @@ class TissueSuppression(Operation):
 
     FILTER_TYPES = ("svd", "svd_complex")
 
-    def __init__(self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs):
+    def __init__(
+        self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs
+    ):
         """
         Args:
             cutoff (int or float): Number of principal (tissue) components to

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1352,12 +1352,18 @@ class TissueSuppression(Operation):
     Two filter types are available, selected with ``filter_type``:
 
     * ``"svd"`` (default) -- the real-valued Direct SVD filter. Builds the Gram
-      matrix with a plain transpose.
+      matrix with a plain transpose. Input is real data of shape
+      ``(n_frames, ...)``.
     * ``"svd_complex"`` -- the same filter with a conjugate (Hermitian)
       transpose, for complex baseband IQ input. This is the filter used for
-      Power-Doppler / ULM processing (as in MUST's ``process.m``). On complex
-      input ``"svd"`` builds ``XᵀX`` instead of the temporal covariance ``XᴴX``
-      and will not suppress the tissue.
+      Power-Doppler / ULM processing (as in MUST's ``process.m``). Input is IQ
+      data as two real channels, shape ``(n_frames, ..., 2)`` (the zea
+      convention -- see e.g. the output of ``Beamform``); the op converts to a
+      complex tensor internally with ``keras.ops.view_as_complex`` and back with
+      ``view_as_real`` before returning, the same pattern
+      :class:`DelayMultiplyAndSum` uses. On real ``[I, Q]`` channel data
+      ``"svd"`` builds ``XᵀX`` instead of the temporal covariance ``XᴴX`` and
+      will not suppress the tissue.
 
     .. note::
         On the TensorFlow backend ``"svd_complex"`` runs eagerly: TensorFlow
@@ -1425,7 +1431,8 @@ class TissueSuppression(Operation):
         Suppresses tissue using Direct SVD.
 
         Args:
-            data (ops.Tensor): Shape (n_frames, ...)
+            data (ops.Tensor): Shape (n_frames, ...). Complex for the
+                ``"svd_complex"`` filter type, real otherwise.
 
         """
         return suppress_tissue(
@@ -1436,5 +1443,15 @@ class TissueSuppression(Operation):
 
     def call(self, **kwargs):
         data = kwargs[self.key]
-        filtered = self.suppress_tissue(ops.array(data))
+        is_complex = self.filter_type == "svd_complex"
+
+        # Real IQ-channel input ((n_frames, ..., 2)) <-> complex ((n_frames, ...))
+        # conversion happens inside the op, same as DelayMultiplyAndSum, so the
+        # op's dict-boundary contract stays real-valued and composes in a
+        # Pipeline like any other op.
+        array = ops.view_as_complex(ops.array(data)) if is_complex else ops.array(data)
+        filtered = self.suppress_tissue(array)
+        if is_complex:
+            filtered = ops.view_as_real(filtered)
+
         return {self.output_key: ops.cast(ops.array(filtered), data.dtype)}

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -245,9 +245,7 @@ class PfieldWeighting(Operation):
         if flat_pfield is None:
             return {self.output_key: data}
 
-        weighted_data = apply_aligned_apodization(
-            data, flat_pfield, self.with_batch_dim
-        )
+        weighted_data = apply_aligned_apodization(data, flat_pfield, self.with_batch_dim)
 
         return {self.output_key: weighted_data}
 
@@ -334,9 +332,7 @@ class ReceiveApodization(Operation):
         Returns:
             dict: Dictionary containing weighted data
         """
-        data = kwargs[
-            self.key
-        ]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
+        data = kwargs[self.key]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
 
         if flat_receive_apodization is None:
             return {self.output_key: data}
@@ -376,8 +372,7 @@ class ScanConvert(Operation):
         if order > 1:
             jittable = False
             log.warning(
-                "GPU support for order > 1 is not available. "
-                + "Disabling jit for ScanConvert."
+                "GPU support for order > 1 is not available. " + "Disabling jit for ScanConvert."
             )
         else:
             jittable = True
@@ -588,9 +583,7 @@ class LowPassFilterIQ(FirFilter):
                 Odd will result in a type I filter, even in a type II filter.
         """
         if "jittable" in kwargs:
-            raise ValueError(
-                "LowPassFilterIQ is not jittable, so jittable must be set to False."
-            )
+            raise ValueError("LowPassFilterIQ is not jittable, so jittable must be set to False.")
         if "complex_channels" in kwargs and not kwargs["complex_channels"]:
             raise ValueError(
                 "LowPassFilterIQ operates on IQ data, so complex_channels must be True."
@@ -728,8 +721,7 @@ class BandPassFilter(FirFilter):
             raise ValueError(passband_error_message)
 
         if not all(
-            isinstance(f, (int, float, np.number)) and not isinstance(f, bool)
-            for f in (f1, f2)
+            isinstance(f, (int, float, np.number)) and not isinstance(f, bool) for f in (f1, f2)
         ):
             raise ValueError(passband_error_message)
 
@@ -882,13 +874,9 @@ class Companding(Operation):
             raise ValueError("comp_type must be 'mu' or 'a'.")
 
         if self.comp_type == "mu":
-            self._compand_func = (
-                self._mu_law_expand if self.expand else self._mu_law_compress
-            )
+            self._compand_func = self._mu_law_expand if self.expand else self._mu_law_compress
         else:
-            self._compand_func = (
-                self._a_law_expand if self.expand else self._a_law_compress
-            )
+            self._compand_func = self._a_law_expand if self.expand else self._a_law_compress
 
     @staticmethod
     def _mu_law_compress(x, mu=255, **kwargs):
@@ -999,9 +987,7 @@ class AnisotropicDiffusion(Operation):
         results = []
         for i in range(batch_size):
             image = data[i]
-            image_out = self._anisotropic_diffusion_single(
-                image, niter, lmbda, rect, eps
-            )
+            image_out = self._anisotropic_diffusion_single(image, niter, lmbda, rect, eps)
             results.append(image_out)
 
         result = ops.stack(results, axis=0)
@@ -1017,25 +1003,15 @@ class AnisotropicDiffusion(Operation):
         M, N = image.shape
 
         for _ in range(niter):
-            iN = ops.concatenate(
-                [image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0
-            )
-            iS = ops.concatenate(
-                [ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0
-            )
-            jW = ops.concatenate(
-                [image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1
-            )
-            jE = ops.concatenate(
-                [ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1
-            )
+            iN = ops.concatenate([image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0)
+            iS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0)
+            jW = ops.concatenate([image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1)
+            jE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1)
 
             if rect is not None:
                 x1, y1, x2, y2 = rect
                 imageuniform = image[x1:x2, y1:y2]
-                q0_squared = (
-                    ops.std(imageuniform) / (ops.mean(imageuniform) + eps)
-                ) ** 2
+                q0_squared = (ops.std(imageuniform) / (ops.mean(imageuniform) + eps)) ** 2
 
             dN = iN - image
             dS = iS - image
@@ -1052,9 +1028,7 @@ class AnisotropicDiffusion(Operation):
                 den = (q_squared - q0_squared) / (q0_squared * (1 + q0_squared) + eps)
             c = 1.0 / (1 + den)
             cS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), c[:-1]], axis=0)
-            cE = ops.concatenate(
-                [ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1
-            )
+            cE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1)
 
             D = (cS * dS) + (c * dN) + (cE * dE) + (c * dW)
             image = image + (lmbda / 4) * D
@@ -1117,9 +1091,7 @@ class UpMix(Operation):
         elif data.shape[-1] == 2:
             data = ops.view_as_complex(data)
 
-        data = upmix(
-            data, sampling_frequency, demodulation_frequency, self.upsampling_rate
-        )
+        data = upmix(data, sampling_frequency, demodulation_frequency, self.upsampling_rate)
         data = ops.expand_dims(data, axis=-1)
         return {self.output_key: data}
 
@@ -1158,9 +1130,7 @@ class LogCompress(Operation):
 
         compressed_data = log_compress(data)
         if self.clip:
-            compressed_data = ops.clip(
-                compressed_data, dynamic_range[0], dynamic_range[1]
-            )
+            compressed_data = ops.clip(compressed_data, dynamic_range[0], dynamic_range[1])
 
         return {self.output_key: compressed_data}
 
@@ -1181,9 +1151,7 @@ class ReshapeGrid(Operation):
             - reshaped_data (Tensor): The reshaped data of shape (..., grid.shape, ...).
         """
         data = kwargs[self.key]
-        reshaped_data = reshape_axis(
-            data, grid.shape[:-1], self.axis + int(self.with_batch_dim)
-        )
+        reshaped_data = reshape_axis(data, grid.shape[:-1], self.axis + int(self.with_batch_dim))
         return {self.output_key: reshaped_data}
 
 
@@ -1198,9 +1166,7 @@ class ApplyWindow(Operation):
     [start (zero)] - [size (window)] - [middle (unmodified)] - [size (window)] - [end (zero)]
     """
 
-    def __init__(
-        self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs
-    ):
+    def __init__(self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs):
         """
         Args:
             axis (int): Axis along which to apply the window.
@@ -1312,9 +1278,7 @@ class CommonMidpointPhaseError(Operation):
         n_tx, n_pix, n_rx, n_ch = data.shape
         receive_subaps = ops.zeros((n_rx, n_tx))
         for diag in range(-halfsa, halfsa + 1):
-            receive_subaps = receive_subaps + ops.diag(
-                ops.ones((n_rx - abs(diag),)), diag
-            )
+            receive_subaps = receive_subaps + ops.diag(ops.ones((n_rx - abs(diag),)), diag)
         receive_subaps = receive_subaps[halfsa : receive_subaps.shape[0] - halfsa : dx]
         transmit_subaps = ops.flip(receive_subaps, axis=0)
         return transmit_subaps, receive_subaps
@@ -1330,9 +1294,7 @@ class CommonMidpointPhaseError(Operation):
         """
 
         transmit_subaps, receive_subaps = self.create_subapertures(data, 8, 1)
-        complex_data = ops.view_as_complex(
-            data
-        )  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
+        complex_data = ops.view_as_complex(data)  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
         complex_data = ops.transpose(complex_data, (2, 0, 1))  # [n_rx, n_tx, n_pix]
         rx_zero_count = ops.matmul(receive_subaps, ops.cast(complex_data == 0, "int32"))
 
@@ -1340,12 +1302,8 @@ class CommonMidpointPhaseError(Operation):
         rx_valid = rx_zero_count <= 1
         complex_data_rx = ops.matmul(receive_subaps, complex_data)
         complex_data_rx = ops.where(rx_valid, complex_data_rx, 0)
-        complex_data_rx = ops.transpose(
-            complex_data_rx, (1, 0, 2)
-        )  # [n_tx, n_subap_rx, n_pix]
-        tx_zero_count = ops.matmul(
-            transmit_subaps, ops.cast(complex_data_rx == 0, "int32")
-        )
+        complex_data_rx = ops.transpose(complex_data_rx, (1, 0, 2))  # [n_tx, n_subap_rx, n_pix]
+        tx_zero_count = ops.matmul(transmit_subaps, ops.cast(complex_data_rx == 0, "int32"))
 
         # Mask out subapertures with point outside fov in transmit
         tx_valid = tx_zero_count <= 1
@@ -1447,10 +1405,7 @@ class TissueSuppression(Operation):
         TensorFlow raises, but that combination does not suppress the tissue
         anyway -- use ``svd_complex`` for complex input).
         """
-        if (
-            self.filter_type == "svd_complex"
-            and keras.backend.backend() == "tensorflow"
-        ):
+        if self.filter_type == "svd_complex" and keras.backend.backend() == "tensorflow":
             return False
         return super().jittable
 

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -245,9 +245,7 @@ class PfieldWeighting(Operation):
         if flat_pfield is None:
             return {self.output_key: data}
 
-        weighted_data = apply_aligned_apodization(
-            data, flat_pfield, self.with_batch_dim
-        )
+        weighted_data = apply_aligned_apodization(data, flat_pfield, self.with_batch_dim)
 
         return {self.output_key: weighted_data}
 
@@ -334,9 +332,7 @@ class ReceiveApodization(Operation):
         Returns:
             dict: Dictionary containing weighted data
         """
-        data = kwargs[
-            self.key
-        ]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
+        data = kwargs[self.key]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
 
         if flat_receive_apodization is None:
             return {self.output_key: data}
@@ -376,8 +372,7 @@ class ScanConvert(Operation):
         if order > 1:
             jittable = False
             log.warning(
-                "GPU support for order > 1 is not available. "
-                + "Disabling jit for ScanConvert."
+                "GPU support for order > 1 is not available. " + "Disabling jit for ScanConvert."
             )
         else:
             jittable = True
@@ -588,9 +583,7 @@ class LowPassFilterIQ(FirFilter):
                 Odd will result in a type I filter, even in a type II filter.
         """
         if "jittable" in kwargs:
-            raise ValueError(
-                "LowPassFilterIQ is not jittable, so jittable must be set to False."
-            )
+            raise ValueError("LowPassFilterIQ is not jittable, so jittable must be set to False.")
         if "complex_channels" in kwargs and not kwargs["complex_channels"]:
             raise ValueError(
                 "LowPassFilterIQ operates on IQ data, so complex_channels must be True."
@@ -728,8 +721,7 @@ class BandPassFilter(FirFilter):
             raise ValueError(passband_error_message)
 
         if not all(
-            isinstance(f, (int, float, np.number)) and not isinstance(f, bool)
-            for f in (f1, f2)
+            isinstance(f, (int, float, np.number)) and not isinstance(f, bool) for f in (f1, f2)
         ):
             raise ValueError(passband_error_message)
 
@@ -882,13 +874,9 @@ class Companding(Operation):
             raise ValueError("comp_type must be 'mu' or 'a'.")
 
         if self.comp_type == "mu":
-            self._compand_func = (
-                self._mu_law_expand if self.expand else self._mu_law_compress
-            )
+            self._compand_func = self._mu_law_expand if self.expand else self._mu_law_compress
         else:
-            self._compand_func = (
-                self._a_law_expand if self.expand else self._a_law_compress
-            )
+            self._compand_func = self._a_law_expand if self.expand else self._a_law_compress
 
     @staticmethod
     def _mu_law_compress(x, mu=255, **kwargs):
@@ -999,9 +987,7 @@ class AnisotropicDiffusion(Operation):
         results = []
         for i in range(batch_size):
             image = data[i]
-            image_out = self._anisotropic_diffusion_single(
-                image, niter, lmbda, rect, eps
-            )
+            image_out = self._anisotropic_diffusion_single(image, niter, lmbda, rect, eps)
             results.append(image_out)
 
         result = ops.stack(results, axis=0)
@@ -1017,25 +1003,15 @@ class AnisotropicDiffusion(Operation):
         M, N = image.shape
 
         for _ in range(niter):
-            iN = ops.concatenate(
-                [image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0
-            )
-            iS = ops.concatenate(
-                [ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0
-            )
-            jW = ops.concatenate(
-                [image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1
-            )
-            jE = ops.concatenate(
-                [ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1
-            )
+            iN = ops.concatenate([image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0)
+            iS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0)
+            jW = ops.concatenate([image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1)
+            jE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1)
 
             if rect is not None:
                 x1, y1, x2, y2 = rect
                 imageuniform = image[x1:x2, y1:y2]
-                q0_squared = (
-                    ops.std(imageuniform) / (ops.mean(imageuniform) + eps)
-                ) ** 2
+                q0_squared = (ops.std(imageuniform) / (ops.mean(imageuniform) + eps)) ** 2
 
             dN = iN - image
             dS = iS - image
@@ -1052,9 +1028,7 @@ class AnisotropicDiffusion(Operation):
                 den = (q_squared - q0_squared) / (q0_squared * (1 + q0_squared) + eps)
             c = 1.0 / (1 + den)
             cS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), c[:-1]], axis=0)
-            cE = ops.concatenate(
-                [ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1
-            )
+            cE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1)
 
             D = (cS * dS) + (c * dN) + (cE * dE) + (c * dW)
             image = image + (lmbda / 4) * D
@@ -1117,9 +1091,7 @@ class UpMix(Operation):
         elif data.shape[-1] == 2:
             data = ops.view_as_complex(data)
 
-        data = upmix(
-            data, sampling_frequency, demodulation_frequency, self.upsampling_rate
-        )
+        data = upmix(data, sampling_frequency, demodulation_frequency, self.upsampling_rate)
         data = ops.expand_dims(data, axis=-1)
         return {self.output_key: data}
 
@@ -1158,9 +1130,7 @@ class LogCompress(Operation):
 
         compressed_data = log_compress(data)
         if self.clip:
-            compressed_data = ops.clip(
-                compressed_data, dynamic_range[0], dynamic_range[1]
-            )
+            compressed_data = ops.clip(compressed_data, dynamic_range[0], dynamic_range[1])
 
         return {self.output_key: compressed_data}
 
@@ -1181,9 +1151,7 @@ class ReshapeGrid(Operation):
             - reshaped_data (Tensor): The reshaped data of shape (..., grid.shape, ...).
         """
         data = kwargs[self.key]
-        reshaped_data = reshape_axis(
-            data, grid.shape[:-1], self.axis + int(self.with_batch_dim)
-        )
+        reshaped_data = reshape_axis(data, grid.shape[:-1], self.axis + int(self.with_batch_dim))
         return {self.output_key: reshaped_data}
 
 
@@ -1198,9 +1166,7 @@ class ApplyWindow(Operation):
     [start (zero)] - [size (window)] - [middle (unmodified)] - [size (window)] - [end (zero)]
     """
 
-    def __init__(
-        self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs
-    ):
+    def __init__(self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs):
         """
         Args:
             axis (int): Axis along which to apply the window.
@@ -1312,9 +1278,7 @@ class CommonMidpointPhaseError(Operation):
         n_tx, n_pix, n_rx, n_ch = data.shape
         receive_subaps = ops.zeros((n_rx, n_tx))
         for diag in range(-halfsa, halfsa + 1):
-            receive_subaps = receive_subaps + ops.diag(
-                ops.ones((n_rx - abs(diag),)), diag
-            )
+            receive_subaps = receive_subaps + ops.diag(ops.ones((n_rx - abs(diag),)), diag)
         receive_subaps = receive_subaps[halfsa : receive_subaps.shape[0] - halfsa : dx]
         transmit_subaps = ops.flip(receive_subaps, axis=0)
         return transmit_subaps, receive_subaps
@@ -1330,9 +1294,7 @@ class CommonMidpointPhaseError(Operation):
         """
 
         transmit_subaps, receive_subaps = self.create_subapertures(data, 8, 1)
-        complex_data = ops.view_as_complex(
-            data
-        )  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
+        complex_data = ops.view_as_complex(data)  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
         complex_data = ops.transpose(complex_data, (2, 0, 1))  # [n_rx, n_tx, n_pix]
         rx_zero_count = ops.matmul(receive_subaps, ops.cast(complex_data == 0, "int32"))
 
@@ -1340,12 +1302,8 @@ class CommonMidpointPhaseError(Operation):
         rx_valid = rx_zero_count <= 1
         complex_data_rx = ops.matmul(receive_subaps, complex_data)
         complex_data_rx = ops.where(rx_valid, complex_data_rx, 0)
-        complex_data_rx = ops.transpose(
-            complex_data_rx, (1, 0, 2)
-        )  # [n_tx, n_subap_rx, n_pix]
-        tx_zero_count = ops.matmul(
-            transmit_subaps, ops.cast(complex_data_rx == 0, "int32")
-        )
+        complex_data_rx = ops.transpose(complex_data_rx, (1, 0, 2))  # [n_tx, n_subap_rx, n_pix]
+        tx_zero_count = ops.matmul(transmit_subaps, ops.cast(complex_data_rx == 0, "int32"))
 
         # Mask out subapertures with point outside fov in transmit
         tx_valid = tx_zero_count <= 1
@@ -1411,9 +1369,7 @@ class TissueSuppression(Operation):
 
     FILTER_TYPES = ("svd", "svd_complex")
 
-    def __init__(
-        self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs
-    ):
+    def __init__(self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs):
         """
         Args:
             cutoff (int or float): Number of principal (tissue) components to

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1349,27 +1349,47 @@ class TissueSuppression(Operation):
     Removes stationary tissue components from multi-frame ultrasound data
     by zeroing the dominant singular values of the Casorati matrix.
 
-    Two filter types are available, selected with ``filter_type``:
+    Input
+    -----
+    Data of shape ``(n_frames, ..., n_ch)``, following zea's channel convention:
+    ``n_ch=1`` (or no channel axis) for RF / real-valued data, ``n_ch=2`` for IQ
+    data carried as two real ``[I, Q]`` channels (e.g. the output of
+    :class:`Beamform` on baseband data). Output has the same shape and dtype as
+    the input.
 
-    * ``"svd"`` (default) -- the real-valued Direct SVD filter. Builds the Gram
-      matrix with a plain transpose. Input is real data of shape
-      ``(n_frames, ...)``.
-    * ``"svd_complex"`` -- the same filter with a conjugate (Hermitian)
-      transpose, for complex baseband IQ input. This is the filter used for
-      Power-Doppler / ULM processing (as in MUST's ``process.m``). Input is IQ
-      data as two real channels, shape ``(n_frames, ..., 2)``.
-      On real ``[I, Q]`` channel data ``"svd"`` builds ``XᵀX`` instead of
-      the temporal covariance ``XᴴX`` and will not suppress the tissue.
+    Two filter types are available:
+
+    * ``"svd"`` -- the real-valued Direct SVD filter, building the temporal Gram
+      matrix with a plain transpose (``XᵀX``). For real data.
+    * ``"svd_complex"`` -- the same filter using the conjugate (Hermitian)
+      transpose (``XᴴX``, the true temporal covariance), for IQ data. The op
+      converts the ``[I, Q]`` channels to a complex tensor internally with
+      ``keras.ops.view_as_complex`` and back with ``view_as_real`` before
+      returning, so the op's inputs and outputs stay real-valued and compose in
+      a :class:`Pipeline` like any other operation. This is the filter used for
+      Power-Doppler / ULM processing (as in MUST's ``process.m``).
+
+    By default ``filter_type=None`` picks between them from the channel axis --
+    ``n_ch=2`` means IQ and selects ``"svd_complex"``, anything else selects
+    ``"svd"`` -- the same ``shape[-1] == 2`` test
+    :func:`zea.func.ultrasound.envelope_detect` and :class:`Upmix` use. Pass
+    ``filter_type`` explicitly to override this.
+
+    Using ``"svd"`` on IQ data is not meaningful: ``XᵀX`` is complex *symmetric*
+    rather than Hermitian, so it is not a covariance and its dominant
+    eigenvectors are not guaranteed to span the tissue subspace. It may still
+    appear to suppress clutter on data whose tissue does not rotate in phase,
+    but that is incidental -- prefer ``"svd_complex"`` for IQ.
 
     .. note::
-        On the TensorFlow backend ``"svd_complex"`` runs eagerly: TensorFlow
-        registers no XLA ``Svd`` kernel for complex dtypes. The other backends
-        JIT it.
+        On the TensorFlow backend the ``"svd_complex"`` path runs eagerly:
+        TensorFlow registers no XLA ``Svd`` kernel for complex dtypes. The other
+        backends JIT it.
     """
 
     FILTER_TYPES = ("svd", "svd_complex")
 
-    def __init__(self, cutoff: int | float = 5, filter_type: str = "svd", **kwargs):
+    def __init__(self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs):
         """
         Args:
             cutoff (int or float): Number of principal (tissue) components to
@@ -1377,13 +1397,15 @@ class TissueSuppression(Operation):
                 is a fraction of the number of frames, resolved at call time as
                 ``round(n_frames * cutoff)`` (matching the ULM convention of
                 specifying the clutter cutoff as a percentage of frames).
-            filter_type (str): Which clutter filter to use, one of
-                :attr:`FILTER_TYPES`. Use ``"svd_complex"`` for complex IQ input.
+            filter_type (str or None): Which clutter filter to use, one of
+                :attr:`FILTER_TYPES`. Defaults to ``None``, which selects
+                ``"svd_complex"`` for IQ input (``n_ch=2``) and ``"svd"``
+                otherwise.
         """
-        if filter_type not in self.FILTER_TYPES:
+        if filter_type is not None and filter_type not in self.FILTER_TYPES:
             raise ValueError(
                 f"Unknown filter_type {filter_type!r}, expected one of "
-                f"{', '.join(map(repr, self.FILTER_TYPES))}."
+                f"{', '.join(map(repr, self.FILTER_TYPES))} or None (auto-detect)."
             )
         if isinstance(cutoff, float) and not 0 <= cutoff < 1:
             raise ValueError(
@@ -1398,16 +1420,30 @@ class TissueSuppression(Operation):
     def jittable(self):
         """Whether this operation can be JIT compiled.
 
-        TensorFlow registers no XLA ``Svd`` kernel for complex dtypes, so on that
-        backend the filter has to run eagerly. ``svd_complex`` only ever makes
-        sense on complex input, so it is never jitted there. Plain ``svd`` is
-        meant for real data and stays jittable (feeding it complex data on
-        TensorFlow raises, but that combination does not suppress the tissue
-        anyway -- use ``svd_complex`` for complex input).
+        TensorFlow registers no XLA ``Svd`` kernel for complex dtypes, so the
+        ``"svd_complex"`` path has to run eagerly there. With ``filter_type=None``
+        the path is only known once the data's channel axis is seen, so on
+        TensorFlow we conservatively assume complex is possible and stay eager;
+        pass ``filter_type="svd"`` explicitly to keep the real filter jitted.
         """
-        if self.filter_type == "svd_complex" and keras.backend.backend() == "tensorflow":
+        if self.filter_type != "svd" and keras.backend.backend() == "tensorflow":
             return False
         return super().jittable
+
+    def resolve_filter_type(self, data) -> str:
+        """Resolve which filter to use for ``data``.
+
+        Args:
+            data (ops.Tensor): Input of shape ``(n_frames, ..., n_ch)``.
+
+        Returns:
+            str: The configured ``filter_type``, or -- when it is ``None`` --
+            ``"svd_complex"`` if the channel axis marks the data as IQ
+            (``n_ch=2``, zea's convention) and ``"svd"`` otherwise.
+        """
+        if self.filter_type is not None:
+            return self.filter_type
+        return "svd_complex" if len(data.shape) > 1 and data.shape[-1] == 2 else "svd"
 
     def resolve_cutoff(self, n_frames: int) -> int:
         """Resolve a fractional ``cutoff`` into a component count.
@@ -1422,31 +1458,38 @@ class TissueSuppression(Operation):
             return int(round(n_frames * self.cutoff))
         return self.cutoff
 
-    def suppress_tissue(self, data):
+    def suppress_tissue(self, data, filter_type=None):
         """
         Suppresses tissue using Direct SVD.
 
         Args:
             data (ops.Tensor): Shape (n_frames, ...). Complex for the
                 ``"svd_complex"`` filter type, real otherwise.
+            filter_type (str or None): Filter to apply. Defaults to ``None``,
+                which resolves it from ``data`` via :meth:`resolve_filter_type`
+                (note that by then the IQ channels have already been merged into
+                a complex axis, so callers inside :meth:`call` pass it in).
 
         """
+        if filter_type is None:
+            filter_type = self.resolve_filter_type(data)
         return suppress_tissue(
             data,
             self.resolve_cutoff(data.shape[0]),
-            conjugate=self.filter_type == "svd_complex",
+            conjugate=filter_type == "svd_complex",
         )
 
     def call(self, **kwargs):
         data = kwargs[self.key]
-        is_complex = self.filter_type == "svd_complex"
+        filter_type = self.resolve_filter_type(data)
+        is_complex = filter_type == "svd_complex"
 
         # Real IQ-channel input ((n_frames, ..., 2)) <-> complex ((n_frames, ...))
         # conversion happens inside the op, same as DelayMultiplyAndSum, so the
         # op's dict-boundary contract stays real-valued and composes in a
         # Pipeline like any other op.
         array = ops.view_as_complex(ops.array(data)) if is_complex else ops.array(data)
-        filtered = self.suppress_tissue(array)
+        filtered = self.suppress_tissue(array, filter_type=filter_type)
         if is_complex:
             filtered = ops.view_as_real(filtered)
 

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -245,7 +245,9 @@ class PfieldWeighting(Operation):
         if flat_pfield is None:
             return {self.output_key: data}
 
-        weighted_data = apply_aligned_apodization(data, flat_pfield, self.with_batch_dim)
+        weighted_data = apply_aligned_apodization(
+            data, flat_pfield, self.with_batch_dim
+        )
 
         return {self.output_key: weighted_data}
 
@@ -332,7 +334,9 @@ class ReceiveApodization(Operation):
         Returns:
             dict: Dictionary containing weighted data
         """
-        data = kwargs[self.key]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
+        data = kwargs[
+            self.key
+        ]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
 
         if flat_receive_apodization is None:
             return {self.output_key: data}
@@ -372,7 +376,8 @@ class ScanConvert(Operation):
         if order > 1:
             jittable = False
             log.warning(
-                "GPU support for order > 1 is not available. " + "Disabling jit for ScanConvert."
+                "GPU support for order > 1 is not available. "
+                + "Disabling jit for ScanConvert."
             )
         else:
             jittable = True
@@ -583,7 +588,9 @@ class LowPassFilterIQ(FirFilter):
                 Odd will result in a type I filter, even in a type II filter.
         """
         if "jittable" in kwargs:
-            raise ValueError("LowPassFilterIQ is not jittable, so jittable must be set to False.")
+            raise ValueError(
+                "LowPassFilterIQ is not jittable, so jittable must be set to False."
+            )
         if "complex_channels" in kwargs and not kwargs["complex_channels"]:
             raise ValueError(
                 "LowPassFilterIQ operates on IQ data, so complex_channels must be True."
@@ -721,7 +728,8 @@ class BandPassFilter(FirFilter):
             raise ValueError(passband_error_message)
 
         if not all(
-            isinstance(f, (int, float, np.number)) and not isinstance(f, bool) for f in (f1, f2)
+            isinstance(f, (int, float, np.number)) and not isinstance(f, bool)
+            for f in (f1, f2)
         ):
             raise ValueError(passband_error_message)
 
@@ -874,9 +882,13 @@ class Companding(Operation):
             raise ValueError("comp_type must be 'mu' or 'a'.")
 
         if self.comp_type == "mu":
-            self._compand_func = self._mu_law_expand if self.expand else self._mu_law_compress
+            self._compand_func = (
+                self._mu_law_expand if self.expand else self._mu_law_compress
+            )
         else:
-            self._compand_func = self._a_law_expand if self.expand else self._a_law_compress
+            self._compand_func = (
+                self._a_law_expand if self.expand else self._a_law_compress
+            )
 
     @staticmethod
     def _mu_law_compress(x, mu=255, **kwargs):
@@ -987,7 +999,9 @@ class AnisotropicDiffusion(Operation):
         results = []
         for i in range(batch_size):
             image = data[i]
-            image_out = self._anisotropic_diffusion_single(image, niter, lmbda, rect, eps)
+            image_out = self._anisotropic_diffusion_single(
+                image, niter, lmbda, rect, eps
+            )
             results.append(image_out)
 
         result = ops.stack(results, axis=0)
@@ -1003,15 +1017,25 @@ class AnisotropicDiffusion(Operation):
         M, N = image.shape
 
         for _ in range(niter):
-            iN = ops.concatenate([image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0)
-            iS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0)
-            jW = ops.concatenate([image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1)
-            jE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1)
+            iN = ops.concatenate(
+                [image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0
+            )
+            iS = ops.concatenate(
+                [ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0
+            )
+            jW = ops.concatenate(
+                [image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1
+            )
+            jE = ops.concatenate(
+                [ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1
+            )
 
             if rect is not None:
                 x1, y1, x2, y2 = rect
                 imageuniform = image[x1:x2, y1:y2]
-                q0_squared = (ops.std(imageuniform) / (ops.mean(imageuniform) + eps)) ** 2
+                q0_squared = (
+                    ops.std(imageuniform) / (ops.mean(imageuniform) + eps)
+                ) ** 2
 
             dN = iN - image
             dS = iS - image
@@ -1028,7 +1052,9 @@ class AnisotropicDiffusion(Operation):
                 den = (q_squared - q0_squared) / (q0_squared * (1 + q0_squared) + eps)
             c = 1.0 / (1 + den)
             cS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), c[:-1]], axis=0)
-            cE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1)
+            cE = ops.concatenate(
+                [ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1
+            )
 
             D = (cS * dS) + (c * dN) + (cE * dE) + (c * dW)
             image = image + (lmbda / 4) * D
@@ -1091,7 +1117,9 @@ class UpMix(Operation):
         elif data.shape[-1] == 2:
             data = ops.view_as_complex(data)
 
-        data = upmix(data, sampling_frequency, demodulation_frequency, self.upsampling_rate)
+        data = upmix(
+            data, sampling_frequency, demodulation_frequency, self.upsampling_rate
+        )
         data = ops.expand_dims(data, axis=-1)
         return {self.output_key: data}
 
@@ -1130,7 +1158,9 @@ class LogCompress(Operation):
 
         compressed_data = log_compress(data)
         if self.clip:
-            compressed_data = ops.clip(compressed_data, dynamic_range[0], dynamic_range[1])
+            compressed_data = ops.clip(
+                compressed_data, dynamic_range[0], dynamic_range[1]
+            )
 
         return {self.output_key: compressed_data}
 
@@ -1151,7 +1181,9 @@ class ReshapeGrid(Operation):
             - reshaped_data (Tensor): The reshaped data of shape (..., grid.shape, ...).
         """
         data = kwargs[self.key]
-        reshaped_data = reshape_axis(data, grid.shape[:-1], self.axis + int(self.with_batch_dim))
+        reshaped_data = reshape_axis(
+            data, grid.shape[:-1], self.axis + int(self.with_batch_dim)
+        )
         return {self.output_key: reshaped_data}
 
 
@@ -1166,7 +1198,9 @@ class ApplyWindow(Operation):
     [start (zero)] - [size (window)] - [middle (unmodified)] - [size (window)] - [end (zero)]
     """
 
-    def __init__(self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs):
+    def __init__(
+        self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs
+    ):
         """
         Args:
             axis (int): Axis along which to apply the window.
@@ -1278,7 +1312,9 @@ class CommonMidpointPhaseError(Operation):
         n_tx, n_pix, n_rx, n_ch = data.shape
         receive_subaps = ops.zeros((n_rx, n_tx))
         for diag in range(-halfsa, halfsa + 1):
-            receive_subaps = receive_subaps + ops.diag(ops.ones((n_rx - abs(diag),)), diag)
+            receive_subaps = receive_subaps + ops.diag(
+                ops.ones((n_rx - abs(diag),)), diag
+            )
         receive_subaps = receive_subaps[halfsa : receive_subaps.shape[0] - halfsa : dx]
         transmit_subaps = ops.flip(receive_subaps, axis=0)
         return transmit_subaps, receive_subaps
@@ -1294,7 +1330,9 @@ class CommonMidpointPhaseError(Operation):
         """
 
         transmit_subaps, receive_subaps = self.create_subapertures(data, 8, 1)
-        complex_data = ops.view_as_complex(data)  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
+        complex_data = ops.view_as_complex(
+            data
+        )  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
         complex_data = ops.transpose(complex_data, (2, 0, 1))  # [n_rx, n_tx, n_pix]
         rx_zero_count = ops.matmul(receive_subaps, ops.cast(complex_data == 0, "int32"))
 
@@ -1302,8 +1340,12 @@ class CommonMidpointPhaseError(Operation):
         rx_valid = rx_zero_count <= 1
         complex_data_rx = ops.matmul(receive_subaps, complex_data)
         complex_data_rx = ops.where(rx_valid, complex_data_rx, 0)
-        complex_data_rx = ops.transpose(complex_data_rx, (1, 0, 2))  # [n_tx, n_subap_rx, n_pix]
-        tx_zero_count = ops.matmul(transmit_subaps, ops.cast(complex_data_rx == 0, "int32"))
+        complex_data_rx = ops.transpose(
+            complex_data_rx, (1, 0, 2)
+        )  # [n_tx, n_subap_rx, n_pix]
+        tx_zero_count = ops.matmul(
+            transmit_subaps, ops.cast(complex_data_rx == 0, "int32")
+        )
 
         # Mask out subapertures with point outside fov in transmit
         tx_valid = tx_zero_count <= 1
@@ -1375,12 +1417,6 @@ class TissueSuppression(Operation):
     :func:`zea.func.ultrasound.envelope_detect` and :class:`Upmix` use. Pass
     ``filter_type`` explicitly to override this.
 
-    Using ``"svd"`` on IQ data is not meaningful: ``XᵀX`` is complex *symmetric*
-    rather than Hermitian, so it is not a covariance and its dominant
-    eigenvectors are not guaranteed to span the tissue subspace. It may still
-    appear to suppress clutter on data whose tissue does not rotate in phase,
-    but that is incidental -- prefer ``"svd_complex"`` for IQ.
-
     .. note::
         On the TensorFlow backend the ``"svd_complex"`` path runs eagerly:
         TensorFlow registers no XLA ``Svd`` kernel for complex dtypes. The other
@@ -1389,7 +1425,9 @@ class TissueSuppression(Operation):
 
     FILTER_TYPES = ("svd", "svd_complex")
 
-    def __init__(self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs):
+    def __init__(
+        self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs
+    ):
         """
         Args:
             cutoff (int or float): Number of principal (tissue) components to

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -245,7 +245,9 @@ class PfieldWeighting(Operation):
         if flat_pfield is None:
             return {self.output_key: data}
 
-        weighted_data = apply_aligned_apodization(data, flat_pfield, self.with_batch_dim)
+        weighted_data = apply_aligned_apodization(
+            data, flat_pfield, self.with_batch_dim
+        )
 
         return {self.output_key: weighted_data}
 
@@ -332,7 +334,9 @@ class ReceiveApodization(Operation):
         Returns:
             dict: Dictionary containing weighted data
         """
-        data = kwargs[self.key]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
+        data = kwargs[
+            self.key
+        ]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
 
         if flat_receive_apodization is None:
             return {self.output_key: data}
@@ -372,7 +376,8 @@ class ScanConvert(Operation):
         if order > 1:
             jittable = False
             log.warning(
-                "GPU support for order > 1 is not available. " + "Disabling jit for ScanConvert."
+                "GPU support for order > 1 is not available. "
+                + "Disabling jit for ScanConvert."
             )
         else:
             jittable = True
@@ -583,7 +588,9 @@ class LowPassFilterIQ(FirFilter):
                 Odd will result in a type I filter, even in a type II filter.
         """
         if "jittable" in kwargs:
-            raise ValueError("LowPassFilterIQ is not jittable, so jittable must be set to False.")
+            raise ValueError(
+                "LowPassFilterIQ is not jittable, so jittable must be set to False."
+            )
         if "complex_channels" in kwargs and not kwargs["complex_channels"]:
             raise ValueError(
                 "LowPassFilterIQ operates on IQ data, so complex_channels must be True."
@@ -721,7 +728,8 @@ class BandPassFilter(FirFilter):
             raise ValueError(passband_error_message)
 
         if not all(
-            isinstance(f, (int, float, np.number)) and not isinstance(f, bool) for f in (f1, f2)
+            isinstance(f, (int, float, np.number)) and not isinstance(f, bool)
+            for f in (f1, f2)
         ):
             raise ValueError(passband_error_message)
 
@@ -874,9 +882,13 @@ class Companding(Operation):
             raise ValueError("comp_type must be 'mu' or 'a'.")
 
         if self.comp_type == "mu":
-            self._compand_func = self._mu_law_expand if self.expand else self._mu_law_compress
+            self._compand_func = (
+                self._mu_law_expand if self.expand else self._mu_law_compress
+            )
         else:
-            self._compand_func = self._a_law_expand if self.expand else self._a_law_compress
+            self._compand_func = (
+                self._a_law_expand if self.expand else self._a_law_compress
+            )
 
     @staticmethod
     def _mu_law_compress(x, mu=255, **kwargs):
@@ -987,7 +999,9 @@ class AnisotropicDiffusion(Operation):
         results = []
         for i in range(batch_size):
             image = data[i]
-            image_out = self._anisotropic_diffusion_single(image, niter, lmbda, rect, eps)
+            image_out = self._anisotropic_diffusion_single(
+                image, niter, lmbda, rect, eps
+            )
             results.append(image_out)
 
         result = ops.stack(results, axis=0)
@@ -1003,15 +1017,25 @@ class AnisotropicDiffusion(Operation):
         M, N = image.shape
 
         for _ in range(niter):
-            iN = ops.concatenate([image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0)
-            iS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0)
-            jW = ops.concatenate([image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1)
-            jE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1)
+            iN = ops.concatenate(
+                [image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0
+            )
+            iS = ops.concatenate(
+                [ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0
+            )
+            jW = ops.concatenate(
+                [image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1
+            )
+            jE = ops.concatenate(
+                [ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1
+            )
 
             if rect is not None:
                 x1, y1, x2, y2 = rect
                 imageuniform = image[x1:x2, y1:y2]
-                q0_squared = (ops.std(imageuniform) / (ops.mean(imageuniform) + eps)) ** 2
+                q0_squared = (
+                    ops.std(imageuniform) / (ops.mean(imageuniform) + eps)
+                ) ** 2
 
             dN = iN - image
             dS = iS - image
@@ -1028,7 +1052,9 @@ class AnisotropicDiffusion(Operation):
                 den = (q_squared - q0_squared) / (q0_squared * (1 + q0_squared) + eps)
             c = 1.0 / (1 + den)
             cS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), c[:-1]], axis=0)
-            cE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1)
+            cE = ops.concatenate(
+                [ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1
+            )
 
             D = (cS * dS) + (c * dN) + (cE * dE) + (c * dW)
             image = image + (lmbda / 4) * D
@@ -1091,7 +1117,9 @@ class UpMix(Operation):
         elif data.shape[-1] == 2:
             data = ops.view_as_complex(data)
 
-        data = upmix(data, sampling_frequency, demodulation_frequency, self.upsampling_rate)
+        data = upmix(
+            data, sampling_frequency, demodulation_frequency, self.upsampling_rate
+        )
         data = ops.expand_dims(data, axis=-1)
         return {self.output_key: data}
 
@@ -1130,7 +1158,9 @@ class LogCompress(Operation):
 
         compressed_data = log_compress(data)
         if self.clip:
-            compressed_data = ops.clip(compressed_data, dynamic_range[0], dynamic_range[1])
+            compressed_data = ops.clip(
+                compressed_data, dynamic_range[0], dynamic_range[1]
+            )
 
         return {self.output_key: compressed_data}
 
@@ -1151,7 +1181,9 @@ class ReshapeGrid(Operation):
             - reshaped_data (Tensor): The reshaped data of shape (..., grid.shape, ...).
         """
         data = kwargs[self.key]
-        reshaped_data = reshape_axis(data, grid.shape[:-1], self.axis + int(self.with_batch_dim))
+        reshaped_data = reshape_axis(
+            data, grid.shape[:-1], self.axis + int(self.with_batch_dim)
+        )
         return {self.output_key: reshaped_data}
 
 
@@ -1166,7 +1198,9 @@ class ApplyWindow(Operation):
     [start (zero)] - [size (window)] - [middle (unmodified)] - [size (window)] - [end (zero)]
     """
 
-    def __init__(self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs):
+    def __init__(
+        self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs
+    ):
         """
         Args:
             axis (int): Axis along which to apply the window.
@@ -1278,7 +1312,9 @@ class CommonMidpointPhaseError(Operation):
         n_tx, n_pix, n_rx, n_ch = data.shape
         receive_subaps = ops.zeros((n_rx, n_tx))
         for diag in range(-halfsa, halfsa + 1):
-            receive_subaps = receive_subaps + ops.diag(ops.ones((n_rx - abs(diag),)), diag)
+            receive_subaps = receive_subaps + ops.diag(
+                ops.ones((n_rx - abs(diag),)), diag
+            )
         receive_subaps = receive_subaps[halfsa : receive_subaps.shape[0] - halfsa : dx]
         transmit_subaps = ops.flip(receive_subaps, axis=0)
         return transmit_subaps, receive_subaps
@@ -1294,7 +1330,9 @@ class CommonMidpointPhaseError(Operation):
         """
 
         transmit_subaps, receive_subaps = self.create_subapertures(data, 8, 1)
-        complex_data = ops.view_as_complex(data)  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
+        complex_data = ops.view_as_complex(
+            data
+        )  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
         complex_data = ops.transpose(complex_data, (2, 0, 1))  # [n_rx, n_tx, n_pix]
         rx_zero_count = ops.matmul(receive_subaps, ops.cast(complex_data == 0, "int32"))
 
@@ -1302,8 +1340,12 @@ class CommonMidpointPhaseError(Operation):
         rx_valid = rx_zero_count <= 1
         complex_data_rx = ops.matmul(receive_subaps, complex_data)
         complex_data_rx = ops.where(rx_valid, complex_data_rx, 0)
-        complex_data_rx = ops.transpose(complex_data_rx, (1, 0, 2))  # [n_tx, n_subap_rx, n_pix]
-        tx_zero_count = ops.matmul(transmit_subaps, ops.cast(complex_data_rx == 0, "int32"))
+        complex_data_rx = ops.transpose(
+            complex_data_rx, (1, 0, 2)
+        )  # [n_tx, n_subap_rx, n_pix]
+        tx_zero_count = ops.matmul(
+            transmit_subaps, ops.cast(complex_data_rx == 0, "int32")
+        )
 
         # Mask out subapertures with point outside fov in transmit
         tx_valid = tx_zero_count <= 1
@@ -1357,13 +1399,9 @@ class TissueSuppression(Operation):
     * ``"svd_complex"`` -- the same filter with a conjugate (Hermitian)
       transpose, for complex baseband IQ input. This is the filter used for
       Power-Doppler / ULM processing (as in MUST's ``process.m``). Input is IQ
-      data as two real channels, shape ``(n_frames, ..., 2)`` (the zea
-      convention -- see e.g. the output of ``Beamform``); the op converts to a
-      complex tensor internally with ``keras.ops.view_as_complex`` and back with
-      ``view_as_real`` before returning, the same pattern
-      :class:`DelayMultiplyAndSum` uses. On real ``[I, Q]`` channel data
-      ``"svd"`` builds ``XᵀX`` instead of the temporal covariance ``XᴴX`` and
-      will not suppress the tissue.
+      data as two real channels, shape ``(n_frames, ..., 2)``.
+      On real ``[I, Q]`` channel data ``"svd"`` builds ``XᵀX`` instead of
+      the temporal covariance ``XᴴX`` and will not suppress the tissue.
 
     .. note::
         On the TensorFlow backend ``"svd_complex"`` runs eagerly: TensorFlow
@@ -1409,7 +1447,10 @@ class TissueSuppression(Operation):
         TensorFlow raises, but that combination does not suppress the tissue
         anyway -- use ``svd_complex`` for complex input).
         """
-        if self.filter_type == "svd_complex" and keras.backend.backend() == "tensorflow":
+        if (
+            self.filter_type == "svd_complex"
+            and keras.backend.backend() == "tensorflow"
+        ):
             return False
         return super().jittable
 

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -245,9 +245,7 @@ class PfieldWeighting(Operation):
         if flat_pfield is None:
             return {self.output_key: data}
 
-        weighted_data = apply_aligned_apodization(
-            data, flat_pfield, self.with_batch_dim
-        )
+        weighted_data = apply_aligned_apodization(data, flat_pfield, self.with_batch_dim)
 
         return {self.output_key: weighted_data}
 
@@ -334,9 +332,7 @@ class ReceiveApodization(Operation):
         Returns:
             dict: Dictionary containing weighted data
         """
-        data = kwargs[
-            self.key
-        ]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
+        data = kwargs[self.key]  # must start with ((batch_size,) n_tx, n_pix, n_el, ...)
 
         if flat_receive_apodization is None:
             return {self.output_key: data}
@@ -376,8 +372,7 @@ class ScanConvert(Operation):
         if order > 1:
             jittable = False
             log.warning(
-                "GPU support for order > 1 is not available. "
-                + "Disabling jit for ScanConvert."
+                "GPU support for order > 1 is not available. " + "Disabling jit for ScanConvert."
             )
         else:
             jittable = True
@@ -588,9 +583,7 @@ class LowPassFilterIQ(FirFilter):
                 Odd will result in a type I filter, even in a type II filter.
         """
         if "jittable" in kwargs:
-            raise ValueError(
-                "LowPassFilterIQ is not jittable, so jittable must be set to False."
-            )
+            raise ValueError("LowPassFilterIQ is not jittable, so jittable must be set to False.")
         if "complex_channels" in kwargs and not kwargs["complex_channels"]:
             raise ValueError(
                 "LowPassFilterIQ operates on IQ data, so complex_channels must be True."
@@ -728,8 +721,7 @@ class BandPassFilter(FirFilter):
             raise ValueError(passband_error_message)
 
         if not all(
-            isinstance(f, (int, float, np.number)) and not isinstance(f, bool)
-            for f in (f1, f2)
+            isinstance(f, (int, float, np.number)) and not isinstance(f, bool) for f in (f1, f2)
         ):
             raise ValueError(passband_error_message)
 
@@ -882,13 +874,9 @@ class Companding(Operation):
             raise ValueError("comp_type must be 'mu' or 'a'.")
 
         if self.comp_type == "mu":
-            self._compand_func = (
-                self._mu_law_expand if self.expand else self._mu_law_compress
-            )
+            self._compand_func = self._mu_law_expand if self.expand else self._mu_law_compress
         else:
-            self._compand_func = (
-                self._a_law_expand if self.expand else self._a_law_compress
-            )
+            self._compand_func = self._a_law_expand if self.expand else self._a_law_compress
 
     @staticmethod
     def _mu_law_compress(x, mu=255, **kwargs):
@@ -999,9 +987,7 @@ class AnisotropicDiffusion(Operation):
         results = []
         for i in range(batch_size):
             image = data[i]
-            image_out = self._anisotropic_diffusion_single(
-                image, niter, lmbda, rect, eps
-            )
+            image_out = self._anisotropic_diffusion_single(image, niter, lmbda, rect, eps)
             results.append(image_out)
 
         result = ops.stack(results, axis=0)
@@ -1017,25 +1003,15 @@ class AnisotropicDiffusion(Operation):
         M, N = image.shape
 
         for _ in range(niter):
-            iN = ops.concatenate(
-                [image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0
-            )
-            iS = ops.concatenate(
-                [ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0
-            )
-            jW = ops.concatenate(
-                [image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1
-            )
-            jE = ops.concatenate(
-                [ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1
-            )
+            iN = ops.concatenate([image[1:], ops.zeros((1, N), dtype=image.dtype)], axis=0)
+            iS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), image[:-1]], axis=0)
+            jW = ops.concatenate([image[:, 1:], ops.zeros((M, 1), dtype=image.dtype)], axis=1)
+            jE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), image[:, :-1]], axis=1)
 
             if rect is not None:
                 x1, y1, x2, y2 = rect
                 imageuniform = image[x1:x2, y1:y2]
-                q0_squared = (
-                    ops.std(imageuniform) / (ops.mean(imageuniform) + eps)
-                ) ** 2
+                q0_squared = (ops.std(imageuniform) / (ops.mean(imageuniform) + eps)) ** 2
 
             dN = iN - image
             dS = iS - image
@@ -1052,9 +1028,7 @@ class AnisotropicDiffusion(Operation):
                 den = (q_squared - q0_squared) / (q0_squared * (1 + q0_squared) + eps)
             c = 1.0 / (1 + den)
             cS = ops.concatenate([ops.zeros((1, N), dtype=image.dtype), c[:-1]], axis=0)
-            cE = ops.concatenate(
-                [ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1
-            )
+            cE = ops.concatenate([ops.zeros((M, 1), dtype=image.dtype), c[:, :-1]], axis=1)
 
             D = (cS * dS) + (c * dN) + (cE * dE) + (c * dW)
             image = image + (lmbda / 4) * D
@@ -1117,9 +1091,7 @@ class UpMix(Operation):
         elif data.shape[-1] == 2:
             data = ops.view_as_complex(data)
 
-        data = upmix(
-            data, sampling_frequency, demodulation_frequency, self.upsampling_rate
-        )
+        data = upmix(data, sampling_frequency, demodulation_frequency, self.upsampling_rate)
         data = ops.expand_dims(data, axis=-1)
         return {self.output_key: data}
 
@@ -1158,9 +1130,7 @@ class LogCompress(Operation):
 
         compressed_data = log_compress(data)
         if self.clip:
-            compressed_data = ops.clip(
-                compressed_data, dynamic_range[0], dynamic_range[1]
-            )
+            compressed_data = ops.clip(compressed_data, dynamic_range[0], dynamic_range[1])
 
         return {self.output_key: compressed_data}
 
@@ -1181,9 +1151,7 @@ class ReshapeGrid(Operation):
             - reshaped_data (Tensor): The reshaped data of shape (..., grid.shape, ...).
         """
         data = kwargs[self.key]
-        reshaped_data = reshape_axis(
-            data, grid.shape[:-1], self.axis + int(self.with_batch_dim)
-        )
+        reshaped_data = reshape_axis(data, grid.shape[:-1], self.axis + int(self.with_batch_dim))
         return {self.output_key: reshaped_data}
 
 
@@ -1198,9 +1166,7 @@ class ApplyWindow(Operation):
     [start (zero)] - [size (window)] - [middle (unmodified)] - [size (window)] - [end (zero)]
     """
 
-    def __init__(
-        self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs
-    ):
+    def __init__(self, axis=-3, size=32, start=16, end=0, window_type="hanning", **kwargs):
         """
         Args:
             axis (int): Axis along which to apply the window.
@@ -1312,9 +1278,7 @@ class CommonMidpointPhaseError(Operation):
         n_tx, n_pix, n_rx, n_ch = data.shape
         receive_subaps = ops.zeros((n_rx, n_tx))
         for diag in range(-halfsa, halfsa + 1):
-            receive_subaps = receive_subaps + ops.diag(
-                ops.ones((n_rx - abs(diag),)), diag
-            )
+            receive_subaps = receive_subaps + ops.diag(ops.ones((n_rx - abs(diag),)), diag)
         receive_subaps = receive_subaps[halfsa : receive_subaps.shape[0] - halfsa : dx]
         transmit_subaps = ops.flip(receive_subaps, axis=0)
         return transmit_subaps, receive_subaps
@@ -1330,9 +1294,7 @@ class CommonMidpointPhaseError(Operation):
         """
 
         transmit_subaps, receive_subaps = self.create_subapertures(data, 8, 1)
-        complex_data = ops.view_as_complex(
-            data
-        )  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
+        complex_data = ops.view_as_complex(data)  # [n_tx, n_pix, n_rx, n_ch] -> [n_rtx, n_pix, r_x]
         complex_data = ops.transpose(complex_data, (2, 0, 1))  # [n_rx, n_tx, n_pix]
         rx_zero_count = ops.matmul(receive_subaps, ops.cast(complex_data == 0, "int32"))
 
@@ -1340,12 +1302,8 @@ class CommonMidpointPhaseError(Operation):
         rx_valid = rx_zero_count <= 1
         complex_data_rx = ops.matmul(receive_subaps, complex_data)
         complex_data_rx = ops.where(rx_valid, complex_data_rx, 0)
-        complex_data_rx = ops.transpose(
-            complex_data_rx, (1, 0, 2)
-        )  # [n_tx, n_subap_rx, n_pix]
-        tx_zero_count = ops.matmul(
-            transmit_subaps, ops.cast(complex_data_rx == 0, "int32")
-        )
+        complex_data_rx = ops.transpose(complex_data_rx, (1, 0, 2))  # [n_tx, n_subap_rx, n_pix]
+        tx_zero_count = ops.matmul(transmit_subaps, ops.cast(complex_data_rx == 0, "int32"))
 
         # Mask out subapertures with point outside fov in transmit
         tx_valid = tx_zero_count <= 1
@@ -1425,9 +1383,7 @@ class TissueSuppression(Operation):
 
     FILTER_TYPES = ("svd", "svd_complex")
 
-    def __init__(
-        self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs
-    ):
+    def __init__(self, cutoff: int | float = 5, filter_type: str | None = None, **kwargs):
         """
         Args:
             cutoff (int or float): Number of principal (tissue) components to


### PR DESCRIPTION
Now uses conjugate transpose for constructing the Gram matrix for tissue suppression when the data is complex-valued IQ. This enables us to use the same tissue suppression as in ULMShare.

There isn't a noticable difference in the outputs before vs after using this for me, but it is technically correct to use the conjugate transpose since the data is complex-valued, and now matches the ULMShare processing.

<img width="837" height="375" alt="image" src="https://github.com/user-attachments/assets/49d4bab5-7f95-4598-bd9f-7bae4253c157" />

<details>
<summary>Snippet</summary>

```python

"""B-mode with and without SVD tissue suppression, on PALA rat-brain data."""

import os

os.environ.setdefault("KERAS_BACKEND", "jax")

import matplotlib.pyplot as plt
import numpy as np
from zea.ops import (
    Beamform,
    EnvelopeDetect,
    LogCompress,
    Normalize,
    Pipeline,
    TissueSuppression,
)

from zea import File, init_device

PATH = "/mnt/z/Ultrasound-BMd/data/vincent/RF_003.hdf5"
N_FRAMES = 64

init_device(verbose=False)

with File(PATH) as f:
    parameters = f.load_parameters()
    data = np.asarray(f.data.raw_data[:N_FRAMES])  # (n_frames, n_tx, n_ax, n_el, 2)

parameters.update(grid_size_x=400, grid_size_z=600, zlims=(0.001, 0.013))
parameters.set_transmits("all")


def bmode(suppress):
    ops = [Beamform(beamformer="delay_and_sum", num_patches=200)]
    if suppress:
        ops.append(
            TissueSuppression(cutoff=5)
        )  # filter_type=None -> auto -> svd_complex
    ops += [EnvelopeDetect(), Normalize(), LogCompress()]
    pipeline = Pipeline(ops, with_batch_dim=True, jit_options="pipeline")
    inputs = pipeline.prepare_parameters(parameters)
    return np.asarray(pipeline(**{**inputs, pipeline.key: data})[pipeline.output_key])


extent = np.array([*parameters.xlims, *parameters.zlims[::-1]]) * 1e3

_, axes = plt.subplots(1, 2, figsize=(12, 5))
for ax, (title, suppress) in zip(
    axes, [("B-mode", False), ("Tissue suppressed", True)]
):
    ax.imshow(
        bmode(suppress).mean(0),
        cmap="gray",
        extent=extent,
        vmin=-60,
        vmax=0,
        aspect="equal",
    )
    ax.set(title=title, xlabel="x (mm)", ylabel="z (mm)")
plt.tight_layout()
plt.savefig("snippet_pala.png", dpi=150, bbox_inches="tight")
print("Saved snippet_pala.png")
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tissue suppression for complex IQ ultrasound data.
  - Introduced selectable tissue-suppression modes for real vs complex inputs, with automatic mode detection.
  - Extended cutoff handling to support both integer values and fractional values (interpreted relative to frame count).

- **Bug Fixes**
  - Improved complex processing to use Hermitian (conjugate) projection behavior.
  - Added validation for unsupported modes and out-of-range fractional cutoff values.

- **Tests**
  - Expanded coverage for complex clutter suppression quality, Hermitian vs non-Hermitian behavior, cutoff resolution (including fractional), and mode autodetection/matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->