### PR TITLE
Move dev tooling to PEP 735 dependency-groups

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,12 +11,13 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Mirrors `uv sync --extra dev` from docs/source/contributing.rst. --frozen keeps
-# this from touching uv.lock. jax[cpu] is installed separately (not part of the
-# `dev` extra) as the cheapest backend to exercise `zea`, matching the JAX-only
-# jobs in CI.
+# Mirrors `uv sync --group dev` from docs/source/contributing.rst. --frozen keeps
+# this from touching uv.lock. The `dev` dependency-group carries tests + docs + lint
+# (ruff/ty) plus the dev-only runtime pkgs (see [dependency-groups] in pyproject.toml).
+# jax[cpu] is installed separately (not part of the `dev` group) as the cheapest
+# backend to exercise `zea`, matching the JAX-only jobs in CI.
 export UV_TORCH_BACKEND=cpu
-uv sync --frozen --extra dev
+uv sync --frozen --group dev
 uv pip install --python .venv/bin/python "jax[cpu]"
 
 uv run --no-sync pre-commit install >/dev/null

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -11,13 +11,10 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Mirrors `uv sync --group dev` from docs/source/contributing.rst. --frozen keeps
-# this from touching uv.lock. The `dev` dependency-group carries tests + docs + lint
-# (ruff/ty) plus the dev-only runtime pkgs (see [dependency-groups] in pyproject.toml).
-# jax[cpu] is installed separately (not part of the `dev` group) as the cheapest
-# backend to exercise `zea`, matching the JAX-only jobs in CI.
+# Mirrors contributing.rst; --frozen keeps this from touching uv.lock. jax[cpu] is
+# installed separately (not in `dev`) as the cheapest backend to exercise zea.
 export UV_TORCH_BACKEND=cpu
-uv sync --frozen --group dev
+uv sync --frozen
 uv pip install --python .venv/bin/python "jax[cpu]"
 
 uv run --no-sync pre-commit install >/dev/null

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -44,7 +44,6 @@ jobs:
       # itself; the heavy ML backends (jax/torch/tensorflow) are extras and are
       # intentionally left out, so their conditional imports are downgraded to
       # warnings in [tool.ty]. ty's version comes from the `lint` group.
-      # --no-default-groups keeps the default `dev` group (pytest/sphinx/...) out;
-      # only `lint` is needed here.
+      # --no-default-groups keeps the default `dev` group out.
       - name: Run Type Checker
         run: uv run --python 3.10 --no-default-groups --group lint ty check --exit-zero-on-warning

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -44,5 +44,7 @@ jobs:
       # itself; the heavy ML backends (jax/torch/tensorflow) are extras and are
       # intentionally left out, so their conditional imports are downgraded to
       # warnings in [tool.ty]. ty's version comes from the `lint` group.
+      # --no-default-groups keeps the default `dev` group (pytest/sphinx/...) out;
+      # only `lint` is needed here.
       - name: Run Type Checker
-        run: uv run --python 3.10 --group lint ty check --exit-zero-on-warning
+        run: uv run --python 3.10 --no-default-groups --group lint ty check --exit-zero-on-warning

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -348,7 +348,7 @@ jobs:
           needs_artifact: ${{ needs.image.outputs.needs_artifact }}
           docker_image: ${{ needs.image.outputs.docker_image }}
 
-      - name: Build documentation with Sphinx (fails on warnings)
+      - name: Build documentation with Sphinx (fails on warnings, linkcheck warns only)
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/zea" \
@@ -361,5 +361,6 @@ jobs:
               make docs-clean && \
               make docs-build SPHINXOPTS='-W --keep-going' && \
               make docs-test && \
-              make docs-linkcheck SPHINXOPTS='--keep-going' \
+              { make docs-linkcheck SPHINXOPTS='--keep-going' || \
+                echo '::warning title=Docs linkcheck failed::Sphinx linkcheck reported unreachable links. This can be a false positive (rate limiting, transient network issues, bot protection). See the step log for the offending URLs.'; } \
             "

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -352,7 +352,7 @@ jobs:
             -w /zea/docs \
             ${{ needs.image.outputs.docker_image }} \
             sh -c "\
-              uv pip install --system --group ../pyproject.toml:docs -e .. && \
+              uv pip install --system --group docs -e .. && \
               export PATH=\"/tmp/.local/bin:\$PATH\" && \
               export ZEA_LOG_LEVEL=ERROR && \
               make docs-clean && \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -177,7 +177,7 @@ jobs:
             -v "${{ github.workspace }}:/zea" \
             -w /zea \
             ${{ needs.image.outputs.docker_image }} \
