### PR TITLE
Reduce warning noise in CI/CD logs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,6 +3,8 @@
 import os
 
 os.environ["KERAS_BACKEND"] = "numpy"
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
 
 import sys
 from importlib.metadata import version as get_version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,8 +3,6 @@
 import os
 
 os.environ["KERAS_BACKEND"] = "numpy"
-os.environ.setdefault("JAX_PLATFORMS", "cpu")
-os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
 
 import sys
 from importlib.metadata import version as get_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -268,7 +268,7 @@ filterwarnings = [
     "ignore:.*os\\.fork\\(\\) was called.*:RuntimeWarning",
     "ignore:.*hf_xet.*:DeprecationWarning",
     "ignore:'(oneOf|parseString|resetCache|enablePackrat)' deprecated:DeprecationWarning",  # matplotlib -> old pyparsing API
-    "ignore:invalid escape sequence:DeprecationWarning:SimpleITK.*",
+    "ignore:invalid escape sequence:DeprecationWarning",
     "ignore:.*sentry_sdk.Hub. is deprecated:DeprecationWarning",  # wandb -> deprecated sentry Hub API
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,9 @@ filterwarnings = [
     "ignore:.*__array__ implementation doesn't accept a copy keyword.*:DeprecationWarning",
     "ignore:.*os\\.fork\\(\\) was called.*:RuntimeWarning",
     "ignore:.*hf_xet.*:DeprecationWarning",
+    "ignore:'(oneOf|parseString|resetCache|enablePackrat)' deprecated:DeprecationWarning",  # matplotlib -> old pyparsing API
+    "ignore:invalid escape sequence:DeprecationWarning:SimpleITK.*",
+    "ignore:.*sentry_sdk.Hub. is deprecated:DeprecationWarning",  # wandb -> deprecated sentry Hub API
 ]
 
 [tool.coverage.run]
@@ -274,7 +277,11 @@ branch = true
 parallel = true
 concurrency = ["multiprocessing", "thread"]
 sigterm = true
-omit = ["/tmp/__autograph_generated_file*.py"]
+omit = [
+    "/tmp/__autograph_generated_file*.py",
+    # Synthetic module compiled in-memory by tests/test_log.py; never on disk.
+    "*/_fake_internal_module.py",
+]
 
 [tool.coverage.report]
 omit = ["zea/ops/keras_ops.py", "zea/data/app.py"]

--- a/zea/simulator.py
+++ b/zea/simulator.py
@@ -238,9 +238,10 @@ def directivity(f, theta, element_width, sound_speed, rigid_baffle=True):
         response = ops.ones_like(theta)
         return response
 
-    wavelength = sound_speed / f
-
-    response = sinc(element_width / wavelength * ops.sin(theta))
+    # element_width / wavelength == element_width * f / sound_speed. Using the
+    # latter avoids dividing by f, so the DC bin (f == 0) stays finite: the
+    # argument is 0 and sinc(0) == 1 (isotropic directivity), the correct limit.
+    response = sinc(element_width * f / sound_speed * ops.sin(theta))
     if not rigid_baffle:
         response *= ops.cos(theta)
     return response
@@ -300,7 +301,11 @@ def hann_fd(f, width):
     """The fourier transform of a hann window in the time domain with given width."""
     denom = 1.0 - (f * width) ** 2
     num = 0.5 * sinc(f * width)
-    result = num / denom
+    # denom == 0 at f * width == +/-1 is a removable singularity where the Hann
+    # window transform equals 0.25. Divide only away from it (using a dummy 1.0
+    # at the singular points) and fill the limit in explicitly, so no 0/0 occurs.
+    singular = denom == 0
+    result = ops.where(singular, 0.25, num / ops.where(singular, 1.0, denom))
     result = ops.where(ops.abs(result) > 1.1, 0.25, result)
     return ops.nan_to_num(result, nan=0.0, posinf=0.0, neginf=0.25)
 


### PR DESCRIPTION
Catching or fixing some expected warnings to reduce the noise in the testing logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in directivity and Hann-window calculations.
  * Prevented invalid values in edge cases involving zero frequency and removable singularities.

* **Chores**
  * Updated warning filters and code coverage exclusions to reduce irrelevant test output and improve reporting accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->