### PR TITLE
Replace argparse with tyro for CLI argument parsing and fix coverage registration

### DIFF
--- a/docs/source/_spec_ref.rst
+++ b/docs/source/_spec_ref.rst
@@ -1125,7 +1125,7 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
 
       .. dropdown:: ``annotations`` — Annotations
 
-         Frame-level annotations, either per frame or broadcast labels.
+         Frame-level annotations, either one per frame or a single broadcast value.
 
          .. list-table::
             :header-rows: 1
@@ -1139,12 +1139,12 @@ Fields marked :bdg-secondary:`optional` may be absent; all others are
             * - ``anatomy``
               - ``str``
               - (n_frames) or scalar
-              - Anatomy label.
+              - Anatomical structure imaged (e.g. carotid, liver).
               - |badge-opt|
             * - ``view``
               - ``str``
               - (n_frames) or scalar
-              - View label.
+              - Imaging plane/orientation (e.g. longitudinal, apical_4_chamber).
               - |badge-opt|
             * - ``label``
               - ``str``

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -19,5 +19,5 @@ Note that is very new functionality, and might change in future releases. Please
 Convert datasets
 -------------------------------
 
-.. autoprogram:: zea.data.convert.__main__:get_parser()
+.. tyroprogram:: zea.data.convert.__main__:Dataset
    :prog: python -m zea.data.convert

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -13,8 +13,5 @@ Note that is very new functionality, and might change in future releases. Please
     zea data <operation> [options]                                 # manipulate zea data files
     zea convert <dataset> <src> <dst> [options]                    # convert raw datasets to zea
 
-The ``convert`` subcommand (documented below) is also available as a standalone
-module with an identical interface: ``python -m zea.data.convert <dataset> <src> <dst>``.
-
 .. tyroprogram:: zea.__main__:CLI
    :prog: zea

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -2,7 +2,7 @@ Command line interface
 ================================
 
 Besides the main :doc:`zea API documentation <_autosummary/zea>`, ``zea`` provides a
-command line interface (CLI) with three primary subcommands (process, app, data).
+command line interface (CLI) with four primary subcommands (process, app, data, convert).
 
 Note that is very new functionality, and might change in future releases. Please report any issues you encounter.
 
@@ -11,13 +11,10 @@ Note that is very new functionality, and might change in future releases. Please
     zea process --dataset <path> --config <config.yaml> [options]  # batch beamform a dataset
     zea app [--share] [--server-port PORT]                         # launch the Gradio visualizer
     zea data <operation> [options]                                 # manipulate zea data files
+    zea convert <dataset> <src> <dst> [options]                    # convert raw datasets to zea
+
+The ``convert`` subcommand (documented below) is also available as a standalone
+module with an identical interface: ``python -m zea.data.convert <dataset> <src> <dst>``.
 
 .. tyroprogram:: zea.__main__:CLI
    :prog: zea
-
--------------------------------
-Convert datasets
--------------------------------
-
-.. tyroprogram:: zea.data.convert.__main__:Dataset
-   :prog: python -m zea.data.convert

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,6 @@ extensions = [
     "sphinx_design",  # for fancy code block selection
     "sphinxcontrib.bibtex",  # for bibliography support
     "sphinx_reredirects",  # for redirecting empty toc entries
-    "sphinxcontrib.autoprogram",  # for argparse support
     "sphinx.ext.mathjax",  # for rendering math in the documentation
     "tyroprogram",  # local: auto-documents the tyro CLI (docs/source/_ext/tyroprogram.py)
 ]

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -569,8 +569,8 @@ Supported datasets & conversion
 The ``zea`` toolbox includes conversion scripts for several public ultrasound datasets,
 available in :mod:`zea.data.convert`
 (`source on GitHub <https://github.com/tue-bmd/zea/tree/main/zea/data/convert/>`__).
-They are invoked as subcommands of ``zea convert`` (or, equivalently,
-``python -m zea.data.convert``; see the full :doc:`CLI reference <cli>` for all options):
+They are invoked as subcommands of ``zea convert``
+(see the full :doc:`CLI reference <cli>` for all options):
 
 .. code-block:: shell
 

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -567,12 +567,12 @@ Supported datasets & conversion
 The ``zea`` toolbox includes conversion scripts for several public ultrasound datasets,
 available in :mod:`zea.data.convert`
 (`source on GitHub <https://github.com/tue-bmd/zea/tree/main/zea/data/convert/>`__).
-They are invoked as subcommands of ``python -m zea.data.convert``
-(see the full :doc:`CLI reference <cli>` for all options):
+They are invoked as subcommands of ``zea convert`` (or, equivalently,
+``python -m zea.data.convert``; see the full :doc:`CLI reference <cli>` for all options):
 
 .. code-block:: shell
 
-    python -m zea.data.convert <dataset> <source> <destination>
+    zea convert <dataset> <source> <destination>
 
 **Supported datasets:**
 
@@ -597,7 +597,7 @@ Record data with your Verasonics script, save the workspace to ``.mat``, then co
 
 .. code-block:: shell
 