-            sh -c "uv pip install --system -e .[tests] && pytest --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy -p no:cacheprovider -m 'not heavy and not notebook' ./tests"
+            sh -c "uv pip install --system --group tests -e . && pytest --cov --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy -p no:cacheprovider -m 'not heavy and not notebook' ./tests"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
@@ -221,7 +221,7 @@ jobs:
           UV_TORCH_BACKEND: cpu
         run: |
           uv venv
-          uv pip install --resolution lowest-direct -e ".[tests]" \
+          uv pip install --resolution lowest-direct --group tests -e "." \
             "tensorflow-cpu>=2.12.1" "jax[cpu]>=0.4.35" "torch>=2.2"
           echo "::group::Resolved dependency versions"
           uv pip freeze
@@ -352,7 +352,7 @@ jobs:
             -w /zea/docs \
             ${{ needs.image.outputs.docker_image }} \
             sh -c "\
-              uv pip install --system -e ..[docs] && \
+              uv pip install --system --group ../pyproject.toml:docs -e .. && \
               export PATH=\"/tmp/.local/bin:\$PATH\" && \
               export ZEA_LOG_LEVEL=ERROR && \
               make docs-clean && \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -201,6 +201,9 @@ jobs:
   # Guard against zea accidentally using functionality newer than the dependency
   # floors declared in pyproject.toml. Installs the *lowest* allowed versions of
   # zea's declared deps and runs the import tests against them.
+  # `.[app]` is named explicitly so lowest-direct pins gradio to its declared
+  # floor: reached only via the `tests` group's `zea[app]` self-reference it
+  # would count as transitive and resolve to the newest release instead.
   minimum-deps:
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -221,7 +224,7 @@ jobs:
           UV_TORCH_BACKEND: cpu
         run: |
           uv venv
-          uv pip install --resolution lowest-direct --group tests -e "." \
+          uv pip install --resolution lowest-direct --group tests -e ".[app]" \
             "tensorflow-cpu>=2.12.1" "jax[cpu]>=0.4.35" "torch>=2.2"
           echo "::group::Resolved dependency versions"
           uv pip freeze

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,20 +11,20 @@ build:
     python: "3.12"
   apt_packages:
     - pandoc
+  jobs:
+    # Runs instead of `python.install` below, which supports uv natively but
+    # cannot pass extra arguments to it, and we use `--no-default-groups` to avoid
+    # installing dev dependencies in the docs build.
+    install:
+      - uv sync --no-default-groups --group docs --extra jax
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
 
-# Optionally, but recommended,
-# declare the Python requirements required to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# Read the Docs only switches the build into uv mode when it sees a uv
+# entry here. This entry is never executed -- build.jobs.install above replaces it!
 python:
   install:
-    # Set UV_NO_DEFAULT_GROUPS=1 in the read the docs dashboard to exclude the 'dev' group from the docs build.
     - method: uv
       command: sync
-      groups:
-        - docs
-      extras:
-        - jax

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,15 +14,17 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/source/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
   install:
-    - method: pip
-      path: .
-      extra_requirements:
+    # Set UV_NO_DEFAULT_GROUPS=1 in the read the docs dashboard to exclude the 'dev' group from the docs build.
+    - method: uv
+      command: sync
+      groups:
         - docs
+      extras:
         - jax

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,15 +46,18 @@ WORKDIR /zea
 
 COPY pyproject.toml uv.lock README.md ./
 
-# Install all non-backend dependencies from the lockfile, installing dev extras only if
-# DEV is true. --no-install-project skips installing zea itself (added later as an
-# editable install), and --inexact keeps pip/setuptools available in the image.
+# Install all non-backend dependencies from the lockfile, installing the dev
+# dependency-group (tests + docs + lint + dev-only runtime pkgs) only if DEV is true.
+# uv installs the `dev` group by default, so the DEV=false branch must pass
+# --no-default-groups to keep dev tooling out of the production image.
+# --no-install-project skips installing zea itself (added later as an editable
+# install), and --inexact keeps pip/setuptools available in the image.
 ARG DEV
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$DEV" = "true" ]; then \
-    uv sync --frozen --no-install-project --inexact --extra dev; \
+    uv sync --frozen --no-install-project --inexact --group dev; \
     else \
-    uv sync --frozen --no-install-project --inexact; \
+    uv sync --frozen --no-install-project --inexact --no-default-groups; \
     fi
 
 # Install the selected backends in a single resolve. uv's --torch-backend selects the

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,9 +55,9 @@ COPY pyproject.toml uv.lock README.md ./
 ARG DEV
 RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$DEV" = "true" ]; then \
-    uv sync --frozen --no-install-project --inexact --group dev; \
+    uv sync --frozen --no-install-project --inexact --dev; \
     else \
-    uv sync --frozen --no-install-project --inexact --no-default-groups; \
+    uv sync --frozen --no-install-project --inexact --no-dev; \
     fi
 
 # Install the selected backends in a single resolve. uv's --torch-backend selects the

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,8 @@
 To build the documentation for the `zea` package, follow these steps:
 
 ## 1. Install dependencies
