### PR TITLE
Add Windows caveats to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Check out the [About](https://zea.readthedocs.io/en/latest/about.html) page for 
 
 > [!WARNING]
 > **Beta!**
-> This package is under active development. It is mainly used to support [our research](https://zea.readthedocs.io/en/latest/about.html#papers). That being said, we are happy to share it with the ultrasound community and hope it will be useful for your research as well.
+> This package is under active development. See a list of ongoing [research](https://zea.readthedocs.io/en/latest/about.html#papers) supported by `zea`. We are happy to share it with the ultrasound community and hope it will be useful for your research as well.
 
 > [!NOTE]
 > 📖 Please cite `zea` in your publications if it helps your research. You can find citation info [here](https://zea.readthedocs.io/en/latest/getting-started.html#citation).

--- a/docs/source/data-acquisition.rst
+++ b/docs/source/data-acquisition.rst
@@ -20,6 +20,8 @@ Additionally, to support the :doc:`cognitive ultrasound framework <about>`, the 
 allow for flexible and efficient access to a part of the data (e.g. a single frame or transmit) without the need
 to load the entire file into memory.
 
+.. _working-with-zea-data-files:
+
 -------------------------------
 Working with zea data files
 -------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,7 +16,7 @@ Check out the :doc:`about` page for more information and the motivation behind `
 .. admonition:: Beta!
    :class: warning
 
-   This package is under active development. It is mainly used to support :ref:`our research <papers>`. That being said, we are happy to share it with the ultrasound community and hope it will be useful for your research as well.
+   This package is under active development. See a list of ongoing :ref:`research <papers>` supported by ``zea``. We are happy to share it with the ultrasound community and hope it will be useful for your research as well.
 
 .. note::
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -64,13 +64,34 @@ Backend
    :start-after: .. backend-installation-start
    :end-before: .. backend-installation-end
 
+.. dropdown:: Notes for Windows users
+   :name: windows-users
+   :class-container: dropdown-accordion-windows-users
+
+   ``zea`` installs and runs on Windows the same way as above, with a couple of caveats:
+
+   - **GPU support is limited.** JAX and TensorFlow only support GPU acceleration on
+     Windows through WSL2. Native Windows installs are CPU-only for those backends.
+     PyTorch is the exception and does support CUDA natively on Windows. See the backend
+     links above for each framework's current platform support. ``zea`` itself runs fine
+     on CPU, but beamforming and model inference are much slower without a GPU, so one is
+     recommended for anything beyond small experiments.
+   - **Streaming reads** (``hf://`` sources, see :ref:`working-with-zea-data-files`) fall
+     back to a lock-guarded read instead of ``zea``'s fully parallel path, since Windows
+     lacks ``os.pread``. This is still faster than downloading whole files, just not as
+     fast as on Linux/macOS.
+
+   If you need GPU acceleration and are on Windows, running ``zea`` inside WSL2 (or the
+   :ref:`Docker images <docker-information>` via WSL2's GPU passthrough) is the most
+   reliable path.
+
 
 .. _docker-information:
 
 Docker
 -------
 
-This repository provides multiple Docker images built and tested in our CI pipeline.
+This repository provides multiple `Docker images <https://hub.docker.com/r/zeahub>`_ built and tested in our CI pipeline.
 
 Pre-built images
 ~~~~~~~~~~~~~~~~
@@ -78,10 +99,10 @@ Pre-built images
 
 The following images are available on Docker Hub:
 
-- `zeahub/all`: This image includes support for all machine learning backends (TensorFlow, PyTorch, and JAX).
-- `zeahub/tensorflow`: This image includes support for TensorFlow.
-- `zeahub/torch`: This image includes support for PyTorch.
-- `zeahub/jax`: This image includes support for JAX.
+- `zeahub/all <https://hub.docker.com/r/zeahub/all>`_: This image includes support for all machine learning backends (TensorFlow, PyTorch, and JAX).
+- `zeahub/tensorflow <https://hub.docker.com/r/zeahub/tensorflow>`_: This image includes support for TensorFlow.
+- `zeahub/torch <https://hub.docker.com/r/zeahub/torch>`_: This image includes support for PyTorch.
+- `zeahub/jax <https://hub.docker.com/r/zeahub/jax>`_: This image includes support for JAX.
 
 These images are uploaded to Docker Hub via the CI pipeline and can be used directly in your projects via:
 


### PR DESCRIPTION
Closes #508 by adding some documentation for Windows users. Link is shareable to that section as well. Also sneaked in some links to Docker containers. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an internal reference label for the “Working with zea data files” section to improve cross-page linking.
  - Updated the main “active development”/warning messaging in both the README and documentation landing page.
  - Clarified Windows GPU limitations (native Windows vs WSL2) and guidance for streaming reads on Windows.
  - Refined Docker “pre-built images” guidance with a Docker Hub link and cleaner backend image listing.
  - Removed duplicated Docker section content from the rendered documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->