-    python -m zea.data.convert verasonics <src> <dst>
+    zea convert verasonics <src> <dst>
 
 See :mod:`zea.data.convert.verasonics` for details.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ docs = [
     "sphinx-autodoc-typehints",
     "sphinx-copybutton",
     "sphinx_design",
-    "sphinxcontrib-autoprogram",
     "sphinx-reredirects",
     "sphinxcontrib-bibtex>=2.6.5",
     "pybtex>=0.26.1",
@@ -279,3 +278,7 @@ omit = ["/tmp/__autograph_generated_file*.py"]
 
 [tool.coverage.report]
 omit = ["zea/ops/keras_ops.py", "zea/data/app.py"]
+exclude_also = [
+    # Module entry-point guards only run as `python -m ...`, not under pytest.
+    'if __name__ == .__main__.:',
+]

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -14,5 +14,5 @@ try:
     import coverage
 
     coverage.process_startup()
-except ImportError:
+except ImportError:  # pragma: no cover - coverage is always installed during a coverage run
     pass

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,18 @@
+"""Enable coverage measurement inside subprocesses.
+
+Python imports ``sitecustomize`` automatically at interpreter startup whenever it
+is importable, which it is here because the repo root is on ``sys.path`` for
+subprocesses launched from it (e.g. ``python -m zea.data.convert`` as spawned by
+the conversion tests). ``coverage.process_startup()`` is a no-op unless the
+``COVERAGE_PROCESS_START`` environment variable points at a coverage config, so
+this module has no effect outside of a coverage run. The test suite sets that
+variable (see ``tests/conftest.py``) only while coverage is active, so the code
+executed in those subprocesses is measured and combined into the report.
+"""
+
+try:
+    import coverage
+
+    coverage.process_startup()
+except ImportError:
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,9 +143,9 @@ def _enable_subprocess_coverage():
     """
     try:
         import coverage
-    except ImportError:
+    except ImportError:  # pragma: no cover - coverage is always installed during a coverage run
         return
-    if coverage.Coverage.current() is None:
+    if coverage.Coverage.current() is None:  # pragma: no cover - only when coverage is inactive
         return
     config_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
     os.environ["COVERAGE_PROCESS_START"] = str(config_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,8 +131,30 @@ def pytest_addoption(parser):
     )
 
 
+def _enable_subprocess_coverage():
+    """Let coverage follow into subprocesses spawned by tests.
+
+    Several tests exercise CLIs through ``subprocess`` (e.g.
+    ``python -m zea.data.convert ...``); without this the code executed there is
+    invisible to coverage. When the suite runs under ``pytest --cov`` we point
+    ``COVERAGE_PROCESS_START`` at our config so the repo-root ``sitecustomize.py``
+    starts coverage in each subprocess (parallel mode writes ``.coverage.*`` files
+    that pytest-cov combines). Outside a coverage run this is a no-op.
+    """
+    try:
+        import coverage
+    except ImportError:
+        return
+    if coverage.Coverage.current() is None:
+        return
+    config_path = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    os.environ["COVERAGE_PROCESS_START"] = str(config_path)
+
+
 def pytest_configure(config):
     """Validate backend availability before importing backend-dependent test modules."""
+    _enable_subprocess_coverage()
+
     for backend in ML_BACKENDS:
         config.addinivalue_line("markers", f"{backend}: test requires the {backend} backend")
 

--- a/tests/data/test_conversion_scripts.py
+++ b/tests/data/test_conversion_scripts.py
@@ -1,6 +1,5 @@
 """Test dataset conversion scripts"""
 
-import argparse
 import csv
 import os
 import shutil
@@ -15,8 +14,10 @@ import imageio
 import numpy as np
 import pytest
 import SimpleITK as sitk
+import tyro
 import yaml
 
+from zea.data.convert.__main__ import Dataset
 from zea.data.convert.images import convert_image_dataset
 from zea.data.convert.utils import (
     check_output_dir_ownership,
@@ -96,9 +97,9 @@ def test_conversion_script(tmp_path_factory, dataset):
                 dataset,
                 str(src),
                 str(dst2),
-                "--split_path",
+                "--split-path",
                 str(dst),
-                "--no_hyperthreading",
+                "--no-hyperthreading",
             ],
             env=create_env_for_dataset(dataset),
         )
@@ -465,7 +466,7 @@ def create_camus_test_data(src):
             gt_image, str(patient_folder / f"{patient_name}_2CH_half_sequence_gt.nii.gz")
         )
 
-    return ["--no_hyperthreading"]  # for code coverage to hit
+    return ["--no-hyperthreading"]  # for code coverage to hit
 
 
 def create_cetus_test_data(src):
@@ -497,7 +498,7 @@ def create_cetus_test_data(src):
             gt_image.SetSpacing((0.0005763, 0.0005763, 0.0005763))
             sitk.WriteImage(gt_image, str(patient_dir / f"{patient_name}_{tp}_gt.nii.gz"))
 
-    return ["--no_hyperthreading"]  # for code coverage to hit
+    return ["--no-hyperthreading"]  # for code coverage to hit
 
 
 def create_picmus_test_data(src):
@@ -1031,18 +1032,7 @@ def test_echoxflow_conversion_script(tmp_path_factory, monkeypatch):
 
     expected = create_echoxflow_test_data(src, monkeypatch)
 
-    args = argparse.Namespace(
-        src=str(src),
-        dst=str(dst),
-        croissant=None,
-        min_frames=10,
-        min_fps=30.0,
-        limit=None,
-        overwrite=False,
-        upload=False,
-        revision=None,
-        hf_repo_id="",
-    )
+    args = tyro.cli(Dataset, args=["echoxflow", str(src), str(dst)])  # ty: ignore[no-matching-overload]
     convert_echoxflow(args)
 
     verify_converted_echoxflow_test_data(dst, expected)
@@ -1055,18 +1045,7 @@ def test_echoxflow_missing_package_raises(monkeypatch):
     # Ensure importing echoxflow fails even if it ever gets installed.
     monkeypatch.setitem(sys.modules, "echoxflow", None)
 
-    args = argparse.Namespace(
-        src="/tmp/echoxflow_src",
-        dst="/tmp/echoxflow_dst",
-        croissant=None,
-        min_frames=10,
-        min_fps=30.0,
-        limit=None,
-        overwrite=False,
-        upload=False,
-        revision=None,
-        hf_repo_id="",
-    )
+    args = tyro.cli(Dataset, args=["echoxflow", "/tmp/echoxflow_src", "/tmp/echoxflow_dst"])  # ty: ignore[no-matching-overload]
     with pytest.raises(ImportError, match="Install it from GitHub"):
         convert_echoxflow(args)
 
@@ -1360,15 +1339,9 @@ def test_verasonics_upload_requires_hf_repo_id(tmp_path, monkeypatch):
     src.mkdir()
     dst.mkdir()
 
-    args = argparse.Namespace(
-        src=str(src),
-        dst=str(dst),
-        frames=None,
-        allow_accumulate=False,
-        device="cpu",
-        upload=True,
-        hf_repo_id="",
-        revision="test-branch",
+    args = tyro.cli(  # ty: ignore[no-matching-overload]
+        Dataset,
+        args=["verasonics", str(src), str(dst), "--upload", "--revision", "test-branch"],
     )
 
     monkeypatch.setattr("zea.data.convert.verasonics.init_device", lambda *_: None)
@@ -1384,15 +1357,9 @@ def test_verasonics_upload_requires_revision(tmp_path, monkeypatch):
     src.mkdir()
     dst.mkdir()
 
-    args = argparse.Namespace(
-        src=str(src),
-        dst=str(dst),
-        frames=None,
-        allow_accumulate=False,
-        device="cpu",
-        upload=True,
-        hf_repo_id="zeahub/test-dataset",
-        revision=None,
+    args = tyro.cli(  # ty: ignore[no-matching-overload]
+        Dataset,
+        args=["verasonics", str(src), str(dst), "--upload", "--hf-repo-id", "zeahub/test-dataset"],
     )
 
     monkeypatch.setattr("zea.data.convert.verasonics.init_device", lambda *_: None)

--- a/tests/data/test_convert_main.py
+++ b/tests/data/test_convert_main.py
@@ -1,0 +1,242 @@
+"""Lightweight tests for the ``python -m zea.data.convert`` CLI (zea.data.convert.__main__)."""
+
+import contextlib
+import io
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import tyro
+
+from zea.data.convert.__main__ import (
+    Dataset,
+    _Camus,
+    _Cetus,
+    _Echonet,
+    _EchonetLVH,
+    _EchoXFlow,
+    _Picmus,
+    _Verasonics,
+)
+
+
+def parse_args(argv):
+    return tyro.cli(Dataset, args=argv)  # ty: ignore[no-matching-overload]
+
+
+# ── parser structure ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "cls"),
+    [
+        ("echonet", _Echonet),
+        ("echonetlvh", _EchonetLVH),
+        ("camus", _Camus),
+        ("cetus", _Cetus),
+        ("picmus", _Picmus),
+        ("verasonics", _Verasonics),
+        ("echoxflow", _EchoXFlow),
+    ],
+)
+def test_all_subcommands_exist(subcommand, cls):
+    """Every dataset must be registered as a subcommand and parse to its dataclass."""
+    args = parse_args([subcommand, "src", "dst"])
+    assert isinstance(args, cls)
+
+
+def test_no_subcommand_exits_nonzero():
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args([])
+    assert exc_info.value.code != 0
+
+
+def test_unknown_subcommand_exits_nonzero():
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(["not-a-dataset", "src", "dst"])
+    assert exc_info.value.code != 0
+
+
+def test_top_level_help_exits_zero():
+    buf = io.StringIO()
+    with pytest.raises(SystemExit) as exc_info, contextlib.redirect_stdout(buf):
+        parse_args(["--help"])
+    assert exc_info.value.code == 0
+    assert "echonet" in buf.getvalue()
+
+
+# ── positional src/dst (shared across all datasets) ────────────────────────────
+
+
+def test_positional_src_dst_required():
+    with pytest.raises(SystemExit):
+        parse_args(["camus"])
+
+
+def test_positional_src_dst_parsed_as_path():
+    args = parse_args(["camus", "raw/", "output/"])
+    assert args.src == Path("raw/")
+    assert args.dst == Path("output/")
+
+
+# ── echonet ──────────────────────────────────────────────────────────────────
+
+
+def test_echonet_defaults():
+    args = parse_args(["echonet", "src", "dst"])
+    assert args.split_path is None
+    assert args.no_hyperthreading is False
+
+
+def test_echonet_flags():
+    args = parse_args(
+        ["echonet", "src", "dst", "--split-path", "split.yaml", "--no-hyperthreading"]
+    )
+    assert args.split_path == Path("split.yaml")
+    assert args.no_hyperthreading is True
+
+
+# ── camus ────────────────────────────────────────────────────────────────────
+
+
+def test_camus_defaults():
+    args = parse_args(["camus", "src", "dst"])
+    assert args.download is False
+    assert args.no_hyperthreading is False
+    assert args.upload is False
+    assert args.revision is None
+    assert args.reduced_dataset is False
+
+
+def test_camus_flags():
+    args = parse_args(
+        ["camus", "src", "dst", "--download", "--upload", "--revision", "v1", "--reduced-dataset"]
+    )
+    assert args.download is True
+    assert args.upload is True
+    assert args.revision == "v1"
+    assert args.reduced_dataset is True
+
+
+# ── verasonics ───────────────────────────────────────────────────────────────
+
+
+def test_verasonics_defaults():
+    args = parse_args(["verasonics", "src", "dst"])
+    assert args.frames is None
+    assert args.allow_accumulate is False
+    assert args.device == "cpu"
+    assert args.upload is False
+    assert args.revision is None
+    assert args.hf_repo_id == ""
+
+
+def test_verasonics_flags():
+    args = parse_args(
+        [
+            "verasonics",
+            "src",
+            "dst",
+            "--frames",
+            "0-3",
+            "7",
+            "--allow-accumulate",
+            "--device",
+            "gpu:0",
+            "--upload",
+            "--revision",
+            "v1",
+            "--hf-repo-id",
+            "zeahub/test",
+        ]
+    )
+    assert args.frames == ["0-3", "7"]
+    assert args.allow_accumulate is True
+    assert args.device == "gpu:0"
+    assert args.hf_repo_id == "zeahub/test"
+
+
+# ── echoxflow ────────────────────────────────────────────────────────────────
+
+
+def test_echoxflow_defaults():
+    args = parse_args(["echoxflow", "src", "dst"])
+    assert args.croissant is None
+    assert args.min_frames == 10
+    assert args.min_fps == 30.0
+    assert args.limit is None
+    assert args.overwrite is False
+    assert args.hf_repo_id == ""
+
+
+def test_echoxflow_flags():
+    args = parse_args(
+        [
+            "echoxflow",
+            "src",
+            "dst",
+            "--min-frames",
+            "5",
+            "--min-fps",
+            "15",
+            "--limit",
+            "2",
+            "--overwrite",
+        ]
+    )
+    assert args.min_frames == 5
+    assert args.min_fps == 15
+    assert args.limit == 2
+    assert args.overwrite is True
+
+
+# ── dispatch (.run() forwards the parsed args to the right converter) ──────────
+
+
+@pytest.mark.parametrize(
+    ("subcommand", "converter_path", "cls"),
+    [
+        ("echonet", "zea.data.convert.echonet.convert_echonet", _Echonet),
+        ("camus", "zea.data.convert.camus.convert_camus", _Camus),
+        ("cetus", "zea.data.convert.cetus.convert_cetus", _Cetus),
+        ("picmus", "zea.data.convert.picmus.convert_picmus", _Picmus),
+        ("verasonics", "zea.data.convert.verasonics.convert_verasonics", _Verasonics),
+        ("echoxflow", "zea.data.convert.echoxflow.convert_echoxflow", _EchoXFlow),
+    ],
+)
+def test_run_dispatches_to_converter(subcommand, converter_path, cls):
+    """Each dataclass's run() imports and calls its converter with itself."""
+    args = parse_args([subcommand, "src", "dst"])
+    with patch(converter_path) as mock_convert:
+        args.run()
+    assert mock_convert.call_count == 1
+    (called_args,), _ = mock_convert.call_args
+    assert called_args is args
+    assert isinstance(called_args, cls)
+
+
+def test_echonetlvh_run_forwards_positional_args():
+    """EchonetLVH's run() forwards individual fields (not the dataclass) to its converter."""
+    args = parse_args(["echonetlvh", "src", "dst", "--max-workers", "2"])
+    with patch("zea.data.convert.echonetlvh.convert_echonetlvh") as mock_convert:
+        args.run()
+    assert mock_convert.call_count == 1
+    call_args, _ = mock_convert.call_args
+    assert call_args[0] == args.src
+    assert call_args[1] == args.dst
+    assert call_args[-1] == 2  # max_workers
+
+
+def test_main_dispatches_to_run(monkeypatch):
+    """zea.data.convert.__main__.main() parses argv and calls .run() on the result."""
+    monkeypatch.setattr("sys.argv", ["zea-convert", "camus", "src", "dst", "--download"])
+
+    with patch("zea.data.convert.camus.convert_camus") as mock_convert:
+        from zea.data.convert.__main__ import main
+
+        main()
+
+    assert mock_convert.call_count == 1
+    (called_args,), _ = mock_convert.call_args
+    assert isinstance(called_args, _Camus)
+    assert called_args.download is True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import io
+from unittest.mock import patch
 
 import pytest
 import tyro
@@ -139,6 +140,55 @@ def test_app_flags():
     args = cli_args.subcommand
     assert args.share is True
     assert args.server_port == 7861
+
+
+# ── convert subcommand ────────────────────────────────────────────────────────
+
+
+def test_convert_subcommand_exists():
+    """The 'convert' subcommand parses to ConvertArgs wrapping the dataset dataclass."""
+    from zea.cli_args import ConvertArgs, _Camus
+
+    cli_args = parse_args(["convert", "camus", "raw/", "out/"])
+    assert isinstance(cli_args.subcommand, ConvertArgs)
+    assert isinstance(cli_args.subcommand.subcommand, _Camus)
+    assert cli_args.subcommand.subcommand.download is False
+
+
+def test_convert_help_lists_datasets():
+    """zea convert --help should print the dataset subcommands and exit 0."""
+    buf = io.StringIO()
+    with pytest.raises(SystemExit) as exc_info, contextlib.redirect_stdout(buf):
+        parse_args(["convert", "--help"])
+    assert exc_info.value.code == 0
+    assert "echonet" in buf.getvalue()
+
+
+def test_convert_main_dispatches_without_preallocating(monkeypatch):
+    """zea.__main__.main() routes 'convert' to the converter with allow_preallocate=False."""
+    monkeypatch.setattr("sys.argv", ["zea", "convert", "camus", "raw/", "out/", "--download"])
+
+    captured = {}
+
+    def fake_init_device(device="auto:1", **kwargs):
+        captured["allow_preallocate"] = kwargs.get("allow_preallocate", True)
+
+    with (
+        patch("zea.internal.device.init_device", side_effect=fake_init_device),
+        patch("zea.data.convert.camus.convert_camus") as mock_convert,
+    ):
+        from zea.__main__ import main
+
+        main()
+
+    # Conversion must not preallocate the full GPU (mirrors the standalone entry point).
+    assert captured["allow_preallocate"] is False
+    assert mock_convert.call_count == 1
+    (called_args,), _ = mock_convert.call_args
+    from zea.cli_args import _Camus
+
+    assert isinstance(called_args, _Camus)
+    assert called_args.download is True
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -6493,20 +6493,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinxcontrib-autoprogram"
-version = "0.1.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c8/5f/044c87c306c9cbac68a4dccacb18ca0fdd4973096fdd92304ea069b11c59/sphinxcontrib-autoprogram-0.1.9.tar.gz", hash = "sha256:219655507fadca29b3062b5d86c37d94db48f03bde4b58d61526872bf72f57cc", size = 18843, upload-time = "2024-03-13T19:10:14.445Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/4c/5d9fb7caee7a765c2daf48cdf097c396eef3e1370290589f1b9e30266694/sphinxcontrib_autoprogram-0.1.9-py2.py3-none-any.whl", hash = "sha256:79a5282d7640337e4bf11f624970a43709f1b704c5c59a59756d45e824db5301", size = 8900, upload-time = "2024-03-13T19:10:12.528Z" },
-]
-
-[[package]]
 name = "sphinxcontrib-bibtex"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7643,7 +7629,6 @@ dev = [
     { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-reredirects", version = "0.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-reredirects", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-autoprogram" },
     { name = "sphinxcontrib-bibtex" },
     { name = "ty" },
 ]
