### PR TITLE
Improved support for curved probes

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -969,7 +969,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
            - ``float32``
            - scalar
            - Hz
-           - Probe nominal centre frequency.
+           - Probe nominal centre frequency (midpoint of the probe's -6 dB band).
            - |badge-opt|
          * - ``probe_bandwidth_percent``
            - ``float32``
@@ -1107,7 +1107,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
             * - ``genetic_strain``
               - ``str``
               - scalar
-              - Genetic strain of an animal subject, e.g. C57BL/6N.
+              - Genetic strain (inbred line) of an animal subject, e.g. C57BL/6N.
               - |badge-opt|
             * - ``fat_percentage``
               - ``float32``

--- a/tests/test_beamformer.py
+++ b/tests/test_beamformer.py
@@ -680,6 +680,30 @@ def test_tof_correction_with_fnumber(probe_geometry, flatgrid):
 
 
 @backend_equality_check()
+def test_tof_correction_convex_probe_fnumber(flatgrid):
+    """A curved (convex) probe runs end-to-end with per-element-normal masking.
+
+    The auto-derived element normals must not produce NaNs/Infs and must still
+    mask some channels (f_number > 0) for a non-flat geometry.
+    """
+    n_el = 48
+    phi = np.linspace(-0.5, 0.5, n_el).astype(np.float32)
+    radius = 40e-3
+    convex_geometry = np.stack(
+        [radius * np.sin(phi), np.zeros_like(phi), radius * (np.cos(phi) - 1.0)], axis=-1
+    ).astype(np.float32)
+
+    inputs = _make_tof_inputs(convex_geometry, flatgrid, n_tx=2, n_ax=64)
+    inputs["f_number"] = 1.0
+    result = keras.ops.convert_to_numpy(tof_correction(**inputs))
+
+    assert result.shape == (2, flatgrid.shape[0], n_el, 1)
+    assert np.all(np.isfinite(result))
+    assert np.any(result == 0.0), "Expected some masked-out values with f_number > 0"
+    return result
+
+
+@backend_equality_check()
 def test_tof_correction_zero_data(probe_geometry, flatgrid):
     """Zero input data should produce zero output regardless of delays."""
     n_tx, n_ax = 2, 64

--- a/tests/test_fnumber_mask.py
+++ b/tests/test_fnumber_mask.py
@@ -1,5 +1,6 @@
 """Test for the fnumber_mask function."""
 
+import keras
 import numpy as np
 import pytest
 from keras import ops
@@ -10,7 +11,23 @@ from zea.beamform.beamformer import (
     fnum_window_fn_tukey,
     fnumber_mask,
 )
+from zea.beamform.geometry import compute_element_normals
 from zea.beamform.pixelgrid import cartesian_pixel_grid
+
+
+def _convex_probe_geometry(n_el=64, radius=40e-3, half_angle=0.5):
+    """Convex arc with the apex element at the origin facing +z.
+
+    Element i sits at arc-angle ``phi_i`` with position
+    ``(R sin phi, 0, R (cos phi - 1))`` and true outward normal
+    ``(sin phi, 0, cos phi)``.
+    """
+    phi = np.linspace(-half_angle, half_angle, n_el).astype(np.float32)
+    positions = np.stack(
+        [radius * np.sin(phi), np.zeros_like(phi), radius * (np.cos(phi) - 1.0)], axis=-1
+    ).astype(np.float32)
+    normals = np.stack([np.sin(phi), np.zeros_like(phi), np.cos(phi)], axis=-1).astype(np.float32)
+    return positions, normals
 
 
 @pytest.fixture
@@ -63,3 +80,96 @@ def test_fnumber_mask(probe_geometry, flatgrid, fnum_window_fn):
     idx_x = 32 + 15
     idx_z = 16
     assert mask_middle_element[idx_z, idx_x] > 0.0
+
+
+def test_compute_element_normals_flat_linear(probe_geometry):
+    """A flat linear array must derive exactly +z for every element."""
+    normals = ops.convert_to_numpy(compute_element_normals(probe_geometry))
+    expected = np.tile(np.array([0.0, 0.0, 1.0], dtype=np.float32), (probe_geometry.shape[0], 1))
+    assert np.array_equal(normals, expected)
+
+
+def test_compute_element_normals_single_element():
+    """A lone element has no tangent; fall back to +z."""
+    normals = ops.convert_to_numpy(compute_element_normals(np.zeros((1, 3), dtype=np.float32)))
+    assert np.array_equal(normals, np.array([[0.0, 0.0, 1.0]], dtype=np.float32))
+
+
+def test_compute_element_normals_convex_arc():
+    """Interior elements of a convex arc recover the analytic radial normal."""
+    positions, expected = _convex_probe_geometry(n_el=64, radius=40e-3, half_angle=0.5)
+    normals = ops.convert_to_numpy(compute_element_normals(positions))
+    # Central differences are exact in the interior; endpoints use a one-sided
+    # difference so allow them a looser tolerance.
+    np.testing.assert_allclose(normals[1:-1], expected[1:-1], atol=1e-4)
+    np.testing.assert_allclose(normals[[0, -1]], expected[[0, -1]], atol=2e-2)
+
+
+@pytest.mark.parametrize(
+    "fnum_window_fn", [fnum_window_fn_hann, fnum_window_fn_rect, fnum_window_fn_tukey]
+)
+def test_fnumber_mask_flat_linear_is_legacy_noop(probe_geometry, flatgrid, fnum_window_fn):
+    """On a flat array the per-element-normal mask equals the old global-+z mask.
+
+    The reference is the legacy angle-relative-to-global-+z formula computed
+    with the same backend ops, so any difference would be a real change in
+    behaviour rather than a norm-implementation rounding difference.
+    """
+    rel = flatgrid[:, None] - probe_geometry[None]
+    rel_norm = ops.linalg.norm(rel, axis=-1)
+    alpha = ops.arccos(rel[..., 2] / (rel_norm + 1e-6))
+    max_alpha = ops.arctan(1.0 / (2.0 * 0.5 + keras.backend.epsilon()))
+    reference = ops.convert_to_numpy(fnum_window_fn(alpha / max_alpha))[..., None]
+
+    mask = ops.convert_to_numpy(
+        fnumber_mask(flatgrid, probe_geometry, f_number=0.5, fnum_window_fn=fnum_window_fn)
+    )
+    assert np.array_equal(mask, reference)
+
+
+def test_fnumber_mask_convex_widens_field_of_view():
+    """Per-element normals extend a convex array's field of view vs forcing +z.
+
+    Because peripheral elements of a convex array physically look outward,
+    steering each element's acceptance cone along its true normal illuminates
+    sector-edge pixels that the global-+z cone blacks out. That shows up as a
+    larger field of view (more pixels receiving any aperture), which is the
+    "larger frame" a curved probe should produce.
+    """
+    # Odd element count so a real element sits exactly at arc-angle 0 (normal +z).
+    positions, _ = _convex_probe_geometry(n_el=65, radius=40e-3, half_angle=0.5)
+    z_normals = np.tile(np.array([0.0, 0.0, 1.0], dtype=np.float32), (positions.shape[0], 1))
+
+    # A grid spanning the full sector so the tilted elements' look-direction
+    # pixels are actually present.
+    grid = (
+        cartesian_pixel_grid(
+            xlims=(-30e-3, 30e-3), zlims=(1e-3, 55e-3), grid_size_x=160, grid_size_z=160
+        )
+        .reshape(-1, 3)
+        .astype(np.float32)
+    )
+
+    mask_new = ops.convert_to_numpy(
+        fnumber_mask(grid, positions, f_number=2.0, fnum_window_fn=fnum_window_fn_rect)
+    )[..., 0]
+    mask_old = ops.convert_to_numpy(
+        fnumber_mask(
+            grid,
+            positions,
+            f_number=2.0,
+            fnum_window_fn=fnum_window_fn_rect,
+            element_normals=z_normals,
+        )
+    )[..., 0]
+
+    # Per-pixel aperture count -> field of view is the set of illuminated pixels.
+    aperture_new = mask_new.sum(axis=1)
+    aperture_old = mask_old.sum(axis=1)
+    assert int((aperture_new > 0).sum()) > int((aperture_old > 0).sum())
+    # Some sector-edge pixels are illuminated only once the normals are correct.
+    assert np.any((aperture_new > 0) & (aperture_old == 0))
+
+    # The apex element (arc-angle 0) faces +z, so its column is unchanged.
+    apex = positions.shape[0] // 2
+    np.testing.assert_allclose(mask_new[:, apex], mask_old[:, apex], atol=1e-6)

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -118,3 +118,39 @@ def test_pitch_derived_from_probe_geometry():
     probe = Probe(probe_geometry=pg)
     with pytest.raises(ValueError, match="Cannot compute pitch: probe has fewer than 2 elements"):
         _ = probe.pitch
+
+
+def test_verasonics_c5_2v_curved_probe():
+    """The C5-2v built-in is a 128-element convex arc (curved, y=0, apex at +z)."""
+    from zea.probes import create_curved_probe_geometry
+
+    probe = Probe.from_name("verasonics_c5_2v")
+    pg = np.asarray(probe.probe_geometry)
+
+    assert probe.type == "curved"
+    assert pg.shape == (128, 3)
+    # Imaging plane is x-z; the array is genuinely curved (z varies), not flat.
+    assert np.allclose(pg[:, 1], 0.0)
+    assert np.ptp(pg[:, 2]) > 1e-3
+    # Apex element faces +z (z ~= 0); peripheral elements curve back toward -z.
+    assert pg[:, 2].max() == pytest.approx(0.0, abs=1e-4)
+    assert pg[:, 2].min() < 0.0
+    # Arc spacing (pitch) is uniform at 0.508 mm.
+    spacing = np.linalg.norm(np.diff(pg, axis=0), axis=1)
+    assert np.allclose(spacing, 0.508e-3, atol=1e-6)
+
+    # The helper reproduces the same geometry from (n_el, pitch, radius).
+    regenerated = create_curved_probe_geometry(n_el=128, pitch=0.508e-3, radius=49.57e-3)
+    assert np.allclose(pg, regenerated)
+
+
+def test_verasonics_p4_2v_phased_probe():
+    """The P4-2v built-in is a 64-element flat phased array."""
+    probe = Probe.from_name("verasonics_p4_2v")
+    pg = np.asarray(probe.probe_geometry)
+
+    assert probe.type == "phased"
+    assert pg.shape == (64, 3)
+    # Flat linear array: y and z are zero, x uniformly spaced at 0.30 mm.
+    assert np.allclose(pg[:, 1:], 0.0)
+    assert probe.pitch == pytest.approx(0.3e-3, rel=1e-4)

--- a/tests/test_verasonics_geometry.py
+++ b/tests/test_verasonics_geometry.py
@@ -1,0 +1,42 @@
+"""Tests for the Verasonics converter's probe-geometry ordering classifier."""
+
+import numpy as np
+
+from zea.data.convert.verasonics import classify_ordered_geometry
+from zea.probes import create_curved_probe_geometry, create_probe_geometry
+
+
+def test_classify_linear_array():
+    """A uniform linear array is classified as ordered/linear."""
+    geom = create_probe_geometry(n_el=64, pitch=0.3e-3)
+    assert classify_ordered_geometry(geom) == (True, "linear")
+
+
+def test_classify_curved_array():
+    """A uniform convex arc (e.g. C5-2v) is ordered/arc, not linear."""
+    geom = create_curved_probe_geometry(n_el=128, pitch=0.508e-3, radius=49.57e-3)
+    is_ordered, kind = classify_ordered_geometry(geom)
+    assert is_ordered is True
+    assert kind == "arc"
+
+
+def test_classify_unordered_geometry():
+    """A shuffled / non-uniform element list is not a recognized ordered array."""
+    rng = np.random.default_rng(0)
+    geom = rng.normal(size=(64, 3)).astype(np.float32) * 1e-3
+    assert classify_ordered_geometry(geom) == (False, "unknown")
+
+
+def test_classify_two_elements_is_linear():
+    """Two elements trivially define a linear step."""
+    geom = np.array([[0.0, 0.0, 0.0], [0.3e-3, 0.0, 0.0]], dtype=np.float32)
+    assert classify_ordered_geometry(geom) == (True, "linear")
+
+
+def test_matrix_array_is_unknown():
+    """A 2-D matrix array (raster-ordered) is not linear or a single arc."""
+    xs, ys = np.meshgrid(np.arange(8), np.arange(8))
+    geom = np.stack([xs.ravel() * 0.3e-3, ys.ravel() * 0.3e-3, np.zeros(64)], axis=-1).astype(
+        np.float32
+    )
+    assert classify_ordered_geometry(geom) == (False, "unknown")

--- a/zea/beamform/beamformer.py
+++ b/zea/beamform/beamformer.py
@@ -10,6 +10,7 @@ import keras
 import numpy as np
 from keras import ops
 
+from zea.beamform.geometry import compute_element_normals
 from zea.beamform.lens_correction import compute_lens_corrected_travel_times
 from zea.func.tensor import vmap
 from zea.internal.checks import _check_raw_data
@@ -769,7 +770,7 @@ def transmit_delays(
     return tx_delay
 
 
-def fnumber_mask(flatgrid, probe_geometry, f_number, fnum_window_fn):
+def fnumber_mask(flatgrid, probe_geometry, f_number, fnum_window_fn, element_normals=None):
     """Receive-aperture apodization mask based on the f-number.
 
     This is the **built-in** receive-aperture (per-element) apodization.
@@ -778,6 +779,16 @@ def fnumber_mask(flatgrid, probe_geometry, f_number, fnum_window_fn):
     defined by the f-number.  The transition within the cone is controlled
     by *fnum_window_fn* (e.g. :func:`fnum_window_fn_rect`,
     :func:`fnum_window_fn_hann`, :func:`fnum_window_fn_tukey`).
+
+    The acceptance cone is measured relative to **each element's own surface
+    normal**.  For a flat linear array every normal is ``+z`` and this is the
+    familiar depth-axis cone; for a **curved/convex** array the peripheral
+    elements are tilted outward, so measuring the cone from their true normal
+    (rather than the global ``+z`` axis) keeps their aperture from being
+    clipped at the edges of the sector.  When *element_normals* is not given it
+    is derived from ``probe_geometry`` via
+    :func:`zea.beamform.geometry.compute_element_normals`, which is an exact
+    no-op (``+z``) for flat arrays.
 
     For a *custom* receive-aperture apodization (arbitrary per-pixel,
     per-element weights) use :class:`zea.ops.ReceiveApodization`, which is
@@ -793,18 +804,27 @@ def fnumber_mask(flatgrid, probe_geometry, f_number, fnum_window_fn):
         fnum_window_fn (callable): Window function mapping normalized
             angles in ``[0, 1]`` to weights.  Must return ``0`` for inputs
             ``> 1``.
+        element_normals (Tensor, optional): Unit surface normals of shape
+            ``(n_el, 3)``.  Defaults to ``None``, in which case they are
+            derived from ``probe_geometry``.
 
     Returns:
         Tensor: Mask of shape ``(n_pix, n_el, 1)``.
     """
+    if element_normals is None:
+        element_normals = compute_element_normals(probe_geometry)
 
     grid_relative_to_probe = flatgrid[:, None] - probe_geometry[None]
 
     grid_relative_to_probe_norm = ops.linalg.norm(grid_relative_to_probe, axis=-1)
 
-    grid_relative_to_probe_z = grid_relative_to_probe[..., 2] / (grid_relative_to_probe_norm + 1e-6)
+    # Unit element -> pixel direction (same +1e-6 guard as before, so a +z
+    # normal reproduces the legacy depth-axis cone bit-for-bit).
+    unit_direction = grid_relative_to_probe / (grid_relative_to_probe_norm[..., None] + 1e-6)
 
-    alpha = ops.arccos(grid_relative_to_probe_z)
+    # Angle between the element -> pixel direction and the element's normal.
+    cos_alpha = ops.sum(unit_direction * element_normals[None], axis=-1)
+    alpha = ops.arccos(ops.clip(cos_alpha, -1.0, 1.0))
 
     # The f-number is f_number = z/aperture = 1/(2 * tan(alpha))
     # Rearranging gives us alpha = arctan(1/(2 * f_number))

--- a/zea/beamform/geometry.py
+++ b/zea/beamform/geometry.py
@@ -1,0 +1,95 @@
+"""Geometry helpers for beamforming.
+
+Lightweight, backend-agnostic utilities derived purely from probe geometry.
+This is a *leaf* module (only depends on ``keras`` / ``numpy``) so it can be
+imported from :mod:`zea.beamform.beamformer`, :mod:`zea.simulator` and
+:mod:`zea.beamform.pfield` without introducing an import cycle.
+"""
+
+import keras
+from keras import ops
+
+
+def compute_element_normals(probe_geometry, eps=1e-12):
+    """Estimate per-element unit surface normals from element positions.
+
+    zea's built-in receive f-number apodization
+    (:func:`zea.beamform.beamformer.fnumber_mask`) measures the acceptance
+    cone relative to each element's surface normal. For a flat linear array
+    every element faces ``+z`` and the normal is trivial, but for a
+    curved/convex array the peripheral elements are physically tilted outward,
+    so their true look-direction is *not* ``+z``. Assuming ``+z`` for those
+    elements needlessly clips the receive aperture at the lateral edges of the
+    sector. This function derives each element's outward normal directly from
+    ``probe_geometry`` so no extra probe metadata (radius of curvature, per
+    element angles, ...) is required.
+
+    The array is treated as a 1-D curve of elements ordered along the aperture
+    lying in the ``x-z`` imaging plane (zea's convention; the medium is at
+    ``+z``). For each element the local tangent ``d`` is estimated by central
+    finite differences of neighbouring element positions (one-sided at the two
+    ends). The outward normal is the depth axis ``+z`` with its component along
+    the tangent removed::
+
+        n = normalize(z_hat - (z_hat.d) / (d.d) * d)
+
+    This yields **exactly** ``(0, 0, 1)`` for a flat array (any spacing,
+    ordered or not — the ``z`` column is identically zero, so the rejection
+    leaves ``z_hat`` untouched), so existing linear-array reconstructions are
+    unchanged bit-for-bit. For a convex arc it recovers the exact radial
+    outward normal at the interior elements.
+
+    Args:
+        probe_geometry (Tensor): Element positions ``(x, y, z)`` of shape
+            ``(n_el, 3)`` in metres, ordered along the array.
+        eps (float): Small value guarding the tangent-length division.
+
+    Returns:
+        Tensor: Unit outward normals of shape ``(n_el, 3)``.
+
+    Notes:
+        * Intended for 1-D arrays (linear / phased / curved) in the ``x-z``
+          plane. For a genuine 3-D matrix array (elements spread in ``y``) a
+          single index-ordered tangent is not meaningful, so the function
+          falls back to ``+z`` for every element when the geometry has a
+          non-negligible ``y`` extent — reproducing today's behaviour.
+        * A single-element array falls back to ``+z``.
+    """
+    z_hat = ops.cast(ops.convert_to_tensor([0.0, 0.0, 1.0]), probe_geometry.dtype)
+    # (n_el, 3) field of +z, used for every fallback path.
+    z_field = z_hat[None] * ops.ones_like(probe_geometry)
+
+    n_el = probe_geometry.shape[0]
+    if n_el is not None and n_el < 2:
+        # A lone element carries no tangent information.
+        return z_field
+
+    # Central finite differences of element positions (one-sided at the ends):
+    #   d[0]        = p[1] - p[0]
+    #   d[i]        = p[i+1] - p[i-1]      (interior)
+    #   d[-1]       = p[-1] - p[-2]
+    fwd = probe_geometry[1:] - probe_geometry[:-1]  # (n_el - 1, 3)
+    tangent = ops.concatenate([fwd[:1], fwd[1:] + fwd[:-1], fwd[-1:]], axis=0)  # (n_el, 3)
+
+    # Reject the tangent component from +z (scale-free: no tangent normalisation,
+    # so a flat array with z==0 gives exactly z_hat regardless of pitch/eps).
+    z_dot_d = ops.sum(z_hat[None] * tangent, axis=-1, keepdims=True)  # (n_el, 1)
+    d_dot_d = ops.sum(tangent * tangent, axis=-1, keepdims=True)  # (n_el, 1)
+    rejected = z_hat[None] - (z_dot_d / ops.maximum(d_dot_d, eps)) * tangent  # (n_el, 3)
+
+    # Normalise without eps on the good path (nn == 1 exactly for a flat array),
+    # falling back to +z where the tangent is (near-)parallel to +z.
+    nn = ops.linalg.norm(rejected, axis=-1, keepdims=True)
+    normals = ops.where(nn < 1e-6, z_field, rejected / ops.maximum(nn, 1e-12))
+
+    # Guard against genuine 3-D matrix arrays: if the elements have a
+    # non-negligible extent in y, an index-ordered 1-D tangent is meaningless,
+    # so reproduce today's "+z for everyone" behaviour. Convex 1-D probes
+    # (y ~= 0) pass straight through. Scalar condition -> broadcasts over both.
+    x, y, z = probe_geometry[:, 0], probe_geometry[:, 1], probe_geometry[:, 2]
+    y_span = ops.max(y) - ops.min(y)
+    inplane_span = ops.maximum(ops.max(x) - ops.min(x), ops.max(z) - ops.min(z))
+    is_planar_xz = y_span <= 1e-3 * inplane_span + keras.backend.epsilon()
+    normals = ops.where(is_planar_xz, normals, z_field)
+
+    return normals

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -875,9 +875,19 @@ class VerasonicsFile(h5py.File):
         Returns:
             focus_distances (np.ndarray): The focus distances of shape (n_tx,).
 
-        Note:
-            This function assumes that the probe geometry is a 1d uniform linear array.
-            If not it will warn and return.
+        .. note::
+            For a 1d uniform linear array, transmits whose t0 delays form a linear ramp
+            across the active elements are treated as plane waves and their focus
+            distance is set to infinity.
+
+        .. note::
+            For a curved/arc array, a "flat-fire" transmit is a diverging wave rather
+            than a plane wave, so this normalization does not apply; an informational
+            log is emitted and the focus distances are returned unchanged.
+
+        .. note::
+            For any other (unrecognized) probe geometry, a warning is logged and the
+            focus distances are returned unchanged.
         """
         is_ordered, kind = self.probe._probe_geometry_ordering
         if kind != "linear":

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -75,7 +75,61 @@ from zea.utils import strtobool
 _VERASONICS_TO_ZEA_PROBE_NAMES = {
     "L11-4v": "verasonics_l11_4v",
     "L11-5v": "verasonics_l11_5v",
+    "C5-2v": "verasonics_c5_2v",
+    "C5-2V": "verasonics_c5_2v",
+    "P4-2v": "verasonics_p4_2v",
+    "P4-2V": "verasonics_p4_2v",
 }
+
+
+def classify_ordered_geometry(geometry, rtol=1e-3):
+    """Classify a probe geometry as an ordered linear array, ordered arc, or neither.
+
+    Used when interpreting transmit delays during conversion. A **uniform linear
+    array** (linear/phased probes) has identical step vectors between consecutive
+    elements. A **convex/curved** array has steps of equal length that turn by a
+    constant angle (a uniform arc). Anything else — a matrix array, or an
+    unordered element list — is ``"unknown"``.
+
+    This lets the converter pick the right check per probe instead of demanding a
+    strict linear array for everything (which needlessly flags valid curved
+    probes).
+
+    Args:
+        geometry (np.ndarray): Element positions of shape ``(n_el, 3)``.
+        rtol (float): Relative tolerance (scaled by the element spacing) for the
+            uniformity checks.
+
+    Returns:
+        tuple[bool, str]: ``(is_ordered, kind)`` with ``kind`` in
+        ``{"linear", "arc", "unknown"}``.
+    """
+    n_el = geometry.shape[0]
+    if n_el < 2:
+        return False, "unknown"
+
+    steps = geometry[1:] - geometry[:-1]
+    lengths = np.linalg.norm(steps, axis=1)
+    scale = lengths[0]
+    if scale == 0:
+        return False, "unknown"
+    tol = rtol * scale
+
+    # Linear: every step vector equals the first (same direction and spacing).
+    if np.max(np.linalg.norm(steps - steps[0], axis=1)) < tol:
+        return True, "linear"
+
+    if n_el < 3:
+        return False, "unknown"
+
+    # Arc: equal step lengths and a constant turning angle between steps.
+    if np.max(np.abs(lengths - scale)) < tol:
+        units = steps / lengths[:, None]
+        cos_turn = np.clip(np.sum(units[1:] * units[:-1], axis=1), -1.0, 1.0)
+        if np.max(np.abs(cos_turn - cos_turn[0])) < rtol:
+            return True, "arc"
+
+    return False, "unknown"
 
 
 _FRAMES_RANGE_RE = re.compile(r"^\d+(-\d+)?$")
@@ -825,11 +879,24 @@ class VerasonicsFile(h5py.File):
             This function assumes that the probe geometry is a 1d uniform linear array.
             If not it will warn and return.
         """
-        if not self.probe._probe_geometry_is_ordered_ula:
-            log.warning(
-                "The probe geometry is not ordered as a uniform linear array. "
-                "Focal distances are not set to infinity for plane waves."
-            )
+        is_ordered, kind = self.probe._probe_geometry_ordering
+        if kind != "linear":
+            if kind == "arc":
+                # Valid curved/convex array: the linear-ramp plane-wave test below
+                # does not apply (a "flat-fire" transmit on a curved array is a
+                # diverging wave, not a plane wave). Keep the focus distances as
+                # read from the file — for a diverging transmit that is a finite
+                # (often 0 or negative) value, not infinity.
+                log.info(
+                    "Curved/arc probe geometry detected; keeping transmit focus "
+                    "distances as read (plane-wave-to-infinity normalization only "
+                    "applies to linear arrays)."
+                )
+            else:
+                log.warning(
+                    "The probe geometry is not a recognized ordered array (linear or "
+                    "arc). Focal distances are not set to infinity for plane waves."
+                )
             return focus_distances
 
         for tx in range(focus_distances.size):
@@ -1374,10 +1441,15 @@ class VerasonicsProbe:
             return self.trans_obj["lensCorrection"][:].item()
 
     @property
+    def _probe_geometry_ordering(self):
+        """``(is_ordered, kind)`` for the geometry; see :func:`classify_ordered_geometry`."""
+        return classify_ordered_geometry(self.geometry)
+
+    @property
     def _probe_geometry_is_ordered_ula(self):
         """Checks if the probe geometry is ordered as a uniform linear array (ULA)."""
-        diff_vec = self.geometry[1:] - self.geometry[:-1]
-        return np.isclose(diff_vec, diff_vec[0]).all()
+        is_ordered, kind = self._probe_geometry_ordering
+        return is_ordered and kind == "linear"
 
     def to_probe_spec(self):
         """Convert the probe to a dict compatible with :class:`~zea.data.spec.ProbeSpec`."""

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1699,13 +1699,7 @@ class ProbeSpec(Spec):
         "type": {"description": "Probe geometry type (linear, phased, curved, ...)."},
         "probe_center_frequency": {
             "unit": "Hz",
-            "description": (
-                "Probe nominal centre frequency (a fixed property of the transducer). "
-                "For zea's built-in probes it is defined as the midpoint of the probe's "
-                "-6 dB band. This is distinct from the centre frequency of the transmit "
-                "pulse actually used in an acquisition, which is `ScanSpec.center_frequency` "
-                "(exposed as `Parameters.center_frequency`)."
-            ),
+            "description": ("Probe nominal centre frequency (midpoint of the probe's -6 dB band)."),
         },
         "probe_bandwidth_percent": {
             "unit": "%",

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -1699,7 +1699,13 @@ class ProbeSpec(Spec):
         "type": {"description": "Probe geometry type (linear, phased, curved, ...)."},
         "probe_center_frequency": {
             "unit": "Hz",
-            "description": "Probe nominal centre frequency.",
+            "description": (
+                "Probe nominal centre frequency (a fixed property of the transducer). "
+                "For zea's built-in probes it is defined as the midpoint of the probe's "
+                "-6 dB band. This is distinct from the centre frequency of the transmit "
+                "pulse actually used in an acquisition, which is `ScanSpec.center_frequency` "
+                "(exposed as `Parameters.center_frequency`)."
+            ),
         },
         "probe_bandwidth_percent": {
             "unit": "%",

--- a/zea/probes.py
+++ b/zea/probes.py
@@ -5,6 +5,33 @@ bandwidth, and properties such as element dimensions and lens geometry.
 All probe objects are instances of :class:`Probe`, which inherits validation from
 :class:`~zea.data.spec.ProbeSpec`.
 
+Probe parameters
+^^^^^^^^^^^^^^^^
+
+A probe is described by the fields below (all optional — record what you have; see
+:class:`~zea.data.spec.ProbeSpec` for exact dtypes and shapes):
+
+- ``name`` -- probe model identifier, e.g. ``"verasonics_c5_2v"``.
+- ``type`` -- geometry class: ``"linear"``, ``"phased"``, ``"curved"``, ...
+- ``probe_geometry`` -- element positions ``(x, y, z)`` in metres, shape
+  ``(n_el, 3)``. The element count ``n_el`` and ``pitch`` are derived from it.
+- ``probe_center_frequency`` -- the probe's nominal centre frequency (Hz), a fixed
+  property of the transducer. For the built-in probes it is defined as the
+  **midpoint of the -6 dB band** named by the probe (e.g. "L11-4v" -> 4-11 MHz ->
+  7.5 MHz), so it derives consistently with ``probe_bandwidth_percent`` from the
+  band edges. This is the *defined band centre*, not a measured peak-response
+  frequency, and it is distinct from the centre frequency of the transmit pulse
+  used in an acquisition, which lives in ``ScanSpec.center_frequency`` /
+  :attr:`~zea.parameters.Parameters.center_frequency`.
+- ``probe_bandwidth_percent`` -- fractional bandwidth as a percentage,
+  ``(f_high - f_low) / f_centre * 100``, using the arithmetic band centre above
+  (the standard fractional-bandwidth reference).
+- ``element_width`` -- width of a single element (m), along the array (azimuthal)
+  direction.
+- ``element_height`` -- elevation aperture of a single element (m).
+- ``lens_sound_speed`` / ``lens_thickness`` -- acoustic-lens speed of sound (m/s)
+  and thickness (m), used to correct receive travel times for the lens.
+
 There are three ways to obtain a probe:
 
 Loading a built-in probe
@@ -17,7 +44,7 @@ A small set of probes is pre-defined and can be retrieved by name:
     >>> from zea import Probe
     >>> probe = Probe.from_name("verasonics_l11_4v")
     >>> float(probe.probe_center_frequency)
-    6250000.0
+    7500000.0
     >>> probe.n_el
     128
 
@@ -29,6 +56,8 @@ Built-in probes
 - :class:`Verasonics_l11_4v` -- Verasonics L11-4V linear array
 - :class:`Verasonics_l11_5v` -- Verasonics L11-5V linear array
 - :class:`Esaote_sll1543` -- Esaote SLL1543 linear array
+- :class:`Verasonics_c5_2v` -- Verasonics C5-2v convex (curved) array
+- :class:`Verasonics_p4_2v` -- Verasonics P4-2v phased array
 
 Loading a probe from a data file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,6 +168,36 @@ def create_probe_geometry(n_el, pitch):
             np.linspace(-aperture / 2, aperture / 2, n_el).T,
             np.zeros((n_el,)),
             np.zeros((n_el,)),
+        ],
+        axis=1,
+    ).astype(np.float32)
+    return probe_geometry
+
+
+def create_curved_probe_geometry(n_el, pitch, radius):
+    """Create the geometry of a convex (curved) array.
+
+    Elements lie on an arc of the given radius of curvature in the ``x-z`` plane
+    (``y = 0``), with the apex element at the origin facing ``+z`` and the
+    peripheral elements curving back toward ``-z`` (zea's convention: the medium
+    is at ``+z``). ``pitch`` is the arc spacing between adjacent elements, so the
+    per-element angular step is ``pitch / radius``.
+
+    Args:
+        n_el (int): Number of elements in the probe.
+        pitch (float): Arc distance between adjacent elements in metres.
+        radius (float): Radius of curvature of the array in metres.
+
+    Returns:
+        np.ndarray: Probe geometry with shape (n_el, 3).
+    """
+    angular_pitch = pitch / radius
+    angles = (np.arange(n_el) - (n_el - 1) / 2) * angular_pitch
+    probe_geometry = np.stack(
+        [
+            radius * np.sin(angles),
+            np.zeros((n_el,)),
+            radius * np.cos(angles) - radius,
         ],
         axis=1,
     ).astype(np.float32)
@@ -266,14 +325,19 @@ class Probe(ProbeSpec):
 
 @probe_registry(name="verasonics_l11_4v")
 class Verasonics_l11_4v(Probe):
-    """Verasonics L11-4V linear ultrasound transducer."""
+    """Verasonics L11-4V linear array.
+
+    Elevation focus ~20 mm, sensitivity -64.5 to -59.5 dB.
+    """
 
     def __init__(self):
         """Verasonics L11-4V linear ultrasound transducer."""
 
         probe_geometry = create_probe_geometry(n_el=128, pitch=0.3e-3)
-        center_frequency = 6.25e6
-        probe_bandwidth_percent = (11 - 4) * 100 / (center_frequency / 1e6)
+        # Centre frequency is the midpoint of the -6 dB band from the probe name.
+        low_freq, high_freq = 4e6, 11e6
+        center_frequency = (low_freq + high_freq) / 2
+        probe_bandwidth_percent = (high_freq - low_freq) / center_frequency * 100
 
         super().__init__(
             name="verasonics_l11_4v",
@@ -281,22 +345,23 @@ class Verasonics_l11_4v(Probe):
             probe_center_frequency=center_frequency,
             probe_bandwidth_percent=probe_bandwidth_percent,
             probe_geometry=probe_geometry,
+            element_width=0.27e-3,
+            element_height=5e-3,
         )
 
 
 @probe_registry(name="verasonics_l11_5v")
 class Verasonics_l11_5v(Probe):
-    """Verasonics L11-5V linear ultrasound transducer."""
+    """Verasonics L11-5V linear array."""
 
     def __init__(self):
         """Verasonics L11-5V linear ultrasound transducer."""
 
         probe_geometry = create_probe_geometry(n_el=128, pitch=0.3e-3)
-        center_frequency = 6.25e6
-        probe_bandwidth_percent = (11 - 5) * 100 / (center_frequency / 1e6)
-
-        # elevation_focus = 18e-3
-        # sensitivity = -52 +/- 3 dB
+        # Centre frequency is the midpoint of the -6 dB band from the probe name.
+        low_freq, high_freq = 5e6, 11e6
+        center_frequency = (low_freq + high_freq) / 2
+        probe_bandwidth_percent = (high_freq - low_freq) / center_frequency * 100
 
         super().__init__(
             name="verasonics_l11_5v",
@@ -304,6 +369,8 @@ class Verasonics_l11_5v(Probe):
             probe_center_frequency=center_frequency,
             probe_bandwidth_percent=probe_bandwidth_percent,
             probe_geometry=probe_geometry,
+            element_width=0.27e-3,
+            element_height=5e-3,
         )
 
 
@@ -318,8 +385,10 @@ class Esaote_sll1543(Probe):
         """Set probe parameters"""
 
         probe_geometry = create_probe_geometry(n_el=192, pitch=0.245 / 1e3)
-        center_frequency = 8e6
-        probe_bandwidth_percent = (13 - 3) * 100 / (center_frequency / 1e6)
+        # Centre frequency is the midpoint of the -6 dB band from the probe name.
+        low_freq, high_freq = 3e6, 13e6
+        center_frequency = (low_freq + high_freq) / 2
+        probe_bandwidth_percent = (high_freq - low_freq) / center_frequency * 100
 
         super().__init__(
             name="esaote_sll1543",
@@ -327,4 +396,56 @@ class Esaote_sll1543(Probe):
             probe_center_frequency=center_frequency,
             probe_bandwidth_percent=probe_bandwidth_percent,
             probe_geometry=probe_geometry,
+        )
+
+
+@probe_registry(name="verasonics_c5_2v")
+class Verasonics_c5_2v(Probe):
+    """Verasonics C5-2v convex (curved) array.
+
+    Elevation focus ~60 mm, sensitivity -55.5 to -50.5 dB.
+    """
+
+    def __init__(self):
+        """Verasonics C5-2v convex (curved) ultrasound transducer."""
+
+        probe_geometry = create_curved_probe_geometry(n_el=128, pitch=0.508e-3, radius=49.57e-3)
+        # Centre frequency is the midpoint of the -6 dB band from the probe name.
+        low_freq, high_freq = 2e6, 5e6
+        center_frequency = (low_freq + high_freq) / 2
+        probe_bandwidth_percent = (high_freq - low_freq) / center_frequency * 100
+
+        super().__init__(
+            name="verasonics_c5_2v",
+            type="curved",
+            probe_center_frequency=center_frequency,
+            probe_bandwidth_percent=probe_bandwidth_percent,
+            probe_geometry=probe_geometry,
+            element_width=0.46e-3,
+        )
+
+
+@probe_registry(name="verasonics_p4_2v")
+class Verasonics_p4_2v(Probe):
+    """Verasonics P4-2v phased array.
+
+    Elevation focus ~60 mm, sensitivity -69 to -65 dB.
+    """
+
+    def __init__(self):
+        """Verasonics P4-2v phased-array ultrasound transducer."""
+
+        probe_geometry = create_probe_geometry(n_el=64, pitch=0.3e-3)
+        # Centre frequency is the midpoint of the -6 dB band from the probe name.
+        low_freq, high_freq = 2e6, 4e6
+        center_frequency = (low_freq + high_freq) / 2
+        probe_bandwidth_percent = (high_freq - low_freq) / center_frequency * 100
+
+        super().__init__(
+            name="verasonics_p4_2v",
+            type="phased",
+            probe_center_frequency=center_frequency,
+            probe_bandwidth_percent=probe_bandwidth_percent,
+            probe_geometry=probe_geometry,
+            element_width=0.25e-3,
         )


### PR DESCRIPTION
When storing data from the Verasonics with the `C5-2v`, some false warning are printed (based on assumption of a non-curved ULA). After, when reconstructing the data with `zea`, the receive aperture (through f-number) is incorrectly applied, again disregarding the curved nature of the probe. This PR aims to fix that. 

**Before**
<img width="526" height="438" alt="AAApatient01_bmode_prev" src="https://github.com/user-attachments/assets/af60fe33-e7e6-4bae-ad21-9bd283ecfa3e" />

**After**
<img width="526" height="438" alt="AAApatient01_bmode_v2" src="https://github.com/user-attachments/assets/0ee69861-5c42-43d8-98fa-50c70fb1e51e" />

## Details
The built-in receive f-number mask (`fnumber_mask`) decided whether an element "sees" a pixel by measuring the angle between the element→pixel direction and the global depth axis (`+z`). That is only right when every element faces straight down, i.e. a flat linear array. On a curved/convex array the peripheral elements are tilted outward, so measuring their acceptance cone from `+z` clips the aperture and throws away signal where the sector fans out.

This PR measures the acceptance cone from each element's own surface normal instead. The normal is derived directly from `probe_geometry`. F-number calculation for linear probes is unaffected. 


## API

`fnumber_mask` gains an optional `element_normals=None` argument; when omitted it derives them from `probe_geometry`. Passing explicit `+z` normals reproduces the old behaviour, which is handy as a before/after toggle in review. 

The derivation lives in a new leaf module `zea/beamform/geometry.py` (`compute_element_normals`) so the simulator and pfield directivity, which make the same `+z` assumption, can reuse it later without importing the beamformer.

## Not in this PR

- Simulator directivity (`simulator.py`) and pfield (`pfield.py`) still assume `+z`. They can use `compute_element_normals` in a follow-up; pfield is the bigger job since it currently rebuilds a synthetic flat array from pitch and ignores `probe_geometry` entirely. TODO: create issue. 

## Included Verasonics curved probes

Added two built-in Verasonics probes and a curved-geometry helper:

- **C5-2v**: 128-element convex array (pitch 0.508 mm, radius of curvature 49.57 mm), plus `create_curved_probe_geometry(n_el, pitch, radius)` (the existing `create_probe_geometry` only does flat linear arrays). The generator reproduces a real converted C5-2v file's element positions to 0.0 mm.
- **P4-2v**: 64-element flat phased array (pitch 0.30 mm).
- Mapped `C5-2v`/`C5-2V`/`P4-2v`/`P4-2V` in the converter's `_VERASONICS_TO_ZEA_PROBE_NAMES` so conversions stop falling back to the generic probe.

## Files
- `zea/beamform/geometry.py` — new, `compute_element_normals`
- `zea/beamform/beamformer.py` — `fnumber_mask` uses per-element normals
- `zea/probes.py` — `create_curved_probe_geometry` + `Verasonics_c5_2v` / `Verasonics_p4_2v` built-ins
- `zea/data/convert/verasonics.py` — C5-2v/P4-2v name mapping + `classify_ordered_geometry` (linear/arc/unknown)
- `tests/test_fnumber_mask.py` — normals correctness, linear no-op, convex FOV widening
- `tests/test_beamformer.py` — convex-probe end-to-end smoke test
- `tests/test_probes.py` — C5-2v / P4-2v geometry tests
- `tests/test_verasonics_geometry.py` — ordering-classifier tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in support for Verasonics **C5-2v** (curved) and **P4-2v** (phased) probes.
  * Added curved-probe geometry generation and utilities to classify ordered probe layouts (linear/arc/unknown), plus improved Verasonics name mapping.
* **Bug Fixes**
  * Improved receive f-number masking for curved/convex probes by using per-element surface normals, widening accuracy of the illuminated field.
* **Documentation**
  * Clarified probe center frequency as the midpoint of the -6 dB band; refined probe metadata wording.
* **Tests**
  * Added/extended regression and unit tests for geometry ordering, element normals, and convex time-of-flight correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->