-Install the `zea` package with documentation dependencies:
+
+Install the `zea` package with documentation dependencies (requires uv or pip >=25.1):
 
 ```sh
 pip install -e . --group docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ To build the documentation for the `zea` package, follow these steps:
 Install the `zea` package with documentation dependencies:
 
 ```sh
-pip install -e .[docs]
+pip install -e . --group docs
 ```
 
 We also need to install `pandoc` to build the documentation:

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -75,14 +75,14 @@ a local environment, use `uv <https://docs.astral.sh/uv/>`_ or ``pip``.
 
          .. code-block:: shell
 
-               uv sync --group dev
+               uv sync
                uv run pre-commit install
 
          This creates a ``.venv`` with the exact locked dependencies and installs
          ``zea`` itself in **editable** mode, so your changes to the source take
-         effect immediately without reinstalling. The ``dev`` dependency-group bundles
-         the ``tests``, ``docs`` and ``lint`` groups. Prefix commands with ``uv run``
-         (e.g. ``uv run pytest``) or activate the environment with
+         effect immediately without reinstalling. This will also install the ``dev`` 
+         dependency-group, i.e. the ``tests``, ``docs`` and ``lint`` groups. Prefix commands 
+         with ``uv run`` (e.g. ``uv run pytest``) or activate the environment with
          ``source .venv/bin/activate``.
 
     .. tab-item:: pip
@@ -93,7 +93,7 @@ a local environment, use `uv <https://docs.astral.sh/uv/>`_ or ``pip``.
 
          .. code-block:: shell
 
-               pip install -e . --group dev
+               pip install -e .
                pre-commit install
 
 For local environments (uv or pip), you also need to install a machine learning

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -93,7 +93,7 @@ a local environment, use `uv <https://docs.astral.sh/uv/>`_ or ``pip``.
 
          .. code-block:: shell
 
-               pip install -e .
+               pip install -e . --group dev
                pre-commit install
 
 For local environments (uv or pip), you also need to install a machine learning

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -60,12 +60,13 @@ a local environment, use `uv <https://docs.astral.sh/uv/>`_ or ``pip``.
     .. tab-item:: Docker
 
          See the :ref:`Docker <docker-information>` section of the installation guide
-         for build and run instructions. Once inside the container, install the dev
-         dependencies:
+         for build and run instructions. Images built with ``DEV=true`` (the default)
+         already include the ``dev`` dependency-group (tests, docs and lint tools). If
+         you're in a container built with ``DEV=false``, install it first:
 
          .. code-block:: shell
 
-               pip install -e .[dev]
+               pip install -e . --group dev
                pre-commit install
 
     .. tab-item:: uv
@@ -74,23 +75,25 @@ a local environment, use `uv <https://docs.astral.sh/uv/>`_ or ``pip``.
 
          .. code-block:: shell
 
-               uv sync --extra dev
+               uv sync --group dev
                uv run pre-commit install
 
          This creates a ``.venv`` with the exact locked dependencies and installs
          ``zea`` itself in **editable** mode, so your changes to the source take
-         effect immediately without reinstalling. Prefix commands with ``uv run``
+         effect immediately without reinstalling. The ``dev`` dependency-group bundles
+         the ``tests``, ``docs`` and ``lint`` groups. Prefix commands with ``uv run``
          (e.g. ``uv run pytest``) or activate the environment with
          ``source .venv/bin/activate``.
 
     .. tab-item:: pip
 
          Install into any existing environment (``venv``, ``conda``, ...) with plain
-         ``pip``. The ``-e`` flag makes the install editable:
+         ``pip`` (requires pip >= 25.1 for ``--group`` support). The ``-e`` flag makes
+         the install editable:
 
          .. code-block:: shell
 
-               pip install -e .[dev]
+               pip install -e . --group dev
                pre-commit install
 
 For local environments (uv or pip), you also need to install a machine learning
@@ -244,7 +247,7 @@ The overall structure of the documentation is manually designed, but the API doc
 .. code-block:: shell
 
    # if you didn't install the dependencies earlier
-   pip install -e .[docs]
+   pip install -e . --group docs
    cd docs
    make docs-clean && make docs-build
    # you can also serve the docs locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,24 +80,11 @@ Contributing = "https://zea.readthedocs.io/en/latest/contributing.html"
 [project.scripts]
 zea = "zea.__main__:main"
 