@@ -7675,7 +7660,6 @@ docs = [
     { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-reredirects", version = "0.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-reredirects", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "sphinxcontrib-autoprogram" },
     { name = "sphinxcontrib-bibtex" },
 ]
 jax = [
@@ -7746,7 +7730,6 @@ requires-dist = [
     { name = "sphinx-copybutton", marker = "extra == 'docs'" },
     { name = "sphinx-design", marker = "extra == 'docs'" },
     { name = "sphinx-reredirects", marker = "extra == 'docs'" },
-    { name = "sphinxcontrib-autoprogram", marker = "extra == 'docs'" },
     { name = "sphinxcontrib-bibtex", marker = "extra == 'docs'", specifier = ">=2.6.5" },
     { name = "tensorflow", marker = "extra == 'backends'", specifier = ">=2.12.1" },
     { name = "torch", marker = "extra == 'backends'", specifier = ">=2.2" },

--- a/zea/__main__.py
+++ b/zea/__main__.py
@@ -5,6 +5,7 @@ Usage::
     zea process --dataset <path> --config <config.yaml> [options]  # batch beamform a dataset
     zea app [--share] [--server-port PORT]                         # launch the Gradio visualizer
     zea data <operation> [options]                                 # manipulate zea data files
+    zea convert <dataset> <src> <dst> [options]                    # convert raw datasets to zea
 
 """
 
@@ -19,7 +20,7 @@ if "ZEA_LOG_LEVEL" not in os.environ:
 
     log.set_level("WARNING")
 
-from zea.cli_args import AppArgs, DataArgs, ProcessArgs
+from zea.cli_args import AppArgs, ConvertArgs, DataArgs, ProcessArgs
 
 # subcommands that don't require a device
 _NO_DEVICE_FNS = [DataArgs]
@@ -34,6 +35,7 @@ class CLI:
             Annotated[ProcessArgs, tyro.conf.subcommand("process")],
             Annotated[AppArgs, tyro.conf.subcommand("app")],
             Annotated[DataArgs, tyro.conf.subcommand("data")],
+            Annotated[ConvertArgs, tyro.conf.subcommand("convert")],
         ]
     ]
     device: Annotated[
@@ -61,7 +63,9 @@ def main() -> None:
     if _check_if_device_needed(args):
         from zea.internal.device import init_device
 
-        init_device(cli_args.device)
+        # Conversion runs should not preallocate the full GPU, mirroring the
+        # standalone ``python -m zea.data.convert`` entry point.
+        init_device(cli_args.device, allow_preallocate=not isinstance(args, ConvertArgs))
 
     if isinstance(args, ProcessArgs):
         from zea.data.process import run_processing
@@ -99,7 +103,7 @@ def main() -> None:
             theme=gr.themes.Soft(primary_hue="violet", secondary_hue="yellow"),
             css=CSS,
         )
-    elif isinstance(args, DataArgs):
+    elif isinstance(args, (DataArgs, ConvertArgs)):
         args.run()
     else:
         raise ValueError(f"Unknown command: {args}")

--- a/zea/cli_args.py
+++ b/zea/cli_args.py
@@ -335,3 +335,245 @@ class DataArgs:
 
     def run(self) -> None:
         _run_data_command(self.subcommand)
+
+
+# ── Dataset conversion subcommands (``zea convert …``) ────────────────────────
+#
+# Thin CLI dataclasses for converting raw open-source ultrasound datasets to the
+# zea format. Each dataset's fields become CLI arguments; its ``run`` method
+# imports the heavy converter from :mod:`zea.data.convert` lazily and dispatches to
+# it. They live here (rather than under ``zea.data.convert``) so that ``zea
+# --help`` / ``zea convert --help`` render without importing an ML backend —
+# importing ``zea.data`` eagerly pulls in keras.
+
+
+@dataclass
+class _Echonet:
+    """Convert Echonet dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    split_path: Path | None = None
+    """Path to the split.yaml file containing the dataset split if a split should be copied."""
+    no_hyperthreading: bool = False
+    """Disable hyperthreading for multiprocessing."""
+
+    def run(self):
+        from zea.data.convert.echonet import convert_echonet
+
+        convert_echonet(self)
+
+
+@dataclass
+class _EchonetLVH:
+    """Convert EchonetLVH dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    no_rejection: bool = False
+    """Do not reject sequences in `manual_rejections.txt`."""
+    rejection_path: Path | None = None
+    """Path to custom rejection txt file (defaults to `manual_rejections.txt` from zea)."""
+    convert_measurements: bool = False
+    """Only convert measurements CSV file."""
+    convert_images: bool = False
+    """Only convert image files."""
+    max_files: int | None = None
+    """Maximum number of files to process (for testing)."""
+    force: bool = False
+    """Force recomputation even if parameters already exist."""
+    max_workers: int = 4
+    """Maximum number of workers to use for precomputing cone parameters and dataloading."""
+
+    def run(self):
+        from zea.data.convert.echonetlvh import convert_echonetlvh
+
+        convert_echonetlvh(
+            self.src,
+            self.dst,
+            self.no_rejection,
+            self.rejection_path,
+            self.convert_measurements,
+            self.convert_images,
+            self.max_files,
+            self.force,
+            self.max_workers,
+        )
+
+
+@dataclass
+class _Camus:
+    """Convert CAMUS dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path, should contain either manually downloaded dataset or will be
+    target location for automated download with the --download flag."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    download: bool = False
+    """Download the CAMUS dataset from the server, will be saved to the --src path."""
+    no_hyperthreading: bool = False
+    """Disable hyperthreading for multiprocessing."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/camus or zeahub/camus-sample)."""
+    revision: str | None = None
+    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
+    Upload to 'main' is not allowed."""
+    reduced_dataset: bool = False
+    """Only convert and upload a small hardcoded sample subset (camus-sample)."""
+
+    def run(self):
+        from zea.data.convert.camus import convert_camus
+
+        convert_camus(self)
+
+
+@dataclass
+class _Cetus:
+    """Convert CETUS dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path, should contain either manually downloaded dataset or will be
+    target location for automated download with the --download flag."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    download: bool = False
+    """Download the CETUS dataset from the server, will be saved to the --src path."""
+    no_hyperthreading: bool = False
+    """Disable hyperthreading for multiprocessing."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/cetus-miccai-2014)."""
+    revision: str | None = None
+    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
+    Upload to 'main' is not allowed."""
+
+    def run(self):
+        from zea.data.convert.cetus import convert_cetus
+
+        convert_cetus(self)
+
+
+@dataclass
+class _Picmus:
+    """Convert PICMUS dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path. Should contain either a manually downloaded and extracted
+    archive (archive_to_download/ or picmus.zip) or will be used as the download target
+    when --download is given. An 'in_vivo/' sub-directory, if present, is automatically
+    included."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    download: bool = False
+    """Download both the main PICMUS dataset and the in-vivo partition from the PICMUS
+    challenge website before converting."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/picmus)."""
+    revision: str | None = None
+    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
+    Upload to 'main' is not allowed."""
+
+    def run(self):
+        from zea.data.convert.picmus import convert_picmus
+
+        convert_picmus(self)
+
+
+@dataclass
+class _Verasonics:
+    """Convert Verasonics data to zea dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    frames: list[str] | None = None
+    """The frames to add to the file. This can be a list of integers, a range of integers
+    (e.g. 4-8), or 'all'. Defaults to 'all', unless specified in a convert.yaml file."""
+    allow_accumulate: bool = False
+    """Sometimes, some transmits are already accumulated on the Verasonics system (e.g.
+    harmonic imaging through pulse inversion). In this case, the mode in the Receive
+    structure is set to 1 (accumulate). If this flag is set, such files will be processed.
+    Otherwise, an error is raised when such a mode is detected."""
+    device: str = "cpu"
+    """Device to use for conversion (e.g., 'cpu' or 'gpu:0')."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub after conversion. Only for zea
+    maintainers with push access to the repository."""
+    revision: str | None = None
+    """Required when --upload is set. Upload to 'main' is not allowed."""
+    hf_repo_id: str = ""
+    """HuggingFace repo ID for ownership checks and optional upload. Required if --upload
+    is set."""
+
+    def run(self):
+        from zea.data.convert.verasonics import convert_verasonics
+
+        convert_verasonics(self)
+
+
+@dataclass
+class _EchoXFlow:
+    """Convert EchoXFlow dataset."""
+
+    src: tyro.conf.Positional[str]
+    """EchoXFlow data root, e.g. /data/EchoXFlow/data"""
+    dst: tyro.conf.Positional[str]
+    """Destination folder path."""
+    croissant: str | None = None
+    """Path to croissant.json (default: <src>/croissant.json)."""
+    min_frames: int = 10
+    """Minimum B-mode frame count."""
+    min_fps: float = 30.0
+    """Minimum frame rate (Hz)."""
+    limit: int | None = None
+    """Convert at most N recordings."""
+    overwrite: bool = False
+    """Overwrite existing output files."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/echoxflow)."""
+    revision: str | None = None
+    """Target branch on the Hub. Required when --upload is set; upload to 'main' is
+    blocked."""
+    hf_repo_id: str = ""
+    """HuggingFace repo id for ownership checks and optional upload (default:
+    zeahub/echoxflow)."""
+
+    def run(self):
+        from zea.data.convert.echoxflow import convert_echoxflow
+
+        convert_echoxflow(self)
+
+
+ConvertDataset = Union[
+    Annotated[_Echonet, tyro.conf.subcommand("echonet")],
+    Annotated[_EchonetLVH, tyro.conf.subcommand("echonetlvh")],
+    Annotated[_Camus, tyro.conf.subcommand("camus")],
+    Annotated[_Cetus, tyro.conf.subcommand("cetus")],
+    Annotated[_Picmus, tyro.conf.subcommand("picmus")],
+    Annotated[_Verasonics, tyro.conf.subcommand("verasonics")],
+    Annotated[_EchoXFlow, tyro.conf.subcommand("echoxflow")],
+]
+
+
+@dataclass
+class ConvertArgs:
+    """Convert raw open-source ultrasound datasets to the zea format.
+
+    Pick a dataset subcommand and provide the source and destination folders::
+
+        zea convert camus ./raw ./output --download
+        zea convert echonet ./raw ./output
+        zea convert echoxflow ./raw ./output
+
+    Run ``zea convert <dataset> --help`` for the per-dataset options.
+    """
+
+    subcommand: tyro.conf.OmitSubcommandPrefixes[ConvertDataset]
+
+    def run(self) -> None:
+        self.subcommand.run()

--- a/zea/data/chunk_reader.py
+++ b/zea/data/chunk_reader.py
@@ -680,7 +680,9 @@ def _ticker(
     from tqdm.auto import tqdm  # tqdm.auto: renders as a widget in notebooks, text elsewhere
 
     name = Path(fetcher.source).name if fetcher.source else "data"
-    with tqdm(total=total, unit="B", unit_scale=True, desc=f"streaming {name}") as bar:
+    # per_chunk is local-only (see Fetcher.per_chunk); HTTP is what's actually "streaming".
+    verb = "reading" if fetcher.per_chunk else "streaming"
+    with tqdm(total=total, unit="B", unit_scale=True, desc=f"{verb} {name}") as bar:
         yield bar.update
 
 

--- a/zea/data/convert/__main__.py
+++ b/zea/data/convert/__main__.py
@@ -1,10 +1,8 @@
 """CLI for converting common open-source ultrasound datasets to the zea format.
 
-The converters are available both as a subcommand of the ``zea`` command line tool
-and as a standalone module:
+Use the ``zea convert`` subcommand::
 
-    zea convert <dataset> <src> <dst> [options]        # preferred
-    python -m zea.data.convert <dataset> <src> <dst>   # equivalent
+    zea convert <dataset> <src> <dst> [options]
 
 Examples::
 
@@ -13,11 +11,12 @@ Examples::
     zea convert echonet ./raw ./output
     zea convert echoxflow ./raw ./output
 
-Run ``zea convert --help`` (or ``python -m zea.data.convert --help``) for all options.
+Run ``zea convert --help`` for all options.
 
-The CLI dataclasses themselves live in :mod:`zea.cli_args` (kept free of heavy
-imports so ``zea --help`` renders without loading an ML backend); they are
-re-exported here for backwards compatibility.
+Running this module directly (``python -m zea.data.convert ...``) remains supported
+for backwards compatibility. The CLI dataclasses live in :mod:`zea.cli_args` (kept
+free of heavy imports so ``zea --help`` renders without loading an ML backend) and
+are re-exported here.
 """
 
 import tyro

--- a/zea/data/convert/__main__.py
+++ b/zea/data/convert/__main__.py
@@ -14,367 +14,232 @@ Examples::
 Run ``python -m zea.data.convert --help`` for all options.
 """
 
-import argparse
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Annotated, Union
+
+import tyro
 
 from zea.internal.device import init_device
 
 
-def _add_parser_args_echonet(subparsers):
-    """Add Echonet specific arguments to the parser."""
-    echonet_parser = subparsers.add_parser("echonet", help="Convert Echonet dataset")
-    echonet_parser.add_argument("src", type=Path, help="Source folder path")
-    echonet_parser.add_argument("dst", type=Path, help="Destination folder path")
-    echonet_parser.add_argument(
-        "--split_path",
-        type=Path,
-        help="Path to the split.yaml file containing the dataset split if a split should be copied",
-    )
-    echonet_parser.add_argument(
-        "--no_hyperthreading",
-        action="store_true",
-        help="Disable hyperthreading for multiprocessing",
-    )
+@dataclass
+class _Echonet:
+    """Convert Echonet dataset."""
 
+    src: tyro.conf.Positional[Path]
+    """Source folder path."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    split_path: Path | None = None
+    """Path to the split.yaml file containing the dataset split if a split should be copied."""
+    no_hyperthreading: bool = False
+    """Disable hyperthreading for multiprocessing."""
 
-def _add_parser_args_camus(subparsers):
-    """Add CAMUS specific arguments to the parser."""
-    camus_parser = subparsers.add_parser("camus", help="Convert CAMUS dataset")
-    camus_parser.add_argument(
-        "src",
-        type=Path,
-        help=(
-            "Source folder path, should contain either manually downloaded dataset "
-            "or will be target location for automated download with the --download flag"
-        ),
-    )
-    camus_parser.add_argument("dst", type=Path, help="Destination folder path")
-    camus_parser.add_argument(
-        "--download",
-        action="store_true",
-        help="Download the CAMUS dataset from the server, will be saved to the --src path",
-    )
-    camus_parser.add_argument(
-        "--no_hyperthreading",
-        action="store_true",
-        help="Disable hyperthreading for multiprocessing",
-    )
-    camus_parser.add_argument(
-        "--upload",
-        action="store_true",
-        help=(
-            "Upload the converted dataset to HuggingFace Hub (zeahub/camus or zeahub/camus-sample)"
-        ),
-    )
-    camus_parser.add_argument(
-        "--revision",
-        type=str,
-        default=None,
-        help=(
-            "Revision branch to upload to on HuggingFace Hub. "
-            "Required when --upload is set. Upload to 'main' is not allowed."
-        ),
-    )
-    camus_parser.add_argument(
-        "--reduced-dataset",
-        dest="reduced_dataset",
-        action="store_true",
-        help="Only convert and upload a small hardcoded sample subset (camus-sample).",
-    )
-
-
-def _add_parser_args_echonetlvh(subparsers):
-    """Add EchonetLVH specific arguments to the parser."""
-    echonetlvh_parser = subparsers.add_parser("echonetlvh", help="Convert EchonetLVH dataset")
-    echonetlvh_parser.add_argument("src", type=Path, help="Source folder path")
-    echonetlvh_parser.add_argument("dst", type=Path, help="Destination folder path")
-    echonetlvh_parser.add_argument(
-        "--no_rejection",
-        action="store_true",
-        help="Do not reject sequences in `manual_rejections.txt`",
-    )
-    echonetlvh_parser.add_argument(
-        "--rejection_path",
-        type=Path,
-        default=None,
-        help="Path to custom rejection txt file (defaults to `manual_rejections.txt` from zea)",
-    )
-    echonetlvh_parser.add_argument(
-        "--convert_measurements",
-        action="store_true",
-        help="Only convert measurements CSV file",
-    )
-    echonetlvh_parser.add_argument(
-        "--convert_images",
-        action="store_true",
-        help="Only convert image files",
-    )
-    echonetlvh_parser.add_argument(
-        "--max_files",
-        type=int,
-        default=None,
-        help="Maximum number of files to process (for testing)",
-    )
-    echonetlvh_parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Force recomputation even if parameters already exist",
-    )
-    echonetlvh_parser.add_argument(
-        "--max_workers",
-        type=int,
-        default=4,
-        help="Maximum number of workers to use for precomputing cone parameters and dataloading.",
-    )
-
-
-def _add_parser_args_picmus(subparsers):
-    """Add PICMUS specific arguments to the parser."""
-    picmus_parser = subparsers.add_parser("picmus", help="Convert PICMUS dataset")
-    picmus_parser.add_argument(
-        "src",
-        type=Path,
-        help=(
-            "Source folder path. Should contain either a manually downloaded and "
-            "extracted archive (archive_to_download/ or picmus.zip) or will be used "
-            "as the download target when --download is given. An 'in_vivo/' "
-            "sub-directory, if present, is automatically included."
-        ),
-    )
-    picmus_parser.add_argument("dst", type=Path, help="Destination folder path")
-    picmus_parser.add_argument(
-        "--download",
-        action="store_true",
-        help=(
-            "Download both the main PICMUS dataset and the in-vivo partition "
-            "from the PICMUS challenge website before converting."
-        ),
-    )
-    picmus_parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload the converted dataset to HuggingFace Hub (zeahub/picmus).",
-    )
-    picmus_parser.add_argument(
-        "--revision",
-        type=str,
-        default=None,
-        help=(
-            "Revision branch to upload to on HuggingFace Hub. "
-            "Required when --upload is set. Upload to 'main' is not allowed."
-        ),
-    )
-
-
-def _add_parser_args_cetus(subparsers):
-    """Add CETUS specific arguments to the parser."""
-    cetus_parser = subparsers.add_parser("cetus", help="Convert CETUS dataset")
-    cetus_parser.add_argument(
-        "src",
-        type=Path,
-        help=(
-            "Source folder path, should contain either manually downloaded dataset "
-            "or will be target location for automated download with the --download flag"
-        ),
-    )
-    cetus_parser.add_argument("dst", type=Path, help="Destination folder path")
-    cetus_parser.add_argument(
-        "--download",
-        action="store_true",
-        help="Download the CETUS dataset from the server, will be saved to the --src path",
-    )
-    cetus_parser.add_argument(
-        "--no_hyperthreading",
-        action="store_true",
-        help="Disable hyperthreading for multiprocessing",
-    )
-    cetus_parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload the converted dataset to HuggingFace Hub (zeahub/cetus-miccai-2014).",
-    )
-    cetus_parser.add_argument(
-        "--revision",
-        type=str,
-        default=None,
-        help=(
-            "Revision branch to upload to on HuggingFace Hub. "
-            "Required when --upload is set. Upload to 'main' is not allowed."
-        ),
-    )
-
-
-def _add_parser_args_verasonics(subparsers):
-    verasonics_parser = subparsers.add_parser(
-        "verasonics", help="Convert Verasonics data to zea dataset"
-    )
-    verasonics_parser.add_argument("src", type=Path, help="Source folder path")
-    verasonics_parser.add_argument("dst", type=Path, help="Destination folder path")
-    verasonics_parser.add_argument(
-        "--frames",
-        type=str,
-        nargs="+",
-        help="The frames to add to the file. This can be a list of integers, a range "
-        "of integers (e.g. 4-8), or 'all'. Defaults to 'all', unless specified in a "
-        "convert.yaml file.",
-    )
-    verasonics_parser.add_argument(
-        "--allow_accumulate",
-        action="store_true",
-        help=(
-            "Sometimes, some transmits are already accumulated on the Verasonics system "
-            "(e.g. harmonic imaging through pulse inversion). In this case, the mode in the "
-            "Receive structure is set to 1 (accumulate). If this flag is set, such files "
-            "will be processed. Otherwise, an error is raised when such a mode is detected."
-        ),
-    )
-    verasonics_parser.add_argument(
-        "--device",
-        type=str,
-        default="cpu",
-        help="Device to use for conversion (e.g., 'cpu' or 'gpu:0').",
-    )
-    verasonics_parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload the converted dataset to HuggingFace Hub after conversion. "
-        "Only for zea maintainers with push access to the repository.",
-    )
-    verasonics_parser.add_argument(
-        "--revision",
-        type=str,
-        default=None,
-        help="Required when --upload is set. Upload to 'main' is not allowed.",
-    )
-    verasonics_parser.add_argument(
-        "--hf_repo_id",
-        type=str,
-        default="",
-        help="HuggingFace repo ID for ownership checks and optional upload. "
-        "Required if --upload is set.",
-    )
-
-
-def _add_parser_args_echoxflow(subparsers):
-    """Add EchoXFlow specific arguments to the parser."""
-    echoxflow_parser = subparsers.add_parser("echoxflow", help="Convert EchoXFlow dataset")
-    echoxflow_parser.add_argument(
-        "src", type=str, help="EchoXFlow data root, e.g. /data/EchoXFlow/data"
-    )
-    echoxflow_parser.add_argument("dst", type=str, help="Destination folder path")
-    echoxflow_parser.add_argument(
-        "--croissant",
-        type=str,
-        default=None,
-        help="Path to croissant.json (default: <src>/croissant.json).",
-    )
-    echoxflow_parser.add_argument(
-        "--min-frames", type=int, default=10, help="Minimum B-mode frame count."
-    )
-    echoxflow_parser.add_argument(
-        "--min-fps", type=float, default=30.0, help="Minimum frame rate (Hz)."
-    )
-    echoxflow_parser.add_argument(
-        "--limit", type=int, default=None, help="Convert at most N recordings."
-    )
-    echoxflow_parser.add_argument(
-        "--overwrite", action="store_true", help="Overwrite existing output files."
-    )
-    echoxflow_parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload the converted dataset to HuggingFace Hub (zeahub/echoxflow).",
-    )
-    echoxflow_parser.add_argument(
-        "--revision",
-        type=str,
-        default=None,
-        help="Target branch on the Hub. Required when --upload is set; upload to 'main' "
-        "is blocked.",
-    )
-    echoxflow_parser.add_argument(
-        "--hf_repo_id",
-        type=str,
-        default="",
-        help="HuggingFace repo id for ownership checks and optional upload "
-        "(default: zeahub/echoxflow).",
-    )
-
-
-def get_parser():
-    """Build and parse command-line arguments for converting raw datasets to a zea dataset."""
-    parser = argparse.ArgumentParser(description="Convert raw data to a zea dataset.")
-    subparsers = parser.add_subparsers(dest="dataset", required=True)
-    _add_parser_args_echonet(subparsers)
-    _add_parser_args_echonetlvh(subparsers)
-    _add_parser_args_camus(subparsers)
-    _add_parser_args_cetus(subparsers)
-    _add_parser_args_picmus(subparsers)
-    _add_parser_args_verasonics(subparsers)
-    _add_parser_args_echoxflow(subparsers)
-    return parser
-
-
-def main():
-    """
-    Parse command-line arguments and dispatch to the selected dataset conversion routine.
-
-    This function obtains CLI arguments via get_args() and calls the corresponding converter.
-
-    Current supported datasets are:
-    - echonet
-    - echonetlvh
-    - camus
-    - cetus
-    - picmus
-    - verasonics
-    - echoxflow
-
-    Raises a ValueError if args.dataset is not one of the supported choices.
-    """
-    parser = get_parser()
-    args = parser.parse_args()
-
-    if args.dataset == "echonet":
+    def run(self):
         from zea.data.convert.echonet import convert_echonet
 
