### PR TITLE
Cap HDF5 libver at v114 for cross-version file portability

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -1107,7 +1107,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
             * - ``genetic_strain``
               - ``str``
               - scalar
-              - Genetic strain of an animal subject, e.g. C57BL/6N.
+              - Genetic strain (inbred line) of an animal subject, e.g. C57BL/6N.
               - |badge-opt|
             * - ``fat_percentage``
               - ``float32``

--- a/tests/data/test_data_format.py
+++ b/tests/data/test_data_format.py
@@ -295,6 +295,64 @@ def test_default_write_is_paged(tmp_hdf5_path):
         assert np.array_equal(file["tracks/track_0/data/raw_data"][:], DATA["raw_data"])
 
 
+@pytest.mark.heavy
+def test_paged_file_readable_by_oldest_supported_h5py(tmp_hdf5_path, tmp_path_factory):
+    """A file written with the currently installed h5py opens under the oldest one we support.
+
+    PAGED_LAYOUT caps ``libver`` at "v114" instead of "latest" precisely so that files
+    stay portable across h5py/HDF5 releases: "latest" resolves to whatever HDF5 the
+    *writer's* h5py bundles, and h5py 3.16 jumped to bundling HDF5 2.0, which writes
+    object-header message versions that HDF5 1.14.x (h5py's own floor, ``h5py >=3.11``
+    in pyproject.toml) can't parse -- surfacing as "bad version number for datatype/layout
+    message" on read. Regression-tested here by installing h5py 3.11.0 into a throwaway
+    venv (never touches the environment running the test suite) and reading the file back
+    with it in a subprocess.
+    """
+    File.create(path=tmp_hdf5_path, data=DATA, scan=SCAN, probe=PROBE)
+
+    venv_dir = tmp_path_factory.mktemp("old_h5py_venv")
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    venv_python = venv_dir / "bin" / "python"
+    pip_install = subprocess.run(
+        [str(venv_python), "-m", "pip", "install", "-q", "h5py==3.11.0", "hdf5plugin"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert pip_install.returncode == 0, (
+        f"could not provision oldest-supported-h5py venv (no network access?): {pip_install.stderr}"
+    )
+
+    read_script = (
+        "import hdf5plugin, h5py, sys\n"
+        "def walk(g):\n"
+        "    for key in g.keys():\n"
+        "        item = g[key]\n"
+        "        if isinstance(item, h5py.Group):\n"
+        "            walk(item)\n"
+        "        else:\n"
+        "            item[()] if item.shape == () else item[...]\n"
+        f"with h5py.File({str(tmp_hdf5_path)!r}, 'r') as f:\n"
+        "    walk(f)\n"
+        "print('h5py', h5py.__version__)\n"
+    )
+    read_result = subprocess.run(
+        [str(venv_python), "-c", read_script],
+        capture_output=True,
+        text=True,
+    )
+    assert read_result.returncode == 0, (
+        f"h5py 3.11 (HDF5 1.14.x) could not read a file written by the current "
+        f"h5py: {read_result.stderr}"
+    )
+    assert "h5py 3.11.0" in read_result.stdout
+
+
 def test_existing_path(tmp_hdf5_path):
     """Tests if passing a path that already exists raises an error."""
     # Ensure that the file exists

--- a/tests/data/test_data_format.py
+++ b/tests/data/test_data_format.py
@@ -316,6 +316,7 @@ def test_paged_file_readable_by_oldest_supported_h5py(tmp_hdf5_path, tmp_path_fa
         check=True,
         capture_output=True,
         text=True,
+        timeout=300,
     )
     venv_python = venv_dir / "bin" / "python"
     pip_install = subprocess.run(
@@ -345,6 +346,7 @@ def test_paged_file_readable_by_oldest_supported_h5py(tmp_hdf5_path, tmp_path_fa
         [str(venv_python), "-c", read_script],
         capture_output=True,
         text=True,
+        timeout=300,
     )
     assert read_result.returncode == 0, (
         f"h5py 3.11 (HDF5 1.14.x) could not read a file written by the current "

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -72,9 +72,16 @@ MAX_CHUNK_BYTES = 8 << 20  # 8 MiB
 # cold open from 3 requests to 2 and ~0.16 s to ~0.05 s, at ~2% file size for 64 KiB
 # pages (larger pages waste space and, past ~1 MiB, requests too).
 #
-# Requires HDF5 >= 1.10.1 on the reader, which `libver="latest"` implies anyway.
+# Requires HDF5 >= 1.10.1 on the reader, which the "v114" high bound below satisfies.
+# The high bound is pinned rather than left as "latest": h5py 3.16 started bundling
+# libhdf5 2.0, and "latest" resolves to whatever's bundled at write time. HDF5 2.0
+# writes newer object-header message versions (e.g. datatype messages) that HDF5
+# 1.14.x readers reject outright with "bad version number for datatype message" -
+# confirmed by round-tripping a file through h5py 3.16/libhdf5 2.0 and reading it
+# back with h5py 3.11/libhdf5 1.14.2. Capping at v114 keeps files readable by the
+# 1.14.x installs still in the wild without limiting which h5py *version* writes them.
 PAGED_LAYOUT = {
-    "libver": "latest",
+    "libver": ("earliest", "v114"),
     "fs_strategy": "page",
     "fs_page_size": 64 * 1024,
     "fs_persist": True,


### PR DESCRIPTION
## Summary
This PR ensures that HDF5 files written with the current h5py remain readable by older HDF5 1.14.x installations (h5py >= 3.11), which is the minimum supported version. The change addresses a compatibility issue introduced when h5py 3.16 began bundling HDF5 2.0.

## Key Changes

- **spec.py**: Changed `PAGED_LAYOUT` configuration from `libver="latest"` to `libver=("earliest", "v114")` to cap the HDF5 version used when writing files. This prevents the use of newer object-header message formats (introduced in HDF5 2.0) that cannot be read by HDF5 1.14.x readers.

- **test_data_format.py**: Added comprehensive regression test `test_paged_file_readable_by_oldest_supported_h5py` that:
  - Creates a file with the current h5py installation
  - Provisions a throwaway venv with h5py 3.11.0 (the oldest supported version)
  - Attempts to read the file back using the old h5py in a subprocess
  - Verifies successful round-trip compatibility

- **_spec_ref.rst**: Minor documentation clarification: updated `genetic_strain` field description to specify "(inbred line)" for clarity.

## Implementation Details

The issue occurs because `libver="latest"` resolves to whatever HDF5 version is bundled with the *writer's* h5py at write time. When h5py 3.16 upgraded to HDF5 2.0, it began writing newer object-header message versions that HDF5 1.14.x cannot parse, resulting in "bad version number for datatype/layout message" errors on read.

By pinning the high bound to "v114", files remain compatible with HDF5 1.14.x readers while still allowing any h5py version to write them. This maintains backward compatibility without restricting which h5py version can be used for writing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `metadata/subject/genetic_strain` describes the animal’s inbred genetic strain (e.g., `C57BL/6N`).

* **Bug Fixes**
  * Improved HDF5 writing compatibility by pinning header library version behavior to keep generated files readable by older HDF5/h5py versions.

* **Tests**
  * Added a heavy regression test that verifies paged HDF5 files can be installed and read successfully with the oldest supported `h5py` version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->