-# Dev-only tooling lives in PEP 735 dependency-groups, not [project.optional-
-# dependencies] extras: extras publish to the wheel's Requires-Dist metadata and are
-# meant for optional *runtime* features an end user opts into (zea[jax], zea[app]);
-# groups never publish and are dev/CI-only. Consumers: CI uses `--only-group lint`
-# (minimal env, no zea runtime deps) and `--group tests`/`--group docs`; readthedocs
-# uses method: uv + command: sync + groups (see .readthedocs.yaml); local/Docker use
-# `--group dev`. Requires pip >= 25.1 / uv (both understand `--group`).
-#
-# We keep uv's default of installing the `dev` group on bare `uv sync` / `uv run` (we
-# do NOT set tool.uv.default-groups), so contributors get the full env without
-# surprises. Environments that must stay lean opt out explicitly: `--no-default-groups`
-# for the DEV=false Docker image and the typecheck CI job, `--only-group` for the lint
-# CI job, and the UV_NO_DEFAULT_GROUPS env var on readthedocs (set in its dashboard).
+# Dev-only tooling: unlike extras, groups are never published. Needs pip >= 25.1 / uv.
+# uv installs `dev` by default; lean envs opt out with --no-default-groups /
+# --only-group (readthedocs: UV_NO_DEFAULT_GROUPS, set in its dashboard).
 [dependency-groups]