-        convert_echonet(args)
-    elif args.dataset == "echonetlvh":
+        convert_echonet(self)
+
+
+@dataclass
+class _EchonetLVH:
+    """Convert EchonetLVH dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    no_rejection: bool = False
+    """Do not reject sequences in `manual_rejections.txt`."""
+    rejection_path: Path | None = None
+    """Path to custom rejection txt file (defaults to `manual_rejections.txt` from zea)."""
+    convert_measurements: bool = False
+    """Only convert measurements CSV file."""
+    convert_images: bool = False
+    """Only convert image files."""
+    max_files: int | None = None
+    """Maximum number of files to process (for testing)."""
+    force: bool = False
+    """Force recomputation even if parameters already exist."""
+    max_workers: int = 4
+    """Maximum number of workers to use for precomputing cone parameters and dataloading."""
+
+    def run(self):
         from zea.data.convert.echonetlvh import convert_echonetlvh
 
         convert_echonetlvh(
-            args.src,
-            args.dst,
-            args.no_rejection,
-            args.rejection_path,
-            args.convert_measurements,
-            args.convert_images,
-            args.max_files,
-            args.force,
-            args.max_workers,
+            self.src,
+            self.dst,
+            self.no_rejection,
+            self.rejection_path,
+            self.convert_measurements,
+            self.convert_images,
+            self.max_files,
+            self.force,
+            self.max_workers,
         )
-    elif args.dataset == "camus":
+
+
+@dataclass
+class _Camus:
+    """Convert CAMUS dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path, should contain either manually downloaded dataset or will be
+    target location for automated download with the --download flag."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    download: bool = False
+    """Download the CAMUS dataset from the server, will be saved to the --src path."""
+    no_hyperthreading: bool = False
+    """Disable hyperthreading for multiprocessing."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/camus or zeahub/camus-sample)."""
+    revision: str | None = None
+    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
+    Upload to 'main' is not allowed."""
+    reduced_dataset: bool = False
+    """Only convert and upload a small hardcoded sample subset (camus-sample)."""
+
+    def run(self):
         from zea.data.convert.camus import convert_camus
 
-        convert_camus(args)
-    elif args.dataset == "cetus":
+        convert_camus(self)
+
+
+@dataclass
+class _Cetus:
+    """Convert CETUS dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path, should contain either manually downloaded dataset or will be
+    target location for automated download with the --download flag."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    download: bool = False
+    """Download the CETUS dataset from the server, will be saved to the --src path."""
+    no_hyperthreading: bool = False
+    """Disable hyperthreading for multiprocessing."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/cetus-miccai-2014)."""
+    revision: str | None = None
+    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
+    Upload to 'main' is not allowed."""
+
+    def run(self):
         from zea.data.convert.cetus import convert_cetus
 
-        convert_cetus(args)
-    elif args.dataset == "picmus":
+        convert_cetus(self)
+
+
+@dataclass
+class _Picmus:
+    """Convert PICMUS dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path. Should contain either a manually downloaded and extracted
+    archive (archive_to_download/ or picmus.zip) or will be used as the download target
+    when --download is given. An 'in_vivo/' sub-directory, if present, is automatically
+    included."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    download: bool = False
+    """Download both the main PICMUS dataset and the in-vivo partition from the PICMUS
+    challenge website before converting."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/picmus)."""
+    revision: str | None = None
+    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
+    Upload to 'main' is not allowed."""
+
+    def run(self):
         from zea.data.convert.picmus import convert_picmus
 
-        convert_picmus(args)
-    elif args.dataset == "verasonics":
+        convert_picmus(self)
+
+
+@dataclass
+class _Verasonics:
+    """Convert Verasonics data to zea dataset."""
+
+    src: tyro.conf.Positional[Path]
+    """Source folder path."""
+    dst: tyro.conf.Positional[Path]
+    """Destination folder path."""
+    frames: list[str] | None = None
+    """The frames to add to the file. This can be a list of integers, a range of integers
+    (e.g. 4-8), or 'all'. Defaults to 'all', unless specified in a convert.yaml file."""
+    allow_accumulate: bool = False
+    """Sometimes, some transmits are already accumulated on the Verasonics system (e.g.
+    harmonic imaging through pulse inversion). In this case, the mode in the Receive
+    structure is set to 1 (accumulate). If this flag is set, such files will be processed.
+    Otherwise, an error is raised when such a mode is detected."""
+    device: str = "cpu"
+    """Device to use for conversion (e.g., 'cpu' or 'gpu:0')."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub after conversion. Only for zea
+    maintainers with push access to the repository."""
+    revision: str | None = None
+    """Required when --upload is set. Upload to 'main' is not allowed."""
+    hf_repo_id: str = ""
+    """HuggingFace repo ID for ownership checks and optional upload. Required if --upload
+    is set."""
+
+    def run(self):
         from zea.data.convert.verasonics import convert_verasonics
 
-        convert_verasonics(args)
-    elif args.dataset == "echoxflow":
+        convert_verasonics(self)
+
+
+@dataclass
+class _EchoXFlow:
+    """Convert EchoXFlow dataset."""
+
+    src: tyro.conf.Positional[str]
+    """EchoXFlow data root, e.g. /data/EchoXFlow/data"""
+    dst: tyro.conf.Positional[str]
+    """Destination folder path."""
+    croissant: str | None = None
+    """Path to croissant.json (default: <src>/croissant.json)."""
+    min_frames: int = 10
+    """Minimum B-mode frame count."""
+    min_fps: float = 30.0
+    """Minimum frame rate (Hz)."""
+    limit: int | None = None
+    """Convert at most N recordings."""
+    overwrite: bool = False
+    """Overwrite existing output files."""
+    upload: bool = False
+    """Upload the converted dataset to HuggingFace Hub (zeahub/echoxflow)."""
+    revision: str | None = None
+    """Target branch on the Hub. Required when --upload is set; upload to 'main' is
+    blocked."""
+    hf_repo_id: str = ""
+    """HuggingFace repo id for ownership checks and optional upload (default:
+    zeahub/echoxflow)."""
+
+    def run(self):
         from zea.data.convert.echoxflow import convert_echoxflow
 
-        convert_echoxflow(args)
-    else:
-        raise ValueError(f"Unknown dataset: {args.dataset}")
+        convert_echoxflow(self)
+
+
+Dataset = Union[
+    Annotated[_Echonet, tyro.conf.subcommand("echonet")],
+    Annotated[_EchonetLVH, tyro.conf.subcommand("echonetlvh")],
+    Annotated[_Camus, tyro.conf.subcommand("camus")],
+    Annotated[_Cetus, tyro.conf.subcommand("cetus")],
+    Annotated[_Picmus, tyro.conf.subcommand("picmus")],
+    Annotated[_Verasonics, tyro.conf.subcommand("verasonics")],
+    Annotated[_EchoXFlow, tyro.conf.subcommand("echoxflow")],
+]
+
+
+def main():
+    """Parse command-line arguments and dispatch to the selected dataset conversion routine."""
+    args = tyro.cli(Dataset)  # ty: ignore[no-matching-overload]
+    args.run()
 
 
 if __name__ == "__main__":

--- a/zea/data/convert/__main__.py
+++ b/zea/data/convert/__main__.py
@@ -1,238 +1,50 @@
 """CLI for converting common open-source ultrasound datasets to the zea format.
 
-Usage::
+The converters are available both as a subcommand of the ``zea`` command line tool
+and as a standalone module:
 
-    python -m zea.data.convert <dataset> <src> <dst> [options]
+    zea convert <dataset> <src> <dst> [options]        # preferred
+    python -m zea.data.convert <dataset> <src> <dst>   # equivalent
 
 Examples::
 
-    python -m zea.data.convert camus ./raw ./output --download
-    python -m zea.data.convert cetus ./raw ./output --download
-    python -m zea.data.convert echonet ./raw ./output
-    python -m zea.data.convert echoxflow ./raw ./output
+    zea convert camus ./raw ./output --download
+    zea convert cetus ./raw ./output --download
+    zea convert echonet ./raw ./output
+    zea convert echoxflow ./raw ./output
 
-Run ``python -m zea.data.convert --help`` for all options.
+Run ``zea convert --help`` (or ``python -m zea.data.convert --help``) for all options.
+
+The CLI dataclasses themselves live in :mod:`zea.cli_args` (kept free of heavy
+imports so ``zea --help`` renders without loading an ML backend); they are
+re-exported here for backwards compatibility.
 """
-
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Annotated, Union
 
 import tyro
 
+from zea.cli_args import ConvertArgs, ConvertDataset as Dataset
+from zea.cli_args import (
+    _Camus,
+    _Cetus,
+    _Echonet,
+    _EchonetLVH,
+    _EchoXFlow,
+    _Picmus,
+    _Verasonics,
+)
 from zea.internal.device import init_device
 
-
-@dataclass
-class _Echonet:
-    """Convert Echonet dataset."""
-
-    src: tyro.conf.Positional[Path]
-    """Source folder path."""
-    dst: tyro.conf.Positional[Path]
-    """Destination folder path."""
-    split_path: Path | None = None
-    """Path to the split.yaml file containing the dataset split if a split should be copied."""
-    no_hyperthreading: bool = False
-    """Disable hyperthreading for multiprocessing."""
-
-    def run(self):
-        from zea.data.convert.echonet import convert_echonet
-
-        convert_echonet(self)
-
-
-@dataclass
-class _EchonetLVH:
-    """Convert EchonetLVH dataset."""
-
-    src: tyro.conf.Positional[Path]
-    """Source folder path."""
-    dst: tyro.conf.Positional[Path]
-    """Destination folder path."""
-    no_rejection: bool = False
-    """Do not reject sequences in `manual_rejections.txt`."""
-    rejection_path: Path | None = None
-    """Path to custom rejection txt file (defaults to `manual_rejections.txt` from zea)."""
-    convert_measurements: bool = False
-    """Only convert measurements CSV file."""
-    convert_images: bool = False
-    """Only convert image files."""
-    max_files: int | None = None
-    """Maximum number of files to process (for testing)."""
-    force: bool = False
-    """Force recomputation even if parameters already exist."""
-    max_workers: int = 4
-    """Maximum number of workers to use for precomputing cone parameters and dataloading."""
-
-    def run(self):
-        from zea.data.convert.echonetlvh import convert_echonetlvh
-
-        convert_echonetlvh(
-            self.src,
-            self.dst,
-            self.no_rejection,
-            self.rejection_path,
-            self.convert_measurements,
-            self.convert_images,
-            self.max_files,
-            self.force,
-            self.max_workers,
-        )
-
-
-@dataclass
-class _Camus:
-    """Convert CAMUS dataset."""
-
-    src: tyro.conf.Positional[Path]
-    """Source folder path, should contain either manually downloaded dataset or will be
-    target location for automated download with the --download flag."""
-    dst: tyro.conf.Positional[Path]
-    """Destination folder path."""
-    download: bool = False
-    """Download the CAMUS dataset from the server, will be saved to the --src path."""
-    no_hyperthreading: bool = False
-    """Disable hyperthreading for multiprocessing."""
-    upload: bool = False
-    """Upload the converted dataset to HuggingFace Hub (zeahub/camus or zeahub/camus-sample)."""
-    revision: str | None = None
-    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
-    Upload to 'main' is not allowed."""
-    reduced_dataset: bool = False
-    """Only convert and upload a small hardcoded sample subset (camus-sample)."""
-
-    def run(self):
-        from zea.data.convert.camus import convert_camus
-
-        convert_camus(self)
-
-
-@dataclass
-class _Cetus:
-    """Convert CETUS dataset."""
-
-    src: tyro.conf.Positional[Path]
-    """Source folder path, should contain either manually downloaded dataset or will be
-    target location for automated download with the --download flag."""
-    dst: tyro.conf.Positional[Path]
-    """Destination folder path."""
-    download: bool = False
-    """Download the CETUS dataset from the server, will be saved to the --src path."""
-    no_hyperthreading: bool = False
-    """Disable hyperthreading for multiprocessing."""
-    upload: bool = False
-    """Upload the converted dataset to HuggingFace Hub (zeahub/cetus-miccai-2014)."""
-    revision: str | None = None
-    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
-    Upload to 'main' is not allowed."""
-
-    def run(self):
-        from zea.data.convert.cetus import convert_cetus
-
-        convert_cetus(self)
-
-
-@dataclass
-class _Picmus:
-    """Convert PICMUS dataset."""
-
-    src: tyro.conf.Positional[Path]
-    """Source folder path. Should contain either a manually downloaded and extracted
-    archive (archive_to_download/ or picmus.zip) or will be used as the download target
-    when --download is given. An 'in_vivo/' sub-directory, if present, is automatically
-    included."""
-    dst: tyro.conf.Positional[Path]
-    """Destination folder path."""
-    download: bool = False
-    """Download both the main PICMUS dataset and the in-vivo partition from the PICMUS
-    challenge website before converting."""
-    upload: bool = False
-    """Upload the converted dataset to HuggingFace Hub (zeahub/picmus)."""
-    revision: str | None = None
-    """Revision branch to upload to on HuggingFace Hub. Required when --upload is set.
-    Upload to 'main' is not allowed."""
-
-    def run(self):
-        from zea.data.convert.picmus import convert_picmus
-
-        convert_picmus(self)
-
-
-@dataclass
-class _Verasonics:
-    """Convert Verasonics data to zea dataset."""
-
-    src: tyro.conf.Positional[Path]
-    """Source folder path."""
-    dst: tyro.conf.Positional[Path]
-    """Destination folder path."""
-    frames: list[str] | None = None
-    """The frames to add to the file. This can be a list of integers, a range of integers
-    (e.g. 4-8), or 'all'. Defaults to 'all', unless specified in a convert.yaml file."""
-    allow_accumulate: bool = False
-    """Sometimes, some transmits are already accumulated on the Verasonics system (e.g.
-    harmonic imaging through pulse inversion). In this case, the mode in the Receive
-    structure is set to 1 (accumulate). If this flag is set, such files will be processed.
-    Otherwise, an error is raised when such a mode is detected."""
-    device: str = "cpu"
-    """Device to use for conversion (e.g., 'cpu' or 'gpu:0')."""
-    upload: bool = False
-    """Upload the converted dataset to HuggingFace Hub after conversion. Only for zea
-    maintainers with push access to the repository."""
-    revision: str | None = None
-    """Required when --upload is set. Upload to 'main' is not allowed."""
-    hf_repo_id: str = ""
-    """HuggingFace repo ID for ownership checks and optional upload. Required if --upload
-    is set."""
-
-    def run(self):
-        from zea.data.convert.verasonics import convert_verasonics
-
-        convert_verasonics(self)
-
-
-@dataclass
-class _EchoXFlow:
-    """Convert EchoXFlow dataset."""
-
-    src: tyro.conf.Positional[str]
-    """EchoXFlow data root, e.g. /data/EchoXFlow/data"""
-    dst: tyro.conf.Positional[str]
-    """Destination folder path."""
-    croissant: str | None = None
-    """Path to croissant.json (default: <src>/croissant.json)."""
-    min_frames: int = 10
-    """Minimum B-mode frame count."""
-    min_fps: float = 30.0
-    """Minimum frame rate (Hz)."""
-    limit: int | None = None
-    """Convert at most N recordings."""
-    overwrite: bool = False
-    """Overwrite existing output files."""
-    upload: bool = False
-    """Upload the converted dataset to HuggingFace Hub (zeahub/echoxflow)."""
-    revision: str | None = None
-    """Target branch on the Hub. Required when --upload is set; upload to 'main' is
-    blocked."""
-    hf_repo_id: str = ""
-    """HuggingFace repo id for ownership checks and optional upload (default:
-    zeahub/echoxflow)."""
-
-    def run(self):
-        from zea.data.convert.echoxflow import convert_echoxflow
-
-        convert_echoxflow(self)
-
-
-Dataset = Union[
-    Annotated[_Echonet, tyro.conf.subcommand("echonet")],
-    Annotated[_EchonetLVH, tyro.conf.subcommand("echonetlvh")],
-    Annotated[_Camus, tyro.conf.subcommand("camus")],
-    Annotated[_Cetus, tyro.conf.subcommand("cetus")],
-    Annotated[_Picmus, tyro.conf.subcommand("picmus")],
-    Annotated[_Verasonics, tyro.conf.subcommand("verasonics")],
-    Annotated[_EchoXFlow, tyro.conf.subcommand("echoxflow")],
+__all__ = [
+    "ConvertArgs",
+    "Dataset",
+    "_Camus",
+    "_Cetus",
+    "_Echonet",
+    "_EchonetLVH",
+    "_EchoXFlow",
+    "_Picmus",
+    "_Verasonics",
+    "main",
 ]
 
 

--- a/zea/data/convert/camus.py
+++ b/zea/data/convert/camus.py
@@ -42,13 +42,13 @@ Dataset splits:
 
 .. code-block:: console
 
-   python -m zea.data.convert camus ./raw ./output --download
+   zea convert camus ./raw ./output --download
 
 For testing purposes, you can also convert a reduced dataset containing only 6 half-sequence files:
 
 .. code-block:: console
 
-    python -m zea.data.convert camus ./raw ./output --download --reduced-dataset
+    zea convert camus ./raw ./output --download --reduced-dataset
 
 """
 