-lint = [
-    "ruff==0.15.22",
-    "ty==0.0.62",
-]
+lint = ["ruff==0.15.22", "ty==0.0.62"]
 tests = [
     "pytest>=9.0.3",
     "papermill>=2.4",
@@ -107,7 +94,7 @@ tests = [
     "ipywidgets",
     "pre-commit",
     "pytest-cov",
-    "gradio>=6.0",
+    "zea[app]",
 ]
 docs = [
     "sphinx",
@@ -124,16 +111,13 @@ docs = [
     "PyStemmer",
     "IPython",
 ]
-# The full local/Docker dev environment: tooling groups plus the runtime extras the
-# old `dev` extra pulled in (display-headless -> opencv-python-headless, models ->
-# onnxruntime; app's gradio already comes via `tests`). A group cannot include a
-# project extra, so those two are inlined here — keep them in sync with the extras.
+# The full dev environment: the tooling groups plus the runtime extras
 dev = [
     { include-group = "tests" },
     { include-group = "docs" },
     { include-group = "lint" },
-    "opencv-python-headless>=4",
-    "onnxruntime>=1.15",
+    "zea[display-headless]",
+    "zea[models]",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,14 +58,46 @@ dependencies = [
     "scikit-learn >=1.4",
 ]
 [project.optional-dependencies]
-dev = [
-    "zea[tests]",
-    "zea[docs]",
-    "zea[display-headless]",
-    "zea[models]",
-    "zea[app]",
-]
+jax = ["jax[cuda12]>=0.4.35"]
+display = ["opencv-python>=4"]
+display-headless = ["opencv-python-headless>=4"]
+# most models don't needs these optional dependencies
+# but some do, so we list them here
+models = ["onnxruntime>=1.15"]
+app = ["gradio>=6.0"]
+# these are just here for .readthedocs.yaml
+# please for proper install (with GPU support)
+# install manually
+backends = ["jax>=0.4.35", "tensorflow>=2.12.1", "torch>=2.2"]
 
+[project.urls]
+Homepage = "https://github.com/tue-bmd/zea/"
+Repository = "https://github.com/tue-bmd/zea/"
+Documentation = "https://zea.readthedocs.io"
+Issues = "https://github.com/tue-bmd/zea/issues"
+Contributing = "https://zea.readthedocs.io/en/latest/contributing.html"
+
+[project.scripts]
+zea = "zea.__main__:main"
+
+# Dev-only tooling lives in PEP 735 dependency-groups, not [project.optional-
+# dependencies] extras: extras publish to the wheel's Requires-Dist metadata and are
+# meant for optional *runtime* features an end user opts into (zea[jax], zea[app]);
+# groups never publish and are dev/CI-only. Consumers: CI uses `--only-group lint`
+# (minimal env, no zea runtime deps) and `--group tests`/`--group docs`; readthedocs
+# uses method: uv + command: sync + groups (see .readthedocs.yaml); local/Docker use
+# `--group dev`. Requires pip >= 25.1 / uv (both understand `--group`).
+#
+# We keep uv's default of installing the `dev` group on bare `uv sync` / `uv run` (we
+# do NOT set tool.uv.default-groups), so contributors get the full env without
+# surprises. Environments that must stay lean opt out explicitly: `--no-default-groups`
+# for the DEV=false Docker image and the typecheck CI job, `--only-group` for the lint
+# CI job, and the UV_NO_DEFAULT_GROUPS env var on readthedocs (set in its dashboard).
+[dependency-groups]
+lint = [
+    "ruff==0.15.22",
+    "ty==0.0.62",
+]
 tests = [
     "pytest>=9.0.3",
     "papermill>=2.4",
@@ -92,32 +124,16 @@ docs = [
     "PyStemmer",
     "IPython",
 ]
-jax = ["jax[cuda12]>=0.4.35"]
-display = ["opencv-python>=4"]
-display-headless = ["opencv-python-headless>=4"]
-# most models don't needs these optional dependencies
-# but some do, so we list them here
-models = ["onnxruntime>=1.15"]
-app = ["gradio>=6.0"]
-# these are just here for .readthedocs.yaml
-# please for proper install (with GPU support)
-# install manually
-backends = ["jax>=0.4.35", "tensorflow>=2.12.1", "torch>=2.2"]
-
-[project.urls]
-Homepage = "https://github.com/tue-bmd/zea/"
-Repository = "https://github.com/tue-bmd/zea/"
-Documentation = "https://zea.readthedocs.io"
-Issues = "https://github.com/tue-bmd/zea/issues"
-Contributing = "https://zea.readthedocs.io/en/latest/contributing.html"
-
-[project.scripts]
-zea = "zea.__main__:main"
-
-[dependency-groups]
-lint = [
-    "ruff==0.15.22",
-    "ty==0.0.62",
+# The full local/Docker dev environment: tooling groups plus the runtime extras the
+# old `dev` extra pulled in (display-headless -> opencv-python-headless, models ->
+# onnxruntime; app's gradio already comes via `tests`). A group cannot include a
+# project extra, so those two are inlined here — keep them in sync with the extras.
+dev = [
+    { include-group = "tests" },
+    { include-group = "docs" },
+    { include-group = "lint" },
+    "opencv-python-headless>=4",
+    "onnxruntime>=1.15",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -124,9 +124,12 @@ def test_package_does_not_import_ml_libs():
         importlib.import_module("zea")
 
 
-def _subprocess_import_zea_with_only_backend(backend):  # pragma: no cover
+def _subprocess_import_zea_with_only_backend(backend, keras_backend=None):  # pragma: no cover
     """
     This function is run in a subprocess to test zea import with only one backend available.
+
+    ``keras_backend`` sets KERAS_BACKEND independently of the available backend (used to
+    test e.g. KERAS_BACKEND=numpy); it defaults to ``backend``.
     """
     import builtins
     import importlib.util
@@ -137,8 +140,10 @@ def _subprocess_import_zea_with_only_backend(backend):  # pragma: no cover
     all_backends = ["tensorflow", "torch", "jax"]
 
     # Set KERAS_BACKEND before any imports
-    if backend is not None:
-        os.environ["KERAS_BACKEND"] = backend
+    if keras_backend is None:
+        keras_backend = backend
+    if keras_backend is not None:
+        os.environ["KERAS_BACKEND"] = keras_backend
 
     import_orig = builtins.__import__
 
@@ -191,14 +196,14 @@ def _subprocess_import_zea_with_only_backend(backend):  # pragma: no cover
     sys.exit(0)
 
 
-def run_import_zea_with_only_backend(backend):
+def run_import_zea_with_only_backend(backend, keras_backend=None):
     """
     Run a subprocess that tries to import zea with only one backend available.
     All other backends will raise ImportError.
     """
     # Get the source code of the subprocess function, dedent, and add call at the end
     code = textwrap.dedent(inspect.getsource(_subprocess_import_zea_with_only_backend))
-    code += f"\n_subprocess_import_zea_with_only_backend({repr(backend)})\n"
+    code += f"\n_subprocess_import_zea_with_only_backend({repr(backend)}, {repr(keras_backend)})\n"
     result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
     return result
 
@@ -236,6 +241,29 @@ def test_import_zea_with_backend_subprocess(backend, should_succeed):
     else:
         if result.returncode == 0:
             assert False, "zea should not import if all backends are missing"
+
+
+@pytest.mark.parametrize("backend,should_succeed", [("jax", True), ("torch", False)])
+def test_import_zea_numpy_backend_requires_jax(backend, should_succeed):
+    """KERAS_BACKEND=numpy requires jax, even when another backend is installed.
+
+    Keras' numpy backend is not standalone, so zea should refuse to import with a clear
+    dependency error when jax is missing, regardless of torch/tensorflow being available.
+    """
+    result = run_import_zea_with_only_backend(backend, keras_backend="numpy")
+    output = result.stdout + result.stderr
+    if should_succeed:
+        assert result.returncode == 0, (
+            f"zea should import with KERAS_BACKEND=numpy and jax available.\n{output}"
+        )
+    else:
+        assert result.returncode != 0, (
+            f"zea should not import with KERAS_BACKEND=numpy while jax is missing "
+            f"(only {backend} installed)."
+        )
+        assert "jax must be installed as well" in output, (
+            f"Expected the numpy/jax dependency error, got:\n{output}"
+        )
 
 
 def test_all_model_modules_imported():

--- a/uv.lock
+++ b/uv.lock
@@ -7523,6 +7523,22 @@ backends = [
     { name = "tensorflow" },
     { name = "torch" },
 ]
+display = [
+    { name = "opencv-python" },
+]
+display-headless = [
+    { name = "opencv-python-headless" },
+]
+jax = [
+    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version < '3.11'" },
+    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version >= '3.11'" },
+]
+models = [
+    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+
+[package.dev-dependencies]
 dev = [
     { name = "cloudpickle" },
     { name = "furo" },
@@ -7543,6 +7559,7 @@ dev = [
     { name = "pystemmer" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "ruff" },
     { name = "simpleitk" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -7558,12 +7575,7 @@ dev = [
     { name = "sphinx-reredirects", version = "0.1.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-reredirects", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-bibtex" },
-]
-display = [
-    { name = "opencv-python" },
-]
-display-headless = [
-    { name = "opencv-python-headless" },
+    { name = "ty" },
 ]
 docs = [
     { name = "furo" },
@@ -7589,13 +7601,9 @@ docs = [
     { name = "sphinx-reredirects", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-bibtex" },
 ]
-jax = [
-    { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version >= '3.11'" },
-]
-models = [
-    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+lint = [
+    { name = "ruff" },
+    { name = "ty" },
 ]
 tests = [
     { name = "cloudpickle" },
@@ -7609,76 +7617,97 @@ tests = [
     { name = "simpleitk" },
 ]
 
-[package.dev-dependencies]
-lint = [
-    { name = "ruff" },
-    { name = "ty" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "cloudpickle", marker = "extra == 'tests'", specifier = ">=3.1.1" },
     { name = "decorator", specifier = ">=5" },
     { name = "fsspec", extras = ["http"] },
-    { name = "furo", marker = "extra == 'docs'" },
     { name = "gradio", marker = "extra == 'app'", specifier = ">=6.0" },
-    { name = "gradio", marker = "extra == 'tests'", specifier = ">=6.0" },
     { name = "grain", specifier = ">=0.2.8" },
     { name = "h5py", specifier = ">=3.11" },
     { name = "hdf5plugin", specifier = ">=4.4" },
     { name = "huggingface-hub", specifier = ">=1.2" },
     { name = "imageio", extras = ["ffmpeg"], specifier = ">=2.0" },
-    { name = "ipykernel", marker = "extra == 'tests'", specifier = ">=6.29.5" },
-    { name = "ipython", marker = "extra == 'docs'" },
-    { name = "ipywidgets", marker = "extra == 'tests'" },
     { name = "jax", marker = "extra == 'backends'", specifier = ">=0.4.35" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'jax'", specifier = ">=0.4.35" },
     { name = "keras", specifier = ">=3.12.1" },
     { name = "matplotlib", specifier = ">=3.10" },
-    { name = "myst-parser", marker = "extra == 'docs'" },
-    { name = "nbsphinx", marker = "extra == 'docs'" },
     { name = "numcodecs", specifier = ">=0.13" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "onnxruntime", marker = "extra == 'models'", specifier = ">=1.15" },
     { name = "opencv-python", marker = "extra == 'display'", specifier = ">=4" },
     { name = "opencv-python-headless", marker = "extra == 'display-headless'", specifier = ">=4" },
-    { name = "papermill", marker = "extra == 'tests'", specifier = ">=2.4" },
     { name = "pillow", specifier = ">=12.2.0" },
-    { name = "pre-commit", marker = "extra == 'tests'" },
-    { name = "pybtex", marker = "extra == 'docs'", specifier = ">=0.26.1" },
-    { name = "pystemmer", marker = "extra == 'docs'" },
-    { name = "pytest", marker = "extra == 'tests'", specifier = ">=9.0.3" },
-    { name = "pytest-cov", marker = "extra == 'tests'" },
     { name = "pyyaml", specifier = ">=6" },
     { name = "scikit-image", specifier = ">=0.23" },
     { name = "scikit-learn", specifier = ">=1.4" },
     { name = "scipy", specifier = ">=1.13" },
-    { name = "simpleitk", marker = "extra == 'tests'", specifier = ">=2.2.1" },
-    { name = "sphinx", marker = "extra == 'docs'" },
-    { name = "sphinx-autobuild", marker = "extra == 'docs'" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'" },
-    { name = "sphinx-copybutton", marker = "extra == 'docs'" },
-    { name = "sphinx-design", marker = "extra == 'docs'" },
-    { name = "sphinx-reredirects", marker = "extra == 'docs'" },
-    { name = "sphinxcontrib-bibtex", marker = "extra == 'docs'", specifier = ">=2.6.5" },
     { name = "tensorflow", marker = "extra == 'backends'", specifier = ">=2.12.1" },
     { name = "torch", marker = "extra == 'backends'", specifier = ">=2.2" },
     { name = "tqdm", specifier = ">=4" },
     { name = "tyro", specifier = ">=1.0" },
     { name = "wandb", specifier = ">=0.18" },
     { name = "wget", specifier = ">=3.2" },
-    { name = "zea", extras = ["app"], marker = "extra == 'dev'" },
-    { name = "zea", extras = ["display-headless"], marker = "extra == 'dev'" },
-    { name = "zea", extras = ["docs"], marker = "extra == 'dev'" },
-    { name = "zea", extras = ["models"], marker = "extra == 'dev'" },
-    { name = "zea", extras = ["tests"], marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev", "tests", "docs", "jax", "display", "display-headless", "models", "app", "backends"]
+provides-extras = ["jax", "display", "display-headless", "models", "app", "backends"]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "cloudpickle", specifier = ">=3.1.1" },
+    { name = "furo" },
+    { name = "gradio", specifier = ">=6.0" },
+    { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "ipython" },
+    { name = "ipywidgets" },
+    { name = "myst-parser" },
+    { name = "nbsphinx" },
+    { name = "onnxruntime", specifier = ">=1.15" },
+    { name = "opencv-python-headless", specifier = ">=4" },
+    { name = "papermill", specifier = ">=2.4" },
+    { name = "pre-commit" },
+    { name = "pybtex", specifier = ">=0.26.1" },
+    { name = "pystemmer" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov" },
+    { name = "ruff", specifier = "==0.15.22" },
+    { name = "simpleitk", specifier = ">=2.2.1" },
+    { name = "sphinx" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design" },
+    { name = "sphinx-reredirects" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
+    { name = "ty", specifier = "==0.0.62" },
+]
+docs = [
+    { name = "furo" },
+    { name = "ipython" },
+    { name = "myst-parser" },
+    { name = "nbsphinx" },
+    { name = "pybtex", specifier = ">=0.26.1" },
+    { name = "pystemmer" },
+    { name = "sphinx" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-autodoc-typehints" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design" },
+    { name = "sphinx-reredirects" },
+    { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
+]
 lint = [
     { name = "ruff", specifier = "==0.15.22" },
     { name = "ty", specifier = "==0.0.62" },
+]
+tests = [
+    { name = "cloudpickle", specifier = ">=3.1.1" },
+    { name = "gradio", specifier = ">=6.0" },
+    { name = "ipykernel", specifier = ">=6.29.5" },
+    { name = "ipywidgets" },
+    { name = "papermill", specifier = ">=2.4" },
+    { name = "pre-commit" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov" },
+    { name = "simpleitk", specifier = ">=2.2.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7542,7 +7542,6 @@ models = [
 dev = [
     { name = "cloudpickle" },
     { name = "furo" },
-    { name = "gradio" },
     { name = "ipykernel" },
     { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -7550,9 +7549,6 @@ dev = [
     { name = "myst-parser", version = "4.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "myst-parser", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "nbsphinx" },
-    { name = "onnxruntime", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opencv-python-headless" },
     { name = "papermill" },
     { name = "pre-commit" },
     { name = "pybtex" },
@@ -7576,6 +7572,7 @@ dev = [
     { name = "sphinx-reredirects", version = "1.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinxcontrib-bibtex" },
     { name = "ty" },
+    { name = "zea", extra = ["app", "display-headless", "models"] },
 ]
 docs = [
     { name = "furo" },
@@ -7607,7 +7604,6 @@ lint = [
 ]
 tests = [
     { name = "cloudpickle" },
-    { name = "gradio" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
     { name = "papermill" },
@@ -7615,6 +7611,7 @@ tests = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "simpleitk" },
+    { name = "zea", extra = ["app"] },
 ]
 
 [package.metadata]
@@ -7654,14 +7651,11 @@ provides-extras = ["jax", "display", "display-headless", "models", "app", "backe
 dev = [
     { name = "cloudpickle", specifier = ">=3.1.1" },
     { name = "furo" },
-    { name = "gradio", specifier = ">=6.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipython" },
     { name = "ipywidgets" },
     { name = "myst-parser" },
     { name = "nbsphinx" },
-    { name = "onnxruntime", specifier = ">=1.15" },
-    { name = "opencv-python-headless", specifier = ">=4" },
     { name = "papermill", specifier = ">=2.4" },
     { name = "pre-commit" },
     { name = "pybtex", specifier = ">=0.26.1" },
@@ -7678,6 +7672,9 @@ dev = [
     { name = "sphinx-reredirects" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
     { name = "ty", specifier = "==0.0.62" },
+    { name = "zea", extras = ["app"] },
+    { name = "zea", extras = ["display-headless"] },
+    { name = "zea", extras = ["models"] },
 ]
 docs = [
     { name = "furo" },
@@ -7700,7 +7697,6 @@ lint = [
 ]
 tests = [
     { name = "cloudpickle", specifier = ">=3.1.1" },
-    { name = "gradio", specifier = ">=6.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
     { name = "ipywidgets" },
     { name = "papermill", specifier = ">=2.4" },
@@ -7708,6 +7704,7 @@ tests = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-cov" },
     { name = "simpleitk", specifier = ">=2.2.1" },
+    { name = "zea", extras = ["app"] },
 ]
 
 [[package]]

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
     from .internal.device import init_device
     from .internal.setup_zea import setup, setup_config
     from .ops import Pipeline
-    from .probes import Probe
     from .parameters import Parameters
+    from .probes import Probe
 
 try:
     # dynamically add __version__ attribute (see pyproject.toml)
@@ -80,6 +80,14 @@ def _bootstrap_backend():
 
         # Error if no backends are installed
         if not installed_backends:
+            if effective_backend == "numpy":
+                raise ImportError(
+                    f"No ML backend (torch, tensorflow, jax) installed in current "
+                    f"environment. KERAS_BACKEND is set to 'numpy', but Keras' numpy "
+                    f"backend is not standalone: jax must be installed as well. Install it with "
+                    f"`pip install {__package__}[jax]` (GPU) or `pip install 'jax[cpu]'` "
+                    f"(CPU-only). For more information, see: {DOCS_URL}"
+                )
             if backend_env:
                 backend_status = f"KERAS_BACKEND is set to '{backend_env}'"
             else:

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -78,16 +78,25 @@ def _bootstrap_backend():
             backend for backend in ML_BACKENDS if importlib.util.find_spec(backend) is not None
         ]
 
+        # Keras' numpy backend is not standalone: it imports jax internally (see
+        # keras/src/backend/numpy/nn.py), so jax is required no matter which other
+        # backends happen to be installed.
+        if effective_backend == "numpy" and "jax" not in installed_backends:
+            if installed_backends:
+                backend_status = f"Installed backends: {', '.join(installed_backends)}."
+            else:
+                backend_status = (
+                    "No ML backend (torch, tensorflow, jax) installed in current environment."
+                )
+            raise ImportError(
+                f"{backend_status} KERAS_BACKEND is set to 'numpy', but Keras' numpy "
+                f"backend is not standalone: jax must be installed as well. Install it with "
+                f"`pip install {__package__}[jax]` (GPU) or `pip install 'jax[cpu]'` "
+                f"(CPU-only). For more information, see: {DOCS_URL}"
+            )
+
         # Error if no backends are installed
         if not installed_backends:
-            if effective_backend == "numpy":
-                raise ImportError(
-                    f"No ML backend (torch, tensorflow, jax) installed in current "
-                    f"environment. KERAS_BACKEND is set to 'numpy', but Keras' numpy "
-                    f"backend is not standalone: jax must be installed as well. Install it with "
-                    f"`pip install {__package__}[jax]` (GPU) or `pip install 'jax[cpu]'` "
-                    f"(CPU-only). For more information, see: {DOCS_URL}"
-                )
             if backend_env:
                 backend_status = f"KERAS_BACKEND is set to '{backend_env}'"
             else:


### PR DESCRIPTION
Follow-up to #463, which added the first dependency-group (`lint`). This finishes the job: `tests`, `docs` and a new aggregate `dev` group move out of `[project.optional-dependencies]`, so dev-only tooling is no longer published in the wheel's metadata. Runtime extras (`jax`, `app`, `models`, `display*`) stay as extras.

Note that this is [the recommended way](https://pydevtools.com/handbook/explanation/understanding-dependency-groups-in-uv/#choose-between-groups-and-extras).

It is good to note that `uv` installs the `dev` dependency group automatically, so a nice and short `uv sync` will get you everything you need to develop for `zea`. Can easily be excluded through `uv sync --no-dev`.

### Also

- readthedocs switches to `method: uv` + `command: sync`.
- Clearer `ImportError` when `KERAS_BACKEND=numpy` and no backend is installed — Keras'
  numpy backend delegates FFT to jax, so jax is required regardless.
- Linkcheck will now now warn instead of error

### Note for contributors

Installing dev dependencies with plain `pip` now needs pip >= 25.1 (`--group` support).
uv users are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup guidance when the NumPy backend is selected without the required JAX installation (now clearly requires JAX when using Keras’ NumPy backend).
* **Documentation**
  * Updated setup and contributing/documentation-build instructions to use dependency groups instead of extras, including local docs install commands.
* **Chores**
  * Refined CI, linting, Docker, and development/remote setup workflows to install dependencies via `uv` and dependency groups for more consistent “dev/tests/docs/lint” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->