@@ -473,8 +473,8 @@ def convert_camus(args):
 
     Usage::
 
-        python -m zea.data.convert camus <source_folder> <destination_folder>
-        python -m zea.data.convert camus <source_folder> <destination_folder> --download
+        zea convert camus <source_folder> <destination_folder>
+        zea convert camus <source_folder> <destination_folder> --download
 
     Args:
         args (argparse.Namespace): An object with attributes:
@@ -662,7 +662,7 @@ This dataset was downloaded, converted to zea format, and uploaded using the
 [zea](https://github.com/tue-bmd/zea) data converter:
 
 ```bash
-python -m zea.data.convert camus <src> <dst> --download
+zea convert camus <src> <dst> --download
 ```
 
 ## Dataset structure

--- a/zea/data/convert/camus.py
+++ b/zea/data/convert/camus.py
@@ -259,7 +259,7 @@ def process_camus(source_path, output_path, overwrite=False):
                 "coordinates": coordinates,
             },
         },
-        probe={"name": "GE M5S"},
+        probe={"name": "GE M5S", "type": "phased"},
         metadata={
             "subject": {
                 "id": patient_name,
@@ -270,12 +270,14 @@ def process_camus(source_path, output_path, overwrite=False):
             "credit": CAMUS_CITATION,
             "text_report": text_report,
             "annotations": {
+                "anatomy": "heart",
                 "view": np.array([view] * n_frames, dtype=np.str_),
                 "label": frame_labels,
                 "image_quality": image_quality,
             },
         },
         description=CAMUS_DESCRIPTION,
+        ignore_warnings=True,
     )
 
 

--- a/zea/data/convert/cetus.py
+++ b/zea/data/convert/cetus.py
@@ -41,7 +41,7 @@ Dataset splits:
 
 .. code-block:: console
 
-   python -m zea.data.convert cetus ./raw ./output --download
+   zea convert cetus ./raw ./output --download
 
 """
 
@@ -296,7 +296,7 @@ def convert_cetus(args):
 
     Usage::
 
-        python -m zea.data.convert cetus <source_folder> <destination_folder> --download
+        zea convert cetus <source_folder> <destination_folder> --download
 
     Args:
         args (argparse.Namespace): An object with attributes:
@@ -469,7 +469,7 @@ This dataset was downloaded, converted to zea format, and uploaded using the
 [zea](https://github.com/tue-bmd/zea) data converter:
 
 ```bash
-python -m zea.data.convert cetus <src> <dst> --download
+zea convert cetus <src> <dst> --download
 ```
 
 ## Dataset structure

--- a/zea/data/convert/echoxflow.py
+++ b/zea/data/convert/echoxflow.py
@@ -6,8 +6,8 @@ laid out as ``<dst>/<exam_id>/<recording_id>.hdf5``.
 
 Usage::
 
-    python -m zea.data.convert echoxflow <src> <dst>
-    python -m zea.data.convert echoxflow <src> <dst> --limit 2
+    zea convert echoxflow <src> <dst>
+    zea convert echoxflow <src> <dst> --limit 2
 
 ``src`` is the EchoXFlow data root (e.g. ``/data/EchoXFlow/data``) containing a
 ``croissant.json`` catalog. Reading EchoXFlow recordings requires the optional
@@ -47,7 +47,7 @@ def _import_echoxflow():
 
     Returns the ``(find_recordings, load_croissant, open_recording)`` callables.
     Raises a clear :class:`ImportError` if the package is not installed, so that
-    ``python -m zea.data.convert --help`` keeps working without it.
+    ``zea convert --help`` keeps working without it.
     """
     try:
         from echoxflow import find_recordings, load_croissant, open_recording
@@ -147,7 +147,7 @@ This dataset was converted to zea format and uploaded using the
 [zea](https://github.com/tue-bmd/zea) data converter:
 
 ```bash
-python -m zea.data.convert echoxflow <src> <dst>
+zea convert echoxflow <src> <dst>
 ```
 
 ## Dataset structure
@@ -169,8 +169,8 @@ def convert_echoxflow(args):
 
     Usage::
 
-        python -m zea.data.convert echoxflow <src> <dst>
-        python -m zea.data.convert echoxflow <src> <dst> --limit 2
+        zea convert echoxflow <src> <dst>
+        zea convert echoxflow <src> <dst> --limit 2
 
     Args:
         args (argparse.Namespace): An object with attributes:

--- a/zea/data/convert/picmus.py
+++ b/zea/data/convert/picmus.py
@@ -36,8 +36,8 @@ The dataset comprises three partitions:
 
 .. code-block:: console
 
-   python -m zea.data.convert picmus ./raw ./output --download
-   python -m zea.data.convert picmus ./raw ./output
+   zea convert picmus ./raw ./output --download
+   zea convert picmus ./raw ./output
 
 """
 
@@ -339,10 +339,10 @@ def convert_picmus(args):
     Usage::
 
         # Download and convert everything (main + in-vivo)
-        python -m zea.data.convert picmus <src> <dst> --download
+        zea convert picmus <src> <dst> --download
 
         # Convert from manually extracted archives
-        python -m zea.data.convert picmus <src> <dst>
+        zea convert picmus <src> <dst>
 
     Args:
         args (argparse.Namespace): An object with the following attributes.
@@ -495,7 +495,7 @@ This dataset was downloaded, converted to zea format, and uploaded using the
 [zea](https://github.com/tue-bmd/zea) data converter:
 
 ```bash
-python -m zea.data.convert picmus <src> <dst> --download
+zea convert picmus <src> <dst> --download
 ```
 
 ## Dataset structure

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -31,7 +31,7 @@ Or alternatively, use the script below to convert all .mat files in a directory:
 
     .. code-block:: bash
 
-        python -m zea.data.convert verasonics "C:/path/to/source" "C:/path/to/output"
+        zea convert verasonics "C:/path/to/source" "C:/path/to/output"
 
 ---------------
 

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -1477,10 +1477,10 @@ def convert_verasonics(args):
         log.error(
             "When converting a single file, the output path should have the .hdf5 or .h5 extension."
         )
-        sys.exit()
+        sys.exit(2)
     elif selected_path.is_dir() and output_path.is_file():
         log.error("When converting a directory, the output path should be a directory.")
-        sys.exit()
+        sys.exit(2)
 
     if output_path.is_dir() and not selected_path_is_directory:
         output_path = output_path / (selected_path.name + "_zea.hdf5")

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -31,10 +31,7 @@ Or alternatively, use the script below to convert all .mat files in a directory:
 
     .. code-block:: bash
 
-        python zea/data/convert/verasonics.py "C:/path/to/directory"
-
-or without the directory argument, the script will prompt you to select a directory
-using a file dialog.
+        python -m zea.data.convert verasonics "C:/path/to/source" "C:/path/to/output"
 
 ---------------
 
@@ -1472,64 +1469,21 @@ def convert_verasonics(args):
     # Is set by the user in case these are found.
     existing_file_policy = None
 
-    if args.src is None:
-        log.info("Select a directory containing Verasonics MATLAB workspace files.")
-        # Create a Tkinter root window
-        try:
-            import tkinter as tk
-            from tkinter import filedialog
-
-            root = tk.Tk()
-            root.withdraw()
-            # Prompt the user to select a file or directory
-            selected_path = filedialog.askdirectory()
-        except ImportError as e:
-            raise ImportError(
-                log.error(
-                    "tkinter is not installed. Please install it with 'apt install python3-tk'."
-                )
-            ) from e
-        except Exception as e:
-            raise ValueError(
-                log.error(
-                    "Failed to open a file dialog (possibly in headless state). "
-                    "Please provide a path as an argument. "
-                )
-            ) from e
-    else:
-        selected_path = args.src
-
-    # Exit when no path is selected
-    if not selected_path:
-        log.error("No path selected.")
-        sys.exit()
-    else:
-        selected_path = Path(selected_path)
-
+    selected_path = Path(args.src)
     selected_path_is_directory = os.path.isdir(selected_path)
 
-    # Set the output path to be next to the input directory with _zea appended
-    # to the name
-    if args.dst is None:
-        if selected_path_is_directory:
-            output_path = selected_path.parent / (Path(selected_path).name + "_zea")
-        else:
-            output_path = str(selected_path.with_suffix("")) + "_zea.hdf5"
-            output_path = Path(output_path)
-    else:
-        output_path = Path(args.dst)
-        if selected_path.is_file() and output_path.suffix not in (".hdf5", ".h5"):
-            log.error(
-                "When converting a single file, the output path should have the .hdf5 "
-                "or .h5 extension."
-            )
-            sys.exit()
-        elif selected_path.is_dir() and output_path.is_file():
-            log.error("When converting a directory, the output path should be a directory.")
-            sys.exit()
+    output_path = Path(args.dst)
+    if selected_path.is_file() and output_path.suffix not in (".hdf5", ".h5"):
+        log.error(
+            "When converting a single file, the output path should have the .hdf5 or .h5 extension."
+        )
+        sys.exit()
+    elif selected_path.is_dir() and output_path.is_file():
+        log.error("When converting a directory, the output path should be a directory.")
+        sys.exit()
 
-        if output_path.is_dir() and not selected_path_is_directory:
-            output_path = output_path / (selected_path.name + "_zea.hdf5")
+    if output_path.is_dir() and not selected_path_is_directory:
+        output_path = output_path / (selected_path.name + "_zea.hdf5")
 
     log.info(f"Selected path: {log.yellow(selected_path)}")
 

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -951,8 +951,11 @@ class File(h5py.File):
         elif stream and not is_hf:
             raise ValueError("stream=True is only supported for 'hf://' paths.")
 
-        # Progress reporting for concurrent chunk reads
-        progress = kwargs.pop("progress", True)
+        # Progress reporting for concurrent chunk reads. Defaults to True for streamed
+        # (hf://) files, where a bar communicates real network wait; a local file's
+        # concurrent reads are fast enough (pread, no round trips) that a bar is just
+        # noise by default.
+        progress = kwargs.pop("progress", stream)
 
         # Cache streamed chunks on disk (see zea.data.chunk_cache). On by default, like the
         # HF hub cache; ``cache=False`` (or ZEA_CHUNK_CACHE=0) re-fetches every time.

--- a/zea/data/file.py
+++ b/zea/data/file.py
@@ -1486,11 +1486,14 @@ class File(h5py.File):
             overwrite: If *False* (default), raise if the file exists.
             ignore_warnings: If *True*, suppress all warnings emitted while
                 creating the file (missing optional metadata fields, custom keys,
-                PHI timestamp warning, etc.). Defaults to *False*. Note that some
-                rarely-used metadata fields (e.g. ``voice_narration``, ``ecg``) are
-                never warned about regardless of this flag.
-            warn_missing_optional_fields: If *True* (default), warn when optional
-                fields are missing from the saved spec.
+                PHI timestamp warning, etc.). Defaults to *False*. Takes precedence
+                over ``warn_missing_optional_fields``. Note that some rarely-used
+                metadata fields (e.g. ``voice_narration``, ``ecg``) are never
+                warned about regardless of this flag.
+            warn_missing_optional_fields: If *True* (default), warn about missing
+                optional fields specifically (a subset of ``ignore_warnings``).
+                ``ignore_warnings=True`` with this set to *False* raises
+                ``ValueError`` as redundant.
 
         Returns:
             None. The validated file is written to ``path``; open it with
@@ -1536,6 +1539,13 @@ class File(h5py.File):
         """
         if tracks is not None and (data is not None or scan is not None):
             raise ValueError("Provide either 'tracks' or 'data'/'scan', not both.")
+
+        if ignore_warnings and not warn_missing_optional_fields:
+            raise ValueError(
+                "warn_missing_optional_fields=False has no effect when ignore_warnings=True: "
+                "ignore_warnings already suppresses every warning, including missing-optional-"
+                "field warnings. Pass only one of the two."
+            )
 
         path = Path(path)
 

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -2079,12 +2079,13 @@ class SignalND(Signal):
 
 @dataclass
 class Annotations(Spec):
-    """Frame-level annotations, either per frame or broadcast labels.
+    """Frame-level annotations, either one per frame or a single broadcast value.
 
     Args:
-        anatomy (str): Anatomy label.
-        view (str): View label.
-        label (str): Pathology or classification label.
+        anatomy (str): Anatomical structure imaged, e.g. carotid, liver, thyroid.
+        view (str): Imaging plane/orientation, e.g. longitudinal, transverse,
+            apical_4_chamber.
+        label (str): Pathology or classification label, e.g. benign, malignant.
         image_quality (str): Image quality label, e.g. low, mid, high.
     """
 
@@ -2101,8 +2102,14 @@ class Annotations(Spec):
     }
 
     FIELD_METADATA = {
-        "anatomy": {"unit": "–", "description": "Anatomy label."},
-        "view": {"unit": "–", "description": "View label."},
+        "anatomy": {
+            "unit": "–",
+            "description": "Anatomical structure imaged (e.g. carotid, liver).",
+        },
+        "view": {
+            "unit": "–",
+            "description": "Imaging plane/orientation (e.g. longitudinal, apical_4_chamber).",
+        },
         "label": {"unit": "–", "description": "Pathology or classification label."},
         "image_quality": {"unit": "–", "description": "Image quality label.", "rare": True},
     }

--- a/zea/data/spec.py
+++ b/zea/data/spec.py
@@ -2279,6 +2279,19 @@ class TrackSpec(Spec):
     }
 
     FIELD_METADATA = {
+        "data": {
+            "unit": "–",
+            "description": (
+                "Recorded data for this track; may be omitted for a transmit-only track."
+            ),
+        },
+        "scan": {
+            "unit": "–",
+            "description": (
+                "Scan acquisition parameters for this track; required when raw_data is "
+                "present in data, or when data is omitted."
+            ),
+        },
         # label is enforced by FileSpec for multi-track (ValueError), and legitimately
         # absent for single-track files — warning here is never useful.
         "label": {"unit": "–", "description": "Short human-readable track name.", "rare": True},


### PR DESCRIPTION
Closes #485. 

Also bumps the codecoverage for entire zea with [3.19%](https://app.codecov.io/gh/tue-bmd/zea/pull/521/tree), as we now do register coverage for the conversion tests (previously unnoticed due to subprocesses). #12 

Will also probably fix patch coverage problem in #448.

## Summary
Migrated the dataset conversion CLI from `argparse` to `tyro`, a modern Python CLI framework that uses dataclasses for argument definition. This improves code maintainability, reduces boilerplate, and provides better type safety.

## Key Changes

- **CLI Framework Migration**: Replaced `argparse`-based argument parsing with `tyro`, using dataclasses (`_Echonet`, `_EchonetLVH`, `_Camus`, `_Cetus`, `_Picmus`, `_Verasonics`, `_EchoXFlow`) to define arguments for each dataset converter
- **Argument Definition**: Converted all command-line arguments to dataclass fields with type annotations and docstrings, eliminating the need for separate parser setup functions
- **Subcommand Handling**: Implemented subcommand dispatch using `tyro.conf.subcommand()` annotations and a `Union` type, replacing the previous `add_subparsers()` approach
- **Dispatch Pattern**: Added `.run()` methods to each dataclass that import and call the appropriate converter function, replacing the previous if/elif chain in `main()`
- **Test Coverage**: Added comprehensive test suite (`tests/data/test_convert_main.py`) with 20+ tests covering parser structure, argument parsing, flag handling, and dispatch behavior
- **Subprocess Coverage**: Added `sitecustomize.py` to enable coverage measurement in subprocesses spawned by conversion tests
- **Documentation**: Updated CLI documentation references from `autoprogram` to `tyroprogram` directive
- **Dependencies**: Removed `sphinxcontrib-autoprogram` from docs dependencies (replaced by tyro's documentation support)

## Notable Implementation Details

- Positional arguments (`src`, `dst`) are marked with `tyro.conf.Positional[]` to maintain CLI compatibility
- Field docstrings serve as help text, improving code readability
- The `EchonetLVH` converter receives unpacked arguments (individual fields) rather than the dataclass instance, maintaining backward compatibility with its existing signature
- All other converters receive the dataclass instance directly
- CLI flag names automatically convert from snake_case to kebab-case (e.g., `no_hyperthreading` → `--no-hyperthreading`)
- Test suite validates both parsing behavior and dispatch to ensure converters receive correct arguments

## How to test
- [ ] Check if you can do `zea data convert` still. Try `--help` and execute. 
- [x] See if codecov got bumped (should not register codecoverage much better).
- [ ] Check docs if CLI is still clearly outlined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `zea convert <dataset> <src> <dst> [options]` with typed, dataset-specific subcommands and consistent `src`/`dst` parsing.
  - Supports invoking the same functionality via `python -m zea.data.convert`.
- **Bug Fixes**
  - Improved Verasonics conversion path handling (automatic output naming/validation and no interactive source selection when `src` is missing).
  - Fixed the Echonet split flag to use the documented `--split-path`.
- **Documentation**
  - Updated CLI/conversion examples across datasets and refreshed Sphinx CLI-related configuration.
- **Tests**
  - Added CLI parsing/dispatch coverage for conversion and improved subprocess coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->