### PR TITLE
Merge the model and data preset utils into one Hugging Face layer

### DIFF
--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -44,6 +44,13 @@ Here are the environment variables that ``zea`` uses at runtime. Arguably the mo
      - ``auto:1``
      - Any valid device name as accepted by :func:`zea.init_device`. For example, ``cpu``,
        ``cuda:0``, ``auto:1``, etc.
+   * - ``ZEA_HF_CACHE_TTL``
+     - Seconds a Hugging Face repository listing or resolved download path may be reused before
+       ``zea`` asks the hub again. Keeps a dataset scan or preset load from repeating the same
+       request; set to ``0`` if you need every call to hit the hub (e.g. a repo being written to
+       from elsewhere while you read it).
+     - ``300``
+     - Any number of seconds, ``0`` to disable.
    * - ``ZEA_CHUNK_CACHE``
      - Cache chunks fetched while streaming (``hf://``) under ``ZEA_CACHE_DIR/chunks``, so a
        repeated read is served from disk instead of re-downloaded. Keyed by content hash, so a

--- a/tests/test_fnumber_mask.py
+++ b/tests/test_fnumber_mask.py
@@ -111,9 +111,11 @@ def test_compute_element_normals_convex_arc():
 def test_fnumber_mask_flat_linear_is_legacy_noop(probe_geometry, flatgrid, fnum_window_fn):
     """On a flat array the per-element-normal mask equals the old global-+z mask.
 
-    The reference is the legacy angle-relative-to-global-+z formula computed
-    with the same backend ops, so any difference would be a real change in
-    behaviour rather than a norm-implementation rounding difference.
+    The reference is the legacy angle-relative-to-global-+z formula computed with
+    the same backend ops, so a difference beyond float32 rounding would be a real
+    change in behaviour. Rounding is not zero: the mask reaches the same angle
+    through a dot product with the element normal, which a backend may fuse and
+    round differently than reading the z component directly.
     """
     rel = flatgrid[:, None] - probe_geometry[None]
     rel_norm = ops.linalg.norm(rel, axis=-1)
@@ -124,7 +126,7 @@ def test_fnumber_mask_flat_linear_is_legacy_noop(probe_geometry, flatgrid, fnum_
     mask = ops.convert_to_numpy(
         fnumber_mask(flatgrid, probe_geometry, f_number=0.5, fnum_window_fn=fnum_window_fn)
     )
-    assert np.array_equal(mask, reference)
+    np.testing.assert_allclose(mask, reference, atol=1e-6)
 
 
 def test_fnumber_mask_convex_widens_field_of_view():

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -15,7 +15,7 @@ import httpx
 import keras
 import numpy as np
 import pytest
-from huggingface_hub import RepoFile
+from huggingface_hub import RepoFile, RepoFolder
 from huggingface_hub.utils import (
     EntryNotFoundError,
     HFValidationError,
@@ -103,20 +103,40 @@ def test_hf_call_does_not_retry_other_errors(monkeypatch):
     assert logins == []
 
 
-def test_hf_call_download_retry_set_excludes_missing_entries(monkeypatch):
-    """`check_file_exists` must fail fast: a missing file is not retried."""
+def test_download_of_a_missing_file_is_not_retried(monkeypatch):
+    """`check_file_exists` must fail fast: a missing file is not worth a login."""
     logins = []
     monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
     calls = []
 
-    def missing():
+    def missing(**kwargs):
         calls.append(1)
         raise EntryNotFoundError("404 Client Error")
 
+    monkeypatch.setattr(ipu, "hf_hub_download", missing)
+
     with pytest.raises(EntryNotFoundError):
-        ipu._hf_call(missing, retry_on=ipu._HF_DOWNLOAD_RETRY_ERRORS)
+        ipu._hf_download(REPO_ID, "config.json")
     assert len(calls) == 1
     assert logins == []
+
+
+def test_download_of_an_unreachable_repo_is_retried(monkeypatch):
+    """A repo that 404s anonymously may just need a token."""
+    logins = []
+    monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
+    calls = []
+
+    def unreachable(**kwargs):
+        calls.append(1)
+        raise _repo_not_found()
+
+    monkeypatch.setattr(ipu, "hf_hub_download", unreachable)
+
+    with pytest.raises(RepositoryNotFoundError):
+        ipu._hf_download(REPO_ID, "config.json")
+    assert len(calls) == 2
+    assert len(logins) == 1
 
 
 # _hf_login
@@ -179,11 +199,12 @@ def test_ttl_cache_disabled_with_zero_ttl():
     assert len(calls) == 2
 
 
-def test_ttl_cache_bypassed_for_unhashable_key():
+def test_ttl_cache_bypassed_without_a_key():
+    """A `None` key (what `_cache_key` returns for unhashable arguments) skips the cache."""
     cache = ipu._TTLCache(ttl=60)
     calls = []
     for _ in range(2):
-        cache.get_or_call(None, lambda: calls.append(1))
+        cache.get_or_call(ipu._cache_key("repo", allow_patterns=["*.h5"]), lambda: calls.append(1))
     assert len(calls) == 2
 
 
@@ -226,6 +247,8 @@ def fake_tree(monkeypatch):
         RepoFile(path="val/b.h5", size=20, oid="2"),
         RepoFile(path="val/notes.txt", size=1, oid="3"),
         RepoFile(path="train/c.hdf5", size=30, oid="4"),
+        # A recursive tree also yields the directories, which are not files.
+        RepoFolder(path="val", oid="5"),
     ]
     calls = []
 
@@ -565,7 +588,7 @@ def test_get_file_hf_missing_entry(monkeypatch):
 
 
 @pytest.fixture
-def registered_presets():
+def registered_presets(local_preset):
     """Register throwaway presets and clean up the global registry afterwards."""
 
     class _Dummy:
@@ -573,7 +596,7 @@ def registered_presets():
 
     presets = {
         "_pytest_hf": {"hf_handle": "hf://zeahub/_pytest", "metadata": {}},
-        "_pytest_local": {"path": "/tmp/_pytest_preset", "metadata": {}},
+        "_pytest_local": {"path": str(local_preset), "metadata": {}},
     }
     mpu.register_presets(presets, _Dummy)
     yield _Dummy, presets
@@ -593,14 +616,16 @@ def test_builtin_preset_resolves_to_hf_handle(registered_presets, fake_model_dow
     assert fake_model_download[0]["repo_id"] == "zeahub/_pytest"
 
 
-def test_builtin_preset_resolves_to_path(registered_presets):
-    """A preset registered with a `path` resolves to that (here missing) directory."""
-    with pytest.raises(ValueError, match="Unknown preset identifier"):
-        mpu.get_file("_pytest_local", "config.json")
+def test_builtin_preset_resolves_to_path(registered_presets, local_preset):
+    """A preset registered with a `path` reads from that directory."""
+    assert mpu.get_file("_pytest_local", "config.json") == str(local_preset / "config.json")
 
 
 def test_model_presets_property_lists_builtins():
-    assert "dense" in DenseNet.presets or DenseNet.presets == {}
+    """`cls.presets` exposes what `register_presets` recorded for that class."""
+    from zea.models.presets import dense_presets
+
+    assert DenseNet.presets == dense_presets
 
 
 # Config helpers
@@ -1209,3 +1234,56 @@ def test_sharded_save_and_load_round_trip(tmp_path, monkeypatch):
 
     assert np.allclose(expected, np.array(reloaded(inputs)))
     assert set(shards).issubset(requested)
+
+
+def test_get_file_local_follows_symlinks(tmp_path):
+    """A snapshot directory is a valid preset: its files are symlinks into `blobs/`."""
+    blobs = tmp_path / "blobs"
+    blobs.mkdir()
+    (blobs / "sha123").write_text(json.dumps({"registered_name": "Functional"}))
+    snapshot = tmp_path / "snapshots" / "abc123"
+    snapshot.mkdir(parents=True)
+    (snapshot / "config.json").symlink_to(blobs / "sha123")
+
+    assert mpu.get_file(str(snapshot), "config.json") == str(snapshot / "config.json")
+    assert mpu.load_json(str(snapshot)) == {"registered_name": "Functional"}
+
+
+def test_download_with_force_download_is_not_memoized(fake_hub_download):
+    """`force_download` means re-fetch, which a memoized path would quietly skip."""
+    ipu._hf_download(REPO_ID, "config.json", force_download=True)
+    ipu._hf_download(REPO_ID, "config.json", force_download=True)
+    assert len(fake_hub_download) == 2
+
+
+def test_ttl_cache_drops_expired_entries():
+    """Expired entries do not pile up in a long-running process."""
+    cache = ipu._TTLCache(ttl=0.02)
+    cache.get_or_call("first", lambda: "value")
+    time.sleep(0.05)
+    cache.get_or_call("second", lambda: "value")
+    assert list(cache._entries) == ["second"]
+
+
+def test_cache_ttl_falls_back_on_an_unparseable_value(monkeypatch):
+    monkeypatch.setenv("ZEA_HF_CACHE_TTL", "off")
+    assert ipu._hf_cache_ttl() == ipu._DEFAULT_HF_CACHE_TTL
+
+    monkeypatch.setenv("ZEA_HF_CACHE_TTL", "0")
+    assert ipu._hf_cache_ttl() == 0
+
+
+def test_streaming_does_not_go_through_the_caches(monkeypatch):
+    """Streamed reads must reach the hub every time; they are not downloads."""
+    opens = []
+
+    class FakeFS:
+        def open(self, path, mode, **kwargs):
+            opens.append(path)
+            return "FILEOBJ"
+
+    monkeypatch.setattr("huggingface_hub.HfFileSystem", FakeFS)
+
+    for _ in range(2):
+        ipu._hf_stream_open(f"hf://{REPO_ID}/val/a.hdf5")
+    assert len(opens) == 2

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -424,6 +424,15 @@ def test_resolve_path_directory(fake_resolve):
     assert sorted(p.name for p in result.iterdir()) == ["a.hdf5", "b.hdf5"]
 
 
+def test_resolve_path_directory_with_trailing_slash(fake_resolve):
+    """`hf://org/repo/val/` names the same directory as `hf://org/repo/val`."""
+    assert ipu._hf_resolve_path(f"hf://{REPO_ID}/val/") == fake_resolve / "val"
+
+
+def test_resolve_path_whole_repo_with_trailing_slash(fake_resolve):
+    assert ipu._hf_resolve_path(f"hf://{REPO_ID}/") == fake_resolve
+
+
 def test_resolve_path_single_file(fake_resolve):
     result = ipu._hf_resolve_path(f"hf://{REPO_ID}/val/a.hdf5")
     assert result == fake_resolve / "val" / "a.hdf5"

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -47,9 +47,7 @@ def _clear_hf_caches():
     ipu._hf_clear_caches()
 
 
-# --------------------------------------------------------------------------------------
 # _hf_call: login-and-retry
-# --------------------------------------------------------------------------------------
 
 
 def test_hf_call_returns_without_login(monkeypatch):
@@ -121,9 +119,7 @@ def test_hf_call_download_retry_set_excludes_missing_entries(monkeypatch):
     assert logins == []
 
 
-# --------------------------------------------------------------------------------------
 # _hf_login
-# --------------------------------------------------------------------------------------
 
 
 def test_hf_login_without_token_is_noop(monkeypatch):
@@ -150,9 +146,7 @@ def test_hf_login_uses_token_from_env(monkeypatch, env_var):
     assert calls == [{"token": "hf_dummy_token", "skip_if_logged_in": True}]
 
 
-# --------------------------------------------------------------------------------------
 # _TTLCache / _cache_key
-# --------------------------------------------------------------------------------------
 
 
 def test_ttl_cache_returns_cached_value():
@@ -221,9 +215,7 @@ def test_cache_key_is_none_for_unhashable_arguments():
     assert ipu._cache_key("repo", allow_patterns=["*.h5"]) is None
 
 
-# --------------------------------------------------------------------------------------
 # Repository listings
-# --------------------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -291,9 +283,7 @@ def test_list_h5_files_unknown_subdirectory_is_empty(fake_tree):
     assert ipu._hf_list_h5_files(f"hf://{REPO_ID}/nope") == []
 
 
-# --------------------------------------------------------------------------------------
 # Downloads
-# --------------------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -384,9 +374,7 @@ def test_download_files_in_path_runs_concurrently(monkeypatch):
     assert state["peak"] > 1
 
 
-# --------------------------------------------------------------------------------------
 # Path resolution
-# --------------------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -438,9 +426,7 @@ def test_snapshot_dir_lookup_without_snapshots_dir(tmp_path):
         ipu._get_snapshot_dir_from_downloaded_file(tmp_path / "a.hdf5")
 
 
-# --------------------------------------------------------------------------------------
 # repo_type prefixes and stream URLs
-# --------------------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -495,9 +481,7 @@ def test_stream_open_retries_after_login(monkeypatch):
     assert len(logins) == 1
 
 
-# --------------------------------------------------------------------------------------
 # zea.models.preset_utils — get_file
-# --------------------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -577,9 +561,7 @@ def test_get_file_hf_missing_entry(monkeypatch):
         mpu.get_file("hf://zeahub/taesdxl", "config.json")
 
 
-# --------------------------------------------------------------------------------------
 # Built-in preset registry
-# --------------------------------------------------------------------------------------
 
 
 @pytest.fixture
@@ -621,9 +603,7 @@ def test_model_presets_property_lists_builtins():
     assert "dense" in DenseNet.presets or DenseNet.presets == {}
 
 
-# --------------------------------------------------------------------------------------
 # Config helpers
-# --------------------------------------------------------------------------------------
 
 
 def test_load_json(local_preset):
@@ -687,9 +667,7 @@ def test_keras_to_zea_registry():
     assert model_registry[mpu.keras_to_zea_registry("DenseNet", model_registry)] is DenseNet
 
 
-# --------------------------------------------------------------------------------------
 # jax_memory_cleanup
-# --------------------------------------------------------------------------------------
 
 
 class _FakeValue:
@@ -730,9 +708,7 @@ def test_jax_memory_cleanup_noop_on_other_backends(monkeypatch):
     assert plain.deleted is False
 
 
-# --------------------------------------------------------------------------------------
 # Loader / saver
-# --------------------------------------------------------------------------------------
 
 
 def test_get_preset_loader_returns_keras_loader(local_preset):
@@ -881,9 +857,7 @@ def test_load_model_builds_from_input_shape(monkeypatch, local_preset):
     assert loaded_from == [str(local_preset / mpu.MODEL_WEIGHTS_FILE)]
 
 
-# --------------------------------------------------------------------------------------
 # Converters and preprocessors
-# --------------------------------------------------------------------------------------
 
 
 def test_get_model_kwargs_forwards_dtype_and_image_shape():
@@ -1010,9 +984,7 @@ def test_save_preprocessor_uses_config_file_and_saves_sublayers(tmp_path):
     assert saved_to == [str(tmp_path)]
 
 
-# --------------------------------------------------------------------------------------
 # zea.models.base — the preset entry points
-# --------------------------------------------------------------------------------------
 
 
 @model_registry(name="_preset_utils_test_submodel")

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -1,0 +1,1163 @@
+"""Tests for the preset utilities shared by zea models and datasets.
+
+Covers the Hugging Face plumbing in ``zea.internal.preset_utils`` (used by both the
+model and the data stack) and the Keras preset loading/saving in
+``zea.models.preset_utils``. Everything here runs offline: hub calls are faked.
+"""
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import keras
+import numpy as np
+import pytest
+from huggingface_hub import RepoFile
+from huggingface_hub.utils import (
+    EntryNotFoundError,
+    HFValidationError,
+    RepositoryNotFoundError,
+)
+
+import zea
+from zea import log
+from zea.internal import preset_utils as ipu
+from zea.internal.registry import model_registry
+from zea.models import preset_utils as mpu
+from zea.models.base import BaseModel, deserialize_zea_object
+from zea.models.dense import DenseNet
+
+REPO_ID = "zeahub/pytest-preset"
+
+
+def _repo_not_found(message="404 Client Error"):
+    """A ``RepositoryNotFoundError`` as huggingface_hub raises it (needs a response)."""
+    request = httpx.Request("GET", "https://huggingface.co")
+    return RepositoryNotFoundError(message, response=httpx.Response(404, request=request))
+
+
+@pytest.fixture(autouse=True)
+def _clear_hf_caches():
+    """Keep the memoized listings/downloads from leaking between tests."""
+    ipu._hf_clear_caches()
+    yield
+    ipu._hf_clear_caches()
+
+
+# --------------------------------------------------------------------------------------
+# _hf_call: login-and-retry
+# --------------------------------------------------------------------------------------
+
+
+def test_hf_call_returns_without_login(monkeypatch):
+    """A successful call does not attempt to log in."""
+    logins = []
+    monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
+
+    assert ipu._hf_call(lambda x: x + 1, 1) == 2
+    assert logins == []
+
+
+def test_hf_call_retries_once_after_login(monkeypatch):
+    """A 404-style failure is retried once, after a login attempt."""
+    logins = []
+    monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
+    calls = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) == 1:
+            raise _repo_not_found()
+        return "ok"
+
+    assert ipu._hf_call(flaky) == "ok"
+    assert len(calls) == 2
+    assert len(logins) == 1
+
+
+def test_hf_call_reraises_when_login_does_not_help(monkeypatch):
+    """Without a usable token the retry raises the original error type."""
+    monkeypatch.setattr(ipu, "_hf_login", lambda: None)
+
+    def always_fails():
+        raise _repo_not_found()
+
+    with pytest.raises(RepositoryNotFoundError):
+        ipu._hf_call(always_fails)
+
+
+def test_hf_call_does_not_retry_other_errors(monkeypatch):
+    """Errors a login cannot fix are propagated without a second attempt."""
+    logins = []
+    monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
+    calls = []
+
+    def boom():
+        calls.append(1)
+        raise OSError("connection reset")
+
+    with pytest.raises(OSError):
+        ipu._hf_call(boom)
+    assert len(calls) == 1
+    assert logins == []
+
+
+def test_hf_call_download_retry_set_excludes_missing_entries(monkeypatch):
+    """`check_file_exists` must fail fast: a missing file is not retried."""
+    logins = []
+    monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
+    calls = []
+
+    def missing():
+        calls.append(1)
+        raise EntryNotFoundError("404 Client Error")
+
+    with pytest.raises(EntryNotFoundError):
+        ipu._hf_call(missing, retry_on=ipu._HF_DOWNLOAD_RETRY_ERRORS)
+    assert len(calls) == 1
+    assert logins == []
+
+
+# --------------------------------------------------------------------------------------
+# _hf_login
+# --------------------------------------------------------------------------------------
+
+
+def test_hf_login_without_token_is_noop(monkeypatch):
+    """No token in the environment means no (potentially interactive) login."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    calls = []
+    monkeypatch.setattr(ipu, "login", lambda **kwargs: calls.append(kwargs))
+
+    ipu._hf_login()
+    assert calls == []
+
+
+@pytest.mark.parametrize("env_var", ["HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"])
+def test_hf_login_uses_token_from_env(monkeypatch, env_var):
+    """Either token variable is picked up, and login is skipped when already done."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HUGGING_FACE_HUB_TOKEN", raising=False)
+    monkeypatch.setenv(env_var, "hf_dummy_token")
+    calls = []
+    monkeypatch.setattr(ipu, "login", lambda **kwargs: calls.append(kwargs))
+
+    ipu._hf_login()
+    assert calls == [{"token": "hf_dummy_token", "skip_if_logged_in": True}]
+
+
+# --------------------------------------------------------------------------------------
+# _TTLCache / _cache_key
+# --------------------------------------------------------------------------------------
+
+
+def test_ttl_cache_returns_cached_value():
+    cache = ipu._TTLCache(ttl=60)
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return "value"
+
+    assert cache.get_or_call("k", compute) == "value"
+    assert cache.get_or_call("k", compute) == "value"
+    assert len(calls) == 1
+
+
+def test_ttl_cache_expires():
+    cache = ipu._TTLCache(ttl=0.02)
+    calls = []
+    cache.get_or_call("k", lambda: calls.append(1))
+    time.sleep(0.05)
+    cache.get_or_call("k", lambda: calls.append(1))
+    assert len(calls) == 2
+
+
+def test_ttl_cache_disabled_with_zero_ttl():
+    cache = ipu._TTLCache(ttl=0)
+    calls = []
+    for _ in range(2):
+        cache.get_or_call("k", lambda: calls.append(1))
+    assert len(calls) == 2
+
+
+def test_ttl_cache_bypassed_for_unhashable_key():
+    cache = ipu._TTLCache(ttl=60)
+    calls = []
+    for _ in range(2):
+        cache.get_or_call(None, lambda: calls.append(1))
+    assert len(calls) == 2
+
+
+def test_ttl_cache_revalidates_entry():
+    """A cached value the predicate rejects (e.g. a deleted file) is recomputed."""
+    cache = ipu._TTLCache(ttl=60)
+    calls = []
+
+    def compute():
+        calls.append(1)
+        return "gone"
+
+    cache.get_or_call("k", compute, valid=lambda _: False)
+    cache.get_or_call("k", compute, valid=lambda _: False)
+    assert len(calls) == 2
+
+
+def test_ttl_cache_clear():
+    cache = ipu._TTLCache(ttl=60)
+    calls = []
+    cache.get_or_call("k", lambda: calls.append(1))
+    cache.clear()
+    cache.get_or_call("k", lambda: calls.append(1))
+    assert len(calls) == 2
+
+
+def test_cache_key_is_none_for_unhashable_arguments():
+    assert ipu._cache_key("repo", "dataset") is not None
+    assert ipu._cache_key("repo", allow_patterns=["*.h5"]) is None
+
+
+# --------------------------------------------------------------------------------------
+# Repository listings
+# --------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_tree(monkeypatch):
+    """Patch ``list_repo_tree`` with a fixed repo layout and count the calls."""
+    entries = [
+        RepoFile(path="val/a.hdf5", size=10, oid="1"),
+        RepoFile(path="val/b.h5", size=20, oid="2"),
+        RepoFile(path="val/notes.txt", size=1, oid="3"),
+        RepoFile(path="train/c.hdf5", size=30, oid="4"),
+    ]
+    calls = []
+
+    def fake_list_repo_tree(repo_id, recursive=True, repo_type="dataset", **kwargs):
+        calls.append((repo_id, repo_type, tuple(sorted(kwargs.items()))))
+        return entries
+
+    monkeypatch.setattr(ipu, "list_repo_tree", fake_list_repo_tree)
+    return calls
+
+
+def test_repo_listing_is_memoized(fake_tree):
+    """Repeated listings of the same repo cost a single hub round trip."""
+    assert ipu._hf_list_files(REPO_ID) == [
+        "val/a.hdf5",
+        "val/b.h5",
+        "val/notes.txt",
+        "train/c.hdf5",
+    ]
+    # Both the name-only and the size-carrying view share one listing.
+    ipu._hf_list_files(REPO_ID)
+    ipu._hf_list_h5_files(f"hf://{REPO_ID}")
+    assert len(fake_tree) == 1
+
+
+def test_repo_listing_keyed_on_revision_and_repo_type(fake_tree):
+    """Different revisions/repo types are cached separately."""
+    ipu._hf_list_files(REPO_ID)
+    ipu._hf_list_files(REPO_ID, revision="v1")
+    ipu._hf_list_files(REPO_ID, repo_type="model")
+    assert len(fake_tree) == 3
+
+
+def test_list_h5_files_filters_extensions(fake_tree):
+    """Only .h5/.hdf5 files are returned, with their sizes."""
+    assert ipu._hf_list_h5_files(f"hf://{REPO_ID}") == [
+        ("val/a.hdf5", 10),
+        ("val/b.h5", 20),
+        ("train/c.hdf5", 30),
+    ]
+
+
+def test_list_h5_files_filters_subdirectory(fake_tree):
+    assert ipu._hf_list_h5_files(f"hf://{REPO_ID}/val") == [
+        ("val/a.hdf5", 10),
+        ("val/b.h5", 20),
+    ]
+
+
+def test_list_h5_files_single_file(fake_tree):
+    assert ipu._hf_list_h5_files(f"hf://{REPO_ID}/val/a.hdf5") == [("val/a.hdf5", 10)]
+
+
+def test_list_h5_files_unknown_subdirectory_is_empty(fake_tree):
+    assert ipu._hf_list_h5_files(f"hf://{REPO_ID}/nope") == []
+
+
+# --------------------------------------------------------------------------------------
+# Downloads
+# --------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_hub_download(monkeypatch, tmp_path):
+    """Patch ``hf_hub_download`` to materialize files in ``tmp_path``."""
+    calls = []
+
+    def fake_download(*, repo_id, filename, cache_dir=None, repo_type=None, **kwargs):
+        calls.append(
+            {
+                "repo_id": repo_id,
+                "filename": filename,
+                "cache_dir": cache_dir,
+                "repo_type": repo_type,
+                **kwargs,
+            }
+        )
+        path = tmp_path / repo_id.replace("/", "--") / "snapshots" / "abc123" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("data")
+        return str(path)
+
+    monkeypatch.setattr(ipu, "hf_hub_download", fake_download)
+    return calls
+
+
+def test_hf_download_is_memoized(fake_hub_download):
+    first = ipu._hf_download(REPO_ID, "config.json")
+    second = ipu._hf_download(REPO_ID, "config.json")
+    assert first == second
+    assert len(fake_hub_download) == 1
+
+
+def test_hf_download_repeats_when_cached_file_disappeared(fake_hub_download):
+    """A memoized path that no longer exists is downloaded again."""
+    path = ipu._hf_download(REPO_ID, "config.json")
+    Path(path).unlink()
+    assert ipu._hf_download(REPO_ID, "config.json") == path
+    assert len(fake_hub_download) == 2
+
+
+@pytest.mark.parametrize(
+    "repo_type, expected_dir",
+    [("dataset", ipu.HF_DATASETS_DIR), ("model", ipu.HF_MODELS_DIR)],
+)
+def test_hf_download_default_cache_dir_per_repo_type(fake_hub_download, repo_type, expected_dir):
+    """Models and datasets land in their own cache directory by default."""
+    ipu._hf_download(REPO_ID, "config.json", repo_type=repo_type)
+    assert fake_hub_download[0]["cache_dir"] == expected_dir
+
+
+def test_download_files_in_path_filters_and_keeps_order(monkeypatch):
+    downloaded = []
+
+    def fake_download(repo_id, filename, cache_dir=None, repo_type="dataset", **kwargs):
+        downloaded.append(filename)
+        return f"/local/{filename}"
+
+    monkeypatch.setattr(ipu, "_hf_download", fake_download)
+
+    files = ["val/a.hdf5", "train/c.hdf5", "val/b.h5"]
+    result = ipu._download_files_in_path(REPO_ID, files, "val/")
+
+    assert result == ["/local/val/a.hdf5", "/local/val/b.h5"]
+    assert sorted(downloaded) == ["val/a.hdf5", "val/b.h5"]
+
+
+def test_download_files_in_path_runs_concurrently(monkeypatch):
+    """Multiple files are fetched in parallel rather than one after another."""
+    lock = threading.Lock()
+    state = {"running": 0, "peak": 0}
+
+    def fake_download(repo_id, filename, cache_dir=None, repo_type="dataset", **kwargs):
+        with lock:
+            state["running"] += 1
+            state["peak"] = max(state["peak"], state["running"])
+        time.sleep(0.05)
+        with lock:
+            state["running"] -= 1
+        return f"/local/{filename}"
+
+    monkeypatch.setattr(ipu, "_hf_download", fake_download)
+
+    files = [f"val/{i}.hdf5" for i in range(4)]
+    result = ipu._download_files_in_path(REPO_ID, files)
+
+    assert result == [f"/local/val/{i}.hdf5" for i in range(4)]
+    assert state["peak"] > 1
+
+
+# --------------------------------------------------------------------------------------
+# Path resolution
+# --------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_resolve(monkeypatch, tmp_path):
+    """Patch listing + download so ``_hf_resolve_path`` works against tmp_path."""
+    files = ["val/a.hdf5", "val/b.hdf5", "train/c.hdf5"]
+    snapshot = tmp_path / f"datasets--{REPO_ID.replace('/', '--')}" / "snapshots" / "abc123"
+
+    monkeypatch.setattr(ipu, "_hf_list_files", lambda repo_id, **kwargs: files)
+
+    def fake_download(repo_id, filename, cache_dir=None, repo_type="dataset", **kwargs):
+        path = snapshot / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("data")
+        return str(path)
+
+    monkeypatch.setattr(ipu, "_hf_download", fake_download)
+    return snapshot
+
+
+def test_resolve_path_directory(fake_resolve):
+    result = ipu._hf_resolve_path(f"hf://{REPO_ID}/val")
+    assert result == fake_resolve / "val"
+    assert sorted(p.name for p in result.iterdir()) == ["a.hdf5", "b.hdf5"]
+
+
+def test_resolve_path_single_file(fake_resolve):
+    result = ipu._hf_resolve_path(f"hf://{REPO_ID}/val/a.hdf5")
+    assert result == fake_resolve / "val" / "a.hdf5"
+
+
+def test_resolve_path_whole_repo(fake_resolve):
+    assert ipu._hf_resolve_path(f"hf://{REPO_ID}") == fake_resolve
+
+
+def test_resolve_path_missing_subpath(fake_resolve):
+    with pytest.raises(FileNotFoundError, match="not found in"):
+        ipu._hf_resolve_path(f"hf://{REPO_ID}/nope.hdf5")
+
+
+def test_resolve_path_empty_repo(monkeypatch):
+    monkeypatch.setattr(ipu, "_hf_list_files", lambda repo_id, **kwargs: [])
+    with pytest.raises(FileNotFoundError, match="No files found in repository"):
+        ipu._hf_resolve_path(f"hf://{REPO_ID}")
+
+
+def test_snapshot_dir_lookup_without_snapshots_dir(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Could not find snapshot directory"):
+        ipu._get_snapshot_dir_from_downloaded_file(tmp_path / "a.hdf5")
+
+
+# --------------------------------------------------------------------------------------
+# repo_type prefixes and stream URLs
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "repo_type, prefix", [("dataset", "datasets/"), ("model", ""), ("space", "spaces/")]
+)
+def test_repo_type_prefix(repo_type, prefix):
+    assert ipu._hf_repo_type_prefix(repo_type) == prefix
+
+
+def test_repo_type_prefix_rejects_unknown():
+    with pytest.raises(ValueError, match="repo_type"):
+        ipu._hf_repo_type_prefix("banana")
+
+
+def test_stream_url():
+    url = ipu._hf_stream_url(f"hf://{REPO_ID}/val/a.hdf5")
+    assert url == f"https://huggingface.co/datasets/{REPO_ID}/resolve/main/val/a.hdf5"
+
+
+def test_stream_url_with_revision_and_repo_type():
+    url = ipu._hf_stream_url(f"hf://{REPO_ID}/model.weights.h5", revision="v1", repo_type="model")
+    assert url == f"https://huggingface.co/{REPO_ID}/resolve/v1/model.weights.h5"
+
+
+def test_stream_url_requires_file():
+    with pytest.raises(ValueError, match="single file"):
+        ipu._hf_stream_url(f"hf://{REPO_ID}")
+
+
+def test_stream_url_rejects_bad_repo_type():
+    with pytest.raises(ValueError, match="repo_type"):
+        ipu._hf_stream_url(f"hf://{REPO_ID}/a.hdf5", repo_type="banana")
+
+
+def test_stream_open_retries_after_login(monkeypatch):
+    """A stream open that 404s anonymously is retried once after logging in."""
+    logins = []
+    monkeypatch.setattr(ipu, "_hf_login", lambda: logins.append(1))
+    attempts = []
+
+    class FakeFS:
+        def open(self, path, mode, **kwargs):
+            attempts.append(path)
+            if len(attempts) == 1:
+                raise _repo_not_found()
+            return "FILEOBJ"
+
+    monkeypatch.setattr("huggingface_hub.HfFileSystem", FakeFS)
+
+    assert ipu._hf_stream_open(f"hf://{REPO_ID}/val/a.hdf5") == "FILEOBJ"
+    assert len(attempts) == 2
+    assert len(logins) == 1
+
+
+# --------------------------------------------------------------------------------------
+# zea.models.preset_utils — get_file
+# --------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_preset(tmp_path):
+    """A minimal local preset directory."""
+    (tmp_path / "config.json").write_text(json.dumps({"registered_name": "Functional"}))
+    return tmp_path
+
+
+def test_get_file_requires_string_preset():
+    with pytest.raises(ValueError, match="must be a string"):
+        mpu.get_file(Path("some/dir"), "config.json")
+
+
+def test_get_file_local(local_preset):
+    assert mpu.get_file(str(local_preset), "config.json") == str(local_preset / "config.json")
+
+
+def test_get_file_local_missing(local_preset):
+    with pytest.raises(FileNotFoundError, match="doesn't exist in preset directory"):
+        mpu.get_file(str(local_preset), "missing.json")
+
+
+def test_get_file_local_rejects_escaping_path(local_preset):
+    """A path that walks out of the preset directory is refused."""
+    with pytest.raises(ValueError, match="escapes the preset directory"):
+        mpu.get_file(str(local_preset), "../secret.json")
+
+
+def test_get_file_unknown_identifier():
+    with pytest.raises(ValueError, match="Unknown preset identifier"):
+        mpu.get_file("not-a-preset", "config.json")
+
+
+@pytest.fixture
+def fake_model_download(monkeypatch):
+    """Patch the shared HF download used by ``zea.models.preset_utils``."""
+    calls = []
+
+    def fake_download(repo_id, filename, cache_dir=None, repo_type="dataset", **kwargs):
+        calls.append({"repo_id": repo_id, "filename": filename, "repo_type": repo_type})
+        return f"/local/{repo_id}/{filename}"
+
+    monkeypatch.setattr(mpu, "_hf_download", fake_download)
+    return calls
+
+
+def test_get_file_hf(fake_model_download):
+    """An ``hf://`` preset downloads from the model repo cache."""
+    assert mpu.get_file("hf://zeahub/taesdxl", "config.json") == "/local/zeahub/taesdxl/config.json"
+    assert fake_model_download == [
+        {"repo_id": "zeahub/taesdxl", "filename": "config.json", "repo_type": "model"}
+    ]
+
+
+def test_get_file_hf_with_subpath(fake_model_download):
+    """A subdirectory in the handle prefixes the requested file."""
+    mpu.get_file("hf://zeahub/models/taesdxl_encoder", "config.json")
+    assert fake_model_download[0]["filename"] == "taesdxl_encoder/config.json"
+
+
+def test_get_file_hf_validation_error(monkeypatch):
+    def boom(*args, **kwargs):
+        raise HFValidationError("bad handle")
+
+    monkeypatch.setattr(mpu, "_hf_download", boom)
+    with pytest.raises(ValueError, match="Unexpected Hugging Face preset"):
+        mpu.get_file("hf://taesdxl", "config.json")
+
+
+def test_get_file_hf_missing_entry(monkeypatch):
+    def boom(*args, **kwargs):
+        raise EntryNotFoundError("404 Client Error")
+
+    monkeypatch.setattr(mpu, "_hf_download", boom)
+    with pytest.raises(FileNotFoundError, match="doesn't exist in preset directory"):
+        mpu.get_file("hf://zeahub/taesdxl", "config.json")
+
+
+# --------------------------------------------------------------------------------------
+# Built-in preset registry
+# --------------------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registered_presets():
+    """Register throwaway presets and clean up the global registry afterwards."""
+
+    class _Dummy:
+        pass
+
+    presets = {
+        "_pytest_hf": {"hf_handle": "hf://zeahub/_pytest", "metadata": {}},
+        "_pytest_local": {"path": "/tmp/_pytest_preset", "metadata": {}},
+    }
+    mpu.register_presets(presets, _Dummy)
+    yield _Dummy, presets
+    for name in presets:
+        mpu.BUILTIN_PRESETS.pop(name, None)
+    mpu.BUILTIN_PRESETS_FOR_MODEL.pop(_Dummy, None)
+
+
+def test_builtin_presets_are_registered_per_class(registered_presets):
+    cls, presets = registered_presets
+    assert mpu.builtin_presets(cls) == presets
+    assert mpu.builtin_presets(object) == {}
+
+
+def test_builtin_preset_resolves_to_hf_handle(registered_presets, fake_model_download):
+    mpu.get_file("_pytest_hf", "config.json")
+    assert fake_model_download[0]["repo_id"] == "zeahub/_pytest"
+
+
+def test_builtin_preset_resolves_to_path(registered_presets):
+    """A preset registered with a `path` resolves to that (here missing) directory."""
+    with pytest.raises(ValueError, match="Unknown preset identifier"):
+        mpu.get_file("_pytest_local", "config.json")
+
+
+def test_model_presets_property_lists_builtins():
+    assert "dense" in DenseNet.presets or DenseNet.presets == {}
+
+
+# --------------------------------------------------------------------------------------
+# Config helpers
+# --------------------------------------------------------------------------------------
+
+
+def test_load_json(local_preset):
+    assert mpu.load_json(str(local_preset)) == {"registered_name": "Functional"}
+
+
+def test_check_file_exists(local_preset):
+    assert mpu.check_file_exists(str(local_preset), "config.json") is True
+    assert mpu.check_file_exists(str(local_preset), "nope.json") is False
+
+
+def test_assert_file_exists(local_preset):
+    mpu._assert_file_exists(str(local_preset), "config.json")
+    with pytest.raises(ValueError, match="has no nope.json"):
+        mpu._assert_file_exists(str(local_preset), "nope.json")
+
+
+def test_set_dtype_in_config_without_dtype_is_identity():
+    config = {"config": {}}
+    assert mpu.set_dtype_in_config(config) is config
+
+
+def test_set_dtype_in_config_forwards_dtype():
+    config = mpu.set_dtype_in_config({"config": {}}, "float16")
+    assert config["config"]["dtype"] == "float16"
+
+
+def test_set_dtype_in_config_updates_policy_map():
+    config = {
+        "config": {
+            "dtype": {
+                "class_name": "DTypePolicyMap",
+                "config": {
+                    "default_policy": "float32",
+                    "policy_map": {"layer": {"config": {"source_name": "float32"}}},
+                },
+            }
+        }
+    }
+    updated = mpu.set_dtype_in_config(config, "bfloat16")
+    policy_map_config = updated["config"]["dtype"]["config"]
+    assert policy_map_config["default_policy"] == "bfloat16"
+    assert policy_map_config["policy_map"]["layer"]["config"]["source_name"] == "bfloat16"
+
+
+@pytest.mark.parametrize("registered_name", ["Functional", "Sequential"])
+def test_check_config_class_functional(registered_name):
+    assert mpu.check_config_class({"registered_name": registered_name}) is keras.Model
+
+
+def test_check_config_class_zea_model():
+    assert mpu.check_config_class({"registered_name": "DenseNet"}) is DenseNet
+
+
+def test_check_config_class_unknown():
+    with pytest.raises(ValueError, match="not found in `zea` registry"):
+        mpu.check_config_class({"registered_name": "NotARegisteredModel"})
+
+
+def test_keras_to_zea_registry():
+    assert model_registry[mpu.keras_to_zea_registry("DenseNet", model_registry)] is DenseNet
+
+
+# --------------------------------------------------------------------------------------
+# jax_memory_cleanup
+# --------------------------------------------------------------------------------------
+
+
+class _FakeValue:
+    def __init__(self, sharding=None):
+        self.sharding = sharding
+        self.deleted = False
+
+    def delete(self):
+        self.deleted = True
+
+
+class _FakeWeight:
+    def __init__(self, value):
+        self._value = value
+
+
+class _FakeLayer:
+    def __init__(self, weights):
+        self.weights = weights
+
+
+def test_jax_memory_cleanup_deletes_unsharded_values(monkeypatch):
+    """Sharded arrays are left alone; deleting them breaks distributed setups."""
+    monkeypatch.setattr(keras.config, "backend", lambda: "jax")
+    plain, sharded = _FakeValue(), _FakeValue(sharding=object())
+    layer = _FakeLayer([_FakeWeight(plain), _FakeWeight(sharded), _FakeWeight(None)])
+
+    mpu.jax_memory_cleanup(layer)
+
+    assert plain.deleted is True
+    assert sharded.deleted is False
+
+
+def test_jax_memory_cleanup_noop_on_other_backends(monkeypatch):
+    monkeypatch.setattr(keras.config, "backend", lambda: "torch")
+    plain = _FakeValue()
+    mpu.jax_memory_cleanup(_FakeLayer([_FakeWeight(plain)]))
+    assert plain.deleted is False
+
+
+# --------------------------------------------------------------------------------------
+# Loader / saver
+# --------------------------------------------------------------------------------------
+
+
+def test_get_preset_loader_returns_keras_loader(local_preset):
+    loader = mpu.get_preset_loader(str(local_preset))
+    assert isinstance(loader, mpu.KerasPresetLoader)
+    assert loader.check_model_class() is keras.Model
+
+
+def test_get_preset_loader_missing_config(tmp_path):
+    with pytest.raises(ValueError, match="has no config.json"):
+        mpu.get_preset_loader(str(tmp_path))
+
+
+def test_get_preset_loader_unrecognized_config(tmp_path):
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "bert"}))
+    with pytest.raises(ValueError, match="Unrecognized format"):
+        mpu.get_preset_loader(str(tmp_path))
+
+
+def test_loader_get_file(local_preset):
+    loader = mpu.get_preset_loader(str(local_preset))
+    assert loader.get_file("config.json") == str(local_preset / "config.json")
+
+
+def test_preset_saver_creates_directory(tmp_path):
+    preset_dir = tmp_path / "nested" / "preset"
+    mpu.get_preset_saver(str(preset_dir))
+    assert preset_dir.is_dir()
+
+
+def test_recursive_pop_removes_nested_keys(tmp_path):
+    saver = mpu.KerasPresetSaver(str(tmp_path))
+    config = {"build_config": 1, "config": {"build_config": 2, "inner": {"build_config": 3}}}
+    saver._recursive_pop(config, "build_config")
+    assert config == {"config": {"inner": {}}}
+
+
+@model_registry(name="_preset_utils_test_model")
+class _TinyPresetModel(BaseModel):
+    """Small registered model used for preset save/load round trips."""
+
+    def __init__(self, units=3, **kwargs):
+        super().__init__(**kwargs)
+        self.units = units
+        self.dense = keras.layers.Dense(units)
+
+    @property
+    def image_shape(self):
+        return (None, 5)
+
+    def build(self, input_shape):
+        self.dense.build(input_shape)
+        super().build(input_shape)
+
+    def call(self, x):
+        return self.dense(x)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"units": self.units})
+        return config
+
+
+def test_save_and_load_preset_round_trip(tmp_path):
+    """A saved preset reloads with identical weights."""
+    model = _TinyPresetModel(units=3)
+    inputs = np.random.rand(2, 5).astype("float32")
+    expected = np.array(model(inputs))
+
+    model.save_to_preset(str(tmp_path))
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "config.json",
+        "metadata.json",
+        "model.weights.h5",
+    ]
+
+    reloaded = _TinyPresetModel.from_preset(str(tmp_path))
+    assert np.allclose(expected, np.array(reloaded(inputs)))
+
+
+def test_saved_config_drops_build_and_compile_config(tmp_path):
+    model = _TinyPresetModel(units=3)
+    model(np.zeros((1, 5), dtype="float32"))
+    model.save_to_preset(str(tmp_path))
+
+    config = json.loads((tmp_path / "config.json").read_text())
+    assert "build_config" not in config
+    assert "compile_config" not in config
+    assert config["registered_name"] == "_TinyPresetModel"
+
+
+def test_saved_metadata(tmp_path):
+    model = _TinyPresetModel(units=3)
+    model(np.zeros((1, 5), dtype="float32"))
+    model.save_to_preset(str(tmp_path))
+
+    metadata = json.loads((tmp_path / "metadata.json").read_text())
+    assert metadata["zea_version"] == zea.__version__
+    assert metadata["parameter_count"] == model.count_params()
+    assert metadata["keras_version"] == keras.version()
+    assert metadata["date_saved"]
+
+
+def test_load_preset_without_weights(tmp_path):
+    """A model that cannot be rebuilt still loads when weights are not requested."""
+    model = DenseNet(input_dim=4, widths=[8], output_dim=2)
+    model(np.zeros((1, 4), dtype="float32"))
+    model.save_to_preset(str(tmp_path))
+
+    reloaded = DenseNet.from_preset(str(tmp_path), load_weights=False)
+    assert isinstance(reloaded, DenseNet)
+
+
+def test_load_preset_unbuildable_model_raises(tmp_path):
+    """Without a build hint, loading weights reports how to fix the preset."""
+    model = DenseNet(input_dim=4, widths=[8], output_dim=2)
+    model(np.zeros((1, 4), dtype="float32"))
+    model.save_to_preset(str(tmp_path))
+
+    with pytest.raises(ValueError, match="Model could not be built"):
+        DenseNet.from_preset(str(tmp_path))
+
+
+def test_load_model_builds_from_input_shape(monkeypatch, local_preset):
+    """An unbuilt model is built from its `input_shape` before weights are loaded."""
+    built_with, loaded_from = [], []
+
+    class _Unbuilt:
+        weights = []
+        built = False
+        input_shape = (None, 5)
+
+        def build(self, input_shape):
+            built_with.append(input_shape)
+
+        def load_weights(self, path):
+            loaded_from.append(path)
+
+    (local_preset / mpu.MODEL_WEIGHTS_FILE).write_text("weights")
+    monkeypatch.setattr(mpu, "load_serialized_object", lambda *a, **kw: _Unbuilt())
+
+    loader = mpu.get_preset_loader(str(local_preset))
+    loader.load_model(cls=object, load_weights=True)
+
+    assert built_with == [(None, 5)]
+    assert loaded_from == [str(local_preset / mpu.MODEL_WEIGHTS_FILE)]
+
+
+# --------------------------------------------------------------------------------------
+# Converters and preprocessors
+# --------------------------------------------------------------------------------------
+
+
+def test_get_model_kwargs_forwards_dtype_and_image_shape():
+    loader = mpu.PresetLoader("preset", {})
+    model_kwargs, kwargs = loader.get_model_kwargs(
+        dtype="float16", image_shape=(4, 4), other="keep"
+    )
+    assert model_kwargs == {"dtype": "float16", "image_shape": (4, 4)}
+    assert kwargs == {"other": "keep"}
+
+
+def test_base_loader_load_model_is_abstract():
+    with pytest.raises(NotImplementedError):
+        mpu.PresetLoader("preset", {}).load_model(cls=object, load_weights=False)
+
+
+def test_base_loader_load_preprocessor_uses_add_missing_kwargs():
+    """The fallback builds the preprocessor from defaults filled in by the class."""
+
+    class _Preprocessor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        @classmethod
+        def _add_missing_kwargs(cls, loader, kwargs):
+            return {**kwargs, "added": True}
+
+    preprocessor = mpu.PresetLoader("preset", {}).load_preprocessor(_Preprocessor, given=1)
+    assert preprocessor.kwargs == {"given": 1, "added": True}
+
+
+def test_image_converter_round_trip(tmp_path):
+    """An image converter saved to a preset is loaded back with its config."""
+    saver = mpu.get_preset_saver(str(tmp_path))
+    saver.save_image_converter(keras.layers.Rescaling(scale=1 / 255))
+    assert (tmp_path / mpu.IMAGE_CONVERTER_CONFIG_FILE).exists()
+
+    loader = mpu.KerasPresetLoader(str(tmp_path), {})
+    converter = loader.load_image_converter(keras.layers.Rescaling)
+    assert isinstance(converter, keras.layers.Rescaling)
+    assert converter.scale == 1 / 255
+
+
+@model_registry(name="_preset_utils_test_preprocessor")
+class _TinyPreprocessor(BaseModel):
+    """Registered stand-in for a preprocessor with preset assets."""
+
+    def __init__(self, factor=2, **kwargs):
+        super().__init__(**kwargs)
+        self.factor = factor
+        self.assets_from = None
+
+    def load_preset_assets(self, preset):
+        self.assets_from = preset
+
+    def call(self, x):
+        return x * self.factor
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({"factor": self.factor})
+        return config
+
+
+def test_load_preprocessor_from_preset(tmp_path):
+    """A `preprocessor.json` for the right class is deserialized and gets its assets."""
+    saver = mpu.get_preset_saver(str(tmp_path))
+    saver.save_preprocessor(_TinyPreprocessor(factor=7))
+
+    loader = mpu.KerasPresetLoader(str(tmp_path), {})
+    preprocessor = loader.load_preprocessor(_TinyPreprocessor)
+
+    assert preprocessor.factor == 7
+    assert preprocessor.assets_from == str(tmp_path)
+
+
+def test_load_preprocessor_falls_back_without_config(tmp_path):
+    """Without a `preprocessor.json` the loader falls back to class defaults."""
+
+    class _Preprocessor:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        @classmethod
+        def _add_missing_kwargs(cls, loader, kwargs):
+            return kwargs
+
+    loader = mpu.KerasPresetLoader(str(tmp_path), {})
+    assert isinstance(loader.load_preprocessor(_Preprocessor), _Preprocessor)
+
+
+def test_load_preprocessor_falls_back_for_other_class(tmp_path):
+    """A `preprocessor.json` belonging to another class is ignored."""
+    saver = mpu.get_preset_saver(str(tmp_path))
+    saver.save_preprocessor(_TinyPreprocessor(factor=7))
+
+    class _Other(_TinyPresetModel):
+        @classmethod
+        def _add_missing_kwargs(cls, loader, kwargs):
+            return kwargs
+
+    loader = mpu.KerasPresetLoader(str(tmp_path), {})
+    assert isinstance(loader.load_preprocessor(_Other), _Other)
+
+
+def test_save_preprocessor_uses_config_file_and_saves_sublayers(tmp_path):
+    """A preprocessor's own `config_file` is honoured and its layers save their assets."""
+    saved_to = []
+
+    class _AssetLayer(keras.layers.Layer):
+        def save_to_preset(self, preset_dir):
+            saved_to.append(preset_dir)
+
+    class _Preprocessor(keras.layers.Layer):
+        config_file = "custom_preprocessor.json"
+
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self.asset_layer = _AssetLayer()
+
+    mpu.get_preset_saver(str(tmp_path)).save_preprocessor(_Preprocessor())
+
+    assert (tmp_path / "custom_preprocessor.json").exists()
+    assert saved_to == [str(tmp_path)]
+
+
+# --------------------------------------------------------------------------------------
+# zea.models.base — the preset entry points
+# --------------------------------------------------------------------------------------
+
+
+@model_registry(name="_preset_utils_test_submodel")
+class _SubTinyPresetModel(_TinyPresetModel):
+    """Registered subclass, to exercise the class-mismatch branches of from_preset."""
+
+
+@pytest.fixture
+def attach_caplog(caplog):
+    """Attach pytest's caplog handler to zea's (non-propagating) logger."""
+    caplog.set_level(logging.DEBUG)
+    log.logger.addHandler(caplog.handler)
+    try:
+        yield caplog
+    finally:
+        log.logger.removeHandler(caplog.handler)
+
+
+@pytest.fixture
+def tiny_preset(tmp_path):
+    """A saved preset for `_TinyPresetModel`."""
+    model = _TinyPresetModel(units=3)
+    model(np.zeros((1, 5), dtype="float32"))
+    model.save_to_preset(str(tmp_path))
+    return str(tmp_path)
+
+
+def test_presets_property_is_empty_for_unregistered_model():
+    assert _TinyPresetModel.presets == {}
+
+
+def test_from_preset_on_subclass_warns_and_returns_subclass(tiny_preset, attach_caplog):
+    """Loading a parent's preset from a subclass returns the subclass, with a warning."""
+    model = _SubTinyPresetModel.from_preset(tiny_preset)
+
+    assert isinstance(model, _SubTinyPresetModel)
+    assert "you are calling from a subclass" in attach_caplog.text
+
+
+def test_from_preset_on_parent_class_warns(tmp_path, attach_caplog):
+    """Loading a subclass' preset from the parent returns the parent, with a warning."""
+    model = _SubTinyPresetModel(units=3)
+    model(np.zeros((1, 5), dtype="float32"))
+    model.save_to_preset(str(tmp_path))
+
+    reloaded = _TinyPresetModel.from_preset(str(tmp_path))
+
+    assert type(reloaded) is _TinyPresetModel
+    assert "which is a subclass of the calling class" in attach_caplog.text
+
+
+def test_from_preset_incompatible_class_raises(tiny_preset):
+    with pytest.raises(ValueError, match="not compatible with the calling class"):
+        _TinyPreprocessor.from_preset(tiny_preset)
+
+
+def test_deserialize_zea_object_requires_from_config():
+    """A class without `from_config()` cannot be reconstructed."""
+    config = {"class_name": "_NoFromConfig", "config": {}}
+    with pytest.raises(TypeError, match="missing a `from_config\\(\\)` method"):
+        deserialize_zea_object(config, cls=type("_NoFromConfig", (), {}))
+
+
+def test_deserialize_zea_object_reports_bad_config():
+    """A config that does not match the constructor is reported with the config."""
+
+    class _NeedsArgument(BaseModel):
+        def __init__(self, required, **kwargs):
+            super().__init__(**kwargs)
+            self.required = required
+
+    config = {"class_name": "_NeedsArgument", "config": {}}
+    with pytest.raises(TypeError, match="could not be deserialized properly"):
+        deserialize_zea_object(config, cls=_NeedsArgument)
+
+
+def test_deserialize_zea_object_resolves_class_from_module():
+    """Without an explicit class, the config's module/registered_name is imported."""
+    config = {
+        "class_name": "DenseNet",
+        "registered_name": "DenseNet",
+        "module": "zea.models.dense",
+        "config": {"input_dim": 4, "widths": [8], "output_dim": 2},
+    }
+    assert isinstance(deserialize_zea_object(config), DenseNet)
+
+
+def test_deserialize_zea_object_rejects_foreign_module():
+    config = {"class_name": "OrderedDict", "module": "collections", "config": {}}
+    with pytest.raises(TypeError, match="Could not locate class"):
+        deserialize_zea_object(config)
+
+
+def test_deserialize_zea_object_missing_zea_module():
+    config = {"class_name": "Nope", "module": "zea.does_not_exist", "config": {}}
+    with pytest.raises(TypeError, match="cannot be imported"):
+        deserialize_zea_object(config)
+
+
+def test_deserialize_zea_object_applies_build_and_compile_config():
+    """`build_config`/`compile_config`/`shared_object_id` in a config are applied."""
+
+    class _Recorder:
+        built = False
+        compiled = False
+
+        @classmethod
+        def from_config(cls, config):
+            return cls()
+
+        def build_from_config(self, config):
+            self.build_config = config
+
+        def compile_from_config(self, config):
+            self.compile_config = config
+
+    config = {
+        "class_name": "_Recorder",
+        "config": {},
+        "build_config": {"input_shape": (None, 5)},
+        "compile_config": {"optimizer": "adam"},
+        "shared_object_id": 7,
+    }
+    instance = deserialize_zea_object(config, cls=_Recorder)
+
+    assert instance.build_config == {"input_shape": (None, 5)}
+    assert instance.built is True
+    assert instance.compile_config == {"optimizer": "adam"}
+    assert instance.compiled is True
+
+
+def test_preset_with_build_config_loads_weights(tmp_path):
+    """The documented way to make a preset loadable: a `build_config` in config.json."""
+    model = _TinyPresetModel(units=3)
+    inputs = np.random.rand(2, 5).astype("float32")
+    expected = np.array(model(inputs))
+    model.save_to_preset(str(tmp_path))
+
+    # The saver strips build_config; presets add it back by hand (see the error
+    # raised by KerasPresetLoader.load_model when a model cannot be built).
+    config_path = tmp_path / mpu.CONFIG_FILE
+    config = json.loads(config_path.read_text())
+    config["build_config"] = {"input_shape": [None, 5]}
+    config_path.write_text(json.dumps(config))
+
+    reloaded = _TinyPresetModel.from_preset(str(tmp_path))
+    assert reloaded.built is True
+    assert np.allclose(expected, np.array(reloaded(inputs)))

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -1161,3 +1161,79 @@ def test_preset_with_build_config_loads_weights(tmp_path):
     reloaded = _TinyPresetModel.from_preset(str(tmp_path))
     assert reloaded.built is True
     assert np.allclose(expected, np.array(reloaded(inputs)))
+
+
+# Sharded weights (mirrors keras-team/keras-hub#2218).
+
+
+@pytest.mark.parametrize(
+    "dtype, bits", [("float32", 32), ("bfloat16", 16), ("int8", 8), ("uint8", 8), ("bool", 1)]
+)
+def test_dtype_size_in_bits(dtype, bits):
+    assert mpu._dtype_size_in_bits(dtype) == bits
+
+
+def test_variables_size_in_bytes_counts_shared_variables_once():
+    variable = keras.Variable(np.zeros((4, 8), dtype="float32"))
+    assert mpu._variables_size_in_bytes([variable]) == 4 * 8 * 4
+    assert mpu._variables_size_in_bytes([variable, variable]) == 4 * 8 * 4
+
+
+def test_get_sharded_filenames_handles_list_values(tmp_path):
+    """A weight can be spread over several shards, so values may be lists."""
+    config_path = tmp_path / mpu.SHARDED_MODEL_WEIGHTS_CONFIG_FILE
+    config_path.write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "a": "model_00000.weights.h5",
+                    "b": ["model_00000.weights.h5", "model_00001.weights.h5"],
+                }
+            }
+        )
+    )
+    loader = mpu.KerasPresetLoader(str(tmp_path), {})
+    assert loader._get_sharded_filenames(str(config_path)) == [
+        "model_00000.weights.h5",
+        "model_00001.weights.h5",
+    ]
+
+
+@pytest.mark.parametrize("max_shard_size", [10, None])
+def test_small_model_is_saved_as_a_single_weights_file(tmp_path, max_shard_size):
+    model = _TinyPresetModel(units=3)
+    model(np.zeros((1, 5), dtype="float32"))
+    model.save_to_preset(str(tmp_path), max_shard_size=max_shard_size)
+
+    assert (tmp_path / mpu.MODEL_WEIGHTS_FILE).exists()
+    assert not (tmp_path / mpu.SHARDED_MODEL_WEIGHTS_CONFIG_FILE).exists()
+
+
+def test_sharded_save_and_load_round_trip(tmp_path, monkeypatch):
+    """A model saved as shards reloads with identical weights."""
+    model = _TinyPresetModel(units=3)
+    inputs = np.random.rand(2, 5).astype("float32")
+    expected = np.array(model(inputs))
+
+    # 64 bytes: above the largest single variable, below the model total.
+    model.save_to_preset(str(tmp_path), max_shard_size=64 / 1024**3)
+
+    assert (tmp_path / mpu.SHARDED_MODEL_WEIGHTS_CONFIG_FILE).exists()
+    assert not (tmp_path / mpu.MODEL_WEIGHTS_FILE).exists()
+    shards = sorted(p.name for p in tmp_path.glob("*.weights.h5"))
+    assert len(shards) > 1
+
+    # Every shard has to be fetched, not just the index (they are separate
+    # downloads for an `hf://` preset).
+    requested = []
+    real_get_file = mpu.get_file
+    monkeypatch.setattr(
+        mpu,
+        "get_file",
+        lambda preset, path: (requested.append(path), real_get_file(preset, path))[1],
+    )
+
+    reloaded = _TinyPresetModel.from_preset(str(tmp_path))
+
+    assert np.allclose(expected, np.array(reloaded(inputs)))
+    assert set(shards).issubset(requested)

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -442,11 +442,6 @@ def test_resolve_path_whole_repo(fake_resolve):
     assert ipu._hf_resolve_path(f"hf://{REPO_ID}") == fake_resolve
 
 
-def test_resolve_path_directory_with_trailing_slash(fake_resolve):
-    """`hf://org/repo/subdir/` is the directory, as the docstring advertises."""
-    assert ipu._hf_resolve_path(f"hf://{REPO_ID}/val/") == fake_resolve / "val"
-
-
 def test_resolve_path_missing_subpath(fake_resolve):
     with pytest.raises(FileNotFoundError, match="not found in"):
         ipu._hf_resolve_path(f"hf://{REPO_ID}/nope.hdf5")

--- a/tests/test_preset_utils.py
+++ b/tests/test_preset_utils.py
@@ -433,6 +433,11 @@ def test_resolve_path_whole_repo(fake_resolve):
     assert ipu._hf_resolve_path(f"hf://{REPO_ID}") == fake_resolve
 
 
+def test_resolve_path_directory_with_trailing_slash(fake_resolve):
+    """`hf://org/repo/subdir/` is the directory, as the docstring advertises."""
+    assert ipu._hf_resolve_path(f"hf://{REPO_ID}/val/") == fake_resolve / "val"
+
+
 def test_resolve_path_missing_subpath(fake_resolve):
     with pytest.raises(FileNotFoundError, match="not found in"):
         ipu._hf_resolve_path(f"hf://{REPO_ID}/nope.hdf5")
@@ -1287,3 +1292,9 @@ def test_streaming_does_not_go_through_the_caches(monkeypatch):
     for _ in range(2):
         ipu._hf_stream_open(f"hf://{REPO_ID}/val/a.hdf5")
     assert len(opens) == 2
+
+
+def test_dtype_size_falls_back_for_unsizeable_dtypes():
+    """An exotic dtype must not turn `save_to_preset` into a ValueError."""
+    assert mpu._dtype_size_in_bits("complex64") == mpu._DEFAULT_DTYPE_BITS
+    assert mpu._dtype_size_in_bits("float8_e4m3fn") == mpu._DEFAULT_DTYPE_BITS

--- a/tests/tools/test_hf.py
+++ b/tests/tools/test_hf.py
@@ -352,3 +352,31 @@ def test_hfpath_joinpath_and_scheme_handling(folder):
 def test_hfpath_repo_id_requires_org_and_repo():
     with pytest.raises(ValueError, match="cannot extract repo_id"):
         HFPath("hf://only-org").repo_id
+
+
+def test_upload_folder_to_hf_invalidates_cache_even_if_tagging_fails(monkeypatch, tmp_path):
+    """The upload landed, so the stale listing has to go regardless of the tag."""
+    import zea.tools.hf as hf
+    from zea.internal import preset_utils as ipu
+
+    monkeypatch.setattr(hf, "_hf_login", lambda: None)
+
+    class FakeApi:
+        def create_branch(self, *args, **kwargs):
+            pass
+
+        def upload_folder(self, **kwargs):
+            pass
+
+        def create_tag(self, *args, **kwargs):
+            raise RuntimeError("tag already exists")
+
+    monkeypatch.setattr(hf, "HfApi", FakeApi)
+
+    ipu._LISTING_CACHE.get_or_call(("zeahub/taesdxl", "model"), lambda: {"old.txt": 1})
+    assert ipu._LISTING_CACHE._entries, "listing was not seeded, the assert below is vacuous"
+
+    with pytest.raises(RuntimeError):
+        hf.upload_folder_to_hf(tmp_path, "zeahub/taesdxl", tag="v1")
+
+    assert ipu._LISTING_CACHE._entries == {}

--- a/tests/tools/test_hf.py
+++ b/tests/tools/test_hf.py
@@ -259,3 +259,69 @@ def test_get_snapshot_dir_from_downloaded_file():
         result = _get_snapshot_dir_from_downloaded_file(str(mock_file))
         assert result == snapshot_hash_dir
         assert result.name == "abc123def"
+
+
+def test_load_model_from_hf(monkeypatch, tmp_path):
+    """The model snapshot is downloaded and its directory returned."""
+    from datetime import datetime, timezone
+
+    import zea.tools.hf as hf
+
+    logins = []
+    monkeypatch.setattr(hf, "_hf_login", lambda: logins.append(1))
+    monkeypatch.setattr(hf, "snapshot_download", lambda **kwargs: str(tmp_path))
+
+    class FakeCommit:
+        title = "Add weights"
+        created_at = datetime(2026, 1, 2, 3, 4, tzinfo=timezone.utc)
+
+    class FakeApi:
+        def list_repo_commits(self, repo_id, revision=None):
+            return [FakeCommit()]
+
+    monkeypatch.setattr(hf, "HfApi", FakeApi)
+
+    model_dir = hf.load_model_from_hf("zeahub/taesdxl")
+
+    assert model_dir == Path(tmp_path)
+    assert logins == [1]
+
+
+def test_upload_folder_to_hf(monkeypatch, tmp_path):
+    """A local directory is uploaded to the given repo, branch and tag."""
+    import zea.tools.hf as hf
+
+    monkeypatch.setattr(hf, "_hf_login", lambda: None)
+    calls = {}
+
+    class FakeApi:
+        def create_branch(self, repo_id, repo_type=None, branch=None, exist_ok=False):
+            calls["branch"] = (repo_id, repo_type, branch, exist_ok)
+
+        def upload_folder(self, folder_path=None, repo_id=None, **kwargs):
+            calls["upload"] = (str(folder_path), repo_id, kwargs.get("commit_message"))
+
+        def create_tag(self, repo_id, repo_type=None, tag=None):
+            calls["tag"] = (repo_id, repo_type, tag)
+
+    monkeypatch.setattr(hf, "HfApi", FakeApi)
+
+    url = hf.upload_folder_to_hf(tmp_path, "zeahub/taesdxl", tag="v1")
+
+    assert url == "https://huggingface.co/zeahub/taesdxl"
+    assert calls["branch"] == ("zeahub/taesdxl", "model", "main", True)
+    assert calls["upload"][0] == str(tmp_path)
+    assert calls["upload"][2] == f"Upload files from {tmp_path.name}"
+    assert calls["tag"] == ("zeahub/taesdxl", "model", "v1")
+
+
+def test_hfpath_joinpath_and_scheme_handling(folder):
+    """joinpath keeps the hf:// scheme, and an already-prefixed part is not doubled."""
+    joined = folder.joinpath("val", "patient0401")
+    assert str(joined) == f"{FOLDER_STR}/val/patient0401"
+    assert str(HFPath(FOLDER_STR, f"{HFPath._scheme}val")) == f"{FOLDER_STR}/val"
+
+
+def test_hfpath_repo_id_requires_org_and_repo():
+    with pytest.raises(ValueError, match="cannot extract repo_id"):
+        HFPath("hf://only-org").repo_id

--- a/tests/tools/test_hf.py
+++ b/tests/tools/test_hf.py
@@ -306,9 +306,15 @@ def test_upload_folder_to_hf(monkeypatch, tmp_path):
 
     monkeypatch.setattr(hf, "HfApi", FakeApi)
 
+    # A stale listing must not survive the upload that invalidates it.
+    from zea.internal import preset_utils as ipu
+
+    ipu._LISTING_CACHE.get_or_call(("zeahub/taesdxl", "model"), lambda: {"old.txt": 1})
+
     url = hf.upload_folder_to_hf(tmp_path, "zeahub/taesdxl", tag="v1")
 
     assert url == "https://huggingface.co/zeahub/taesdxl"
+    assert ipu._LISTING_CACHE._entries == {}
     assert calls["branch"] == ("zeahub/taesdxl", "model", "main", True)
     assert calls["upload"][0] == str(tmp_path)
     assert calls["upload"][2] == f"Upload files from {tmp_path.name}"

--- a/tests/tools/test_hf.py
+++ b/tests/tools/test_hf.py
@@ -174,6 +174,26 @@ def test_hf_parse_path():
         _hf_parse_path("invalid://path")
 
 
+@pytest.mark.parametrize(
+    "hf_path, expected",
+    [
+        ("hf://zeahub/camus-sample/val/", "val"),
+        ("hf://zeahub/camus-sample/val//", "val"),
+        ("hf://zeahub/camus-sample/", None),
+        ("hf://zeahub/camus-sample//", None),
+    ],
+)
+def test_hf_parse_path_ignores_trailing_slash(hf_path, expected):
+    """A trailing slash names the same directory, so it must not reach the subpath.
+
+    Repository entries never carry one, so `hf://org/repo/subdir/` used to resolve to
+    the subpath `subdir/`, which matched no entry and could not be downloaded.
+    """
+    repo_id, subpath = _hf_parse_path(hf_path)
+    assert repo_id == "zeahub/camus-sample"
+    assert subpath == expected
+
+
 def test_download_files_in_path(fake_files, monkeypatch):
     """Test file filtering and download logic."""
 

--- a/tests/tools/test_hf.py
+++ b/tests/tools/test_hf.py
@@ -310,6 +310,7 @@ def test_upload_folder_to_hf(monkeypatch, tmp_path):
     from zea.internal import preset_utils as ipu
 
     ipu._LISTING_CACHE.get_or_call(("zeahub/taesdxl", "model"), lambda: {"old.txt": 1})
+    assert ipu._LISTING_CACHE._entries, "listing was not seeded, the assert below is vacuous"
 
     url = hf.upload_folder_to_hf(tmp_path, "zeahub/taesdxl", tag="v1")
 

--- a/zea/beamform/beamformer.py
+++ b/zea/beamform/beamformer.py
@@ -819,7 +819,7 @@ def fnumber_mask(flatgrid, probe_geometry, f_number, fnum_window_fn, element_nor
     grid_relative_to_probe_norm = ops.linalg.norm(grid_relative_to_probe, axis=-1)
 
     # Unit element -> pixel direction (same +1e-6 guard as before, so a +z
-    # normal reproduces the legacy depth-axis cone bit-for-bit).
+    # normal reproduces the legacy depth-axis cone up to float32 rounding).
     unit_direction = grid_relative_to_probe / (grid_relative_to_probe_norm[..., None] + 1e-6)
 
     # Angle between the element -> pixel direction and the element's normal.

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -65,7 +65,7 @@ def _hf_parse_path(hf_path: str):
     """Parse hf://repo_id[/subpath] into (repo_id, subpath or None)."""
     if not hf_path.startswith(HF_PREFIX):
         raise ValueError(f"Invalid hf_path: {hf_path}. It must start with '{HF_PREFIX}'.")
-    path = hf_path.removeprefix(HF_PREFIX)
+    path = hf_path.removeprefix(HF_PREFIX).rstrip("/")
     parts = path.split("/")
     repo_id = "/".join(parts[:2])
     subpath = "/".join(parts[2:]) if len(parts) > 2 else None

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -22,6 +22,7 @@ from huggingface_hub.utils import (
     RepositoryNotFoundError,
 )
 
+from zea import log
 from zea.internal.cache import ZEA_CACHE_DIR
 
 HF_SCHEME = "hf"
@@ -41,6 +42,11 @@ _HF_CACHE_DIRS = {"dataset": HF_DATASETS_DIR, "model": HF_MODELS_DIR}
 _HF_REPO_TYPE_PREFIX = {"dataset": "datasets/", "model": "", "space": "spaces/"}
 
 
+# ``login()`` writes the token file, and concurrent downloads can all fail
+# authentication at once, so only one of them gets to log in.
+_LOGIN_LOCK = threading.Lock()
+
+
 def _hf_login() -> None:
     """Authenticate using a token from the environment, if available.
 
@@ -51,7 +57,8 @@ def _hf_login() -> None:
     """
     token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
     if token:
-        login(token=token, skip_if_logged_in=True)
+        with _LOGIN_LOCK:
+            login(token=token, skip_if_logged_in=True)
 
 
 def _hf_parse_path(hf_path: str):
@@ -99,12 +106,30 @@ def _hf_call(func, *args, retry_on=_HF_LOGIN_RETRY_ERRORS, **kwargs):
         return func(*args, **kwargs)
 
 
+_DEFAULT_HF_CACHE_TTL = 300.0
+
+
+def _hf_cache_ttl() -> float:
+    """How long hub answers may be reused, from ``ZEA_HF_CACHE_TTL`` (seconds)."""
+    value = os.environ.get("ZEA_HF_CACHE_TTL")
+    if value is None:
+        return _DEFAULT_HF_CACHE_TTL
+    try:
+        return float(value)
+    except ValueError:
+        log.warning(
+            f"Ignoring ZEA_HF_CACHE_TTL={value!r}: expected a number of seconds. "
+            f"Falling back to {_DEFAULT_HF_CACHE_TTL}."
+        )
+        return _DEFAULT_HF_CACHE_TTL
+
+
 # Repository listings and resolved download paths are stable over the lifetime of a
 # single operation, which asks for them repeatedly (a dataset scan lists the same repo
 # once per path it inspects, and loading a preset asks for `config.json` once to check
 # that it exists and once to read it). Memoizing them briefly turns those into a single
 # hub round trip. Set ``ZEA_HF_CACHE_TTL=0`` to disable.
-_HF_CACHE_TTL = float(os.environ.get("ZEA_HF_CACHE_TTL", 300))
+_HF_CACHE_TTL = _hf_cache_ttl()
 
 
 class _TTLCache:
@@ -136,8 +161,12 @@ class _TTLCache:
                 return value
 
         value = func()
+        now = time.monotonic()
         with self._lock:
-            self._entries[key] = (time.monotonic() + self.ttl, value)
+            # Expired entries are only dropped here, so a long-lived process (the data
+            # explorer, a dataset scan over thousands of files) does not accumulate them.
+            self._entries = {k: v for k, v in self._entries.items() if v[0] > now}
+            self._entries[key] = (now + self.ttl, value)
         return value
 
     def clear(self):
@@ -213,6 +242,10 @@ def _hf_download(repo_id, filename, cache_dir=None, repo_type="dataset", **kwarg
             **kwargs,
         )
 
+    if kwargs.get("force_download"):
+        # An explicit re-download is exactly what a memoized path would skip.
+        return _download()
+
     key = _cache_key(repo_id, filename, str(cache_dir), repo_type, **kwargs)
     return _DOWNLOAD_CACHE.get_or_call(key, _download, valid=os.path.exists)
 
@@ -231,8 +264,7 @@ def _get_snapshot_dir_from_downloaded_file(downloaded_file_path: str | Path) -> 
     raise FileNotFoundError(f"Could not find snapshot directory for {downloaded_file_path}")
 
 
-# Downloads are network-bound, so a small pool overlaps their round trips instead of
-# paying for them one after another. Matches huggingface_hub's own default for snapshots.
+# Same default huggingface_hub uses for snapshot downloads.
 _HF_DOWNLOAD_WORKERS = 8
 
 
@@ -240,7 +272,7 @@ def _download_files_in_path(
     repo_id: str,
     files: list,
     path_filter: str | None = None,
-    cache_dir=HF_DATASETS_DIR,
+    cache_dir=None,
     repo_type="dataset",
     **kwargs,
 ) -> list[str]:
@@ -263,8 +295,9 @@ def _download_files_in_path(
         return [_download(filename) for filename in matched]
 
     with ThreadPoolExecutor(max_workers=min(_HF_DOWNLOAD_WORKERS, len(matched))) as pool:
-        # ``map`` keeps the input order and re-raises the first failure, like the
-        # sequential loop it replaces.
+        # ``map`` keeps the input order and raises the first failure, as the sequential
+        # loop did. Unlike that loop it does not stop at the first one: the downloads
+        # already in flight run to completion before the error surfaces.
         return list(pool.map(_download, matched))
 
 

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -321,7 +321,7 @@ def _hf_list_h5_files(hf_path: str, **kwargs) -> list[tuple[str, int]]:
     if subpath and subpath in entries:
         matched = [subpath]
     elif subpath:
-        prefix = subpath.rstrip("/") + "/"
+        prefix = subpath + "/"
         matched = [f for f in entries if f.startswith(prefix) and f.endswith(_HF_H5_EXTENSIONS)]
     else:
         matched = [f for f in entries if f.endswith(_HF_H5_EXTENSIONS)]
@@ -350,9 +350,6 @@ def _hf_resolve_path(
     )
 
     if subpath:
-        # A trailing slash is how you spell "the directory" (and the docstring
-        # advertises it), so strip it like `_hf_list_h5_files` does.
-        subpath = subpath.rstrip("/")
         prefix = subpath + "/"
         # Directory case
         if any(f.startswith(prefix) for f in files):

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -1,12 +1,21 @@
-"""Preset utils for zea datasets hosted on Hugging Face.
+"""Shared Hugging Face plumbing for zea presets (models and datasets).
+
+Both halves of zea resolve ``hf://`` handles: :mod:`zea.models.preset_utils` loads Keras
+presets from model repos, and the data stack (:mod:`zea.data.datasets`,
+:mod:`zea.data.file`, :mod:`zea.data.file_operations`) loads HDF5 files from dataset
+repos. Everything they have in common lives here — handle parsing, authentication,
+repository listings, downloads and streaming — so the two sides cannot drift apart.
 
 See https://huggingface.co/zeahub/
 """
 
 import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from huggingface_hub import RepoFile, hf_hub_download, list_repo_files, list_repo_tree, login
+from huggingface_hub import RepoFile, hf_hub_download, list_repo_tree, login
 from huggingface_hub.utils import (
     EntryNotFoundError,
     HFValidationError,
@@ -15,11 +24,21 @@ from huggingface_hub.utils import (
 
 from zea.internal.cache import ZEA_CACHE_DIR
 
-HF_DATASETS_DIR = ZEA_CACHE_DIR / "huggingface" / "datasets"
-HF_DATASETS_DIR.mkdir(parents=True, exist_ok=True)
-
 HF_SCHEME = "hf"
 HF_PREFIX = "hf://"
+
+HF_DATASETS_DIR = ZEA_CACHE_DIR / "huggingface" / "datasets"
+HF_MODELS_DIR = ZEA_CACHE_DIR / "huggingface" / "models"
+for _cache_dir in (HF_DATASETS_DIR, HF_MODELS_DIR):
+    _cache_dir.mkdir(parents=True, exist_ok=True)
+
+# Default local cache directory per huggingface_hub ``repo_type``, so a model download
+# never lands in the dataset cache (and vice versa) when no ``cache_dir`` is given.
+_HF_CACHE_DIRS = {"dataset": HF_DATASETS_DIR, "model": HF_MODELS_DIR}
+
+# Maps huggingface_hub ``repo_type`` values to the path prefix used by both
+# :class:`~huggingface_hub.HfFileSystem` and the ``resolve`` download URLs.
+_HF_REPO_TYPE_PREFIX = {"dataset": "datasets/", "model": "", "space": "spaces/"}
 
 
 def _hf_login() -> None:
@@ -46,23 +65,156 @@ def _hf_parse_path(hf_path: str):
     return repo_id, subpath
 
 
-def _hf_list_files(repo_id, repo_type="dataset", **kwargs):
+def _hf_repo_type_prefix(repo_type: str) -> str:
+    """The path prefix for a ``repo_type``, validated."""
+    prefix = _HF_REPO_TYPE_PREFIX.get(repo_type)
+    if prefix is None:  # "model" maps to "", so test membership, not truthiness
+        raise ValueError(
+            f"Unsupported repo_type '{repo_type}'. Expected one of {list(_HF_REPO_TYPE_PREFIX)}."
+        )
+    return prefix
+
+
+# The hub answers 404 (rather than 403) for repos an anonymous client may not see, so a
+# "not found" can really mean "not authenticated". Retrying once after a login turns
+# those into a successful call whenever a token is available.
+_HF_LOGIN_RETRY_ERRORS = (RepositoryNotFoundError, HFValidationError, EntryNotFoundError)
+
+# A missing *file* in a repo we can already reach is a genuine 404, and
+# ``check_file_exists`` relies on it being reported quickly, so downloads only retry on
+# errors that a login can plausibly fix.
+_HF_DOWNLOAD_RETRY_ERRORS = (RepositoryNotFoundError,)
+
+
+def _hf_call(func, *args, retry_on=_HF_LOGIN_RETRY_ERRORS, **kwargs):
+    """Call a hub function, retrying it once after a login attempt.
+
+    :func:`_hf_login` is a no-op when no token is available and never prompts
+    interactively, so a failure it cannot fix is simply raised again by the retry.
+    """
     try:
-        files = list_repo_files(repo_id, repo_type=repo_type, **kwargs)
-    except (RepositoryNotFoundError, HFValidationError, EntryNotFoundError):
+        return func(*args, **kwargs)
+    except retry_on:
         _hf_login()
-        files = list_repo_files(repo_id, repo_type=repo_type, **kwargs)
-    return files
+        return func(*args, **kwargs)
 
 
-def _hf_download(repo_id, filename, cache_dir=HF_DATASETS_DIR, repo_type="dataset", **kwargs):
-    return hf_hub_download(
-        repo_id=repo_id,
-        filename=filename,
-        cache_dir=cache_dir,
-        repo_type=repo_type,
-        **kwargs,
-    )
+# Repository listings and resolved download paths are stable over the lifetime of a
+# single operation, which asks for them repeatedly (a dataset scan lists the same repo
+# once per path it inspects, and loading a preset asks for `config.json` once to check
+# that it exists and once to read it). Memoizing them briefly turns those into a single
+# hub round trip. Set ``ZEA_HF_CACHE_TTL=0`` to disable.
+_HF_CACHE_TTL = float(os.environ.get("ZEA_HF_CACHE_TTL", 300))
+
+
+class _TTLCache:
+    """Minimal thread-safe cache whose entries expire after ``ttl`` seconds."""
+
+    def __init__(self, ttl: float):
+        self.ttl = ttl
+        self._entries: dict = {}
+        self._lock = threading.Lock()
+
+    def get_or_call(self, key, func, valid=None):
+        """Return the value cached under ``key``, else call ``func()`` and cache it.
+
+        Args:
+            key: Hashable cache key, or ``None`` to bypass the cache entirely.
+            func (callable): Zero-argument callable producing the value.
+            valid (callable, optional): Predicate re-checked on a cache hit; a value
+                it rejects (e.g. a downloaded file that has since been deleted) is
+                dropped and recomputed.
+        """
+        if self.ttl <= 0 or key is None:
+            return func()
+
+        with self._lock:
+            entry = self._entries.get(key)
+        if entry is not None:
+            expires_at, value = entry
+            if expires_at > time.monotonic() and (valid is None or valid(value)):
+                return value
+
+        value = func()
+        with self._lock:
+            self._entries[key] = (time.monotonic() + self.ttl, value)
+        return value
+
+    def clear(self):
+        """Drop all entries."""
+        with self._lock:
+            self._entries.clear()
+
+
+_LISTING_CACHE = _TTLCache(_HF_CACHE_TTL)
+_DOWNLOAD_CACHE = _TTLCache(_HF_CACHE_TTL)
+
+
+def _hf_clear_caches() -> None:
+    """Drop the memoized repository listings and resolved download paths."""
+    _LISTING_CACHE.clear()
+    _DOWNLOAD_CACHE.clear()
+
+
+def _cache_key(*parts, **kwargs):
+    """Build a hashable cache key, or ``None`` if the arguments cannot be hashed."""
+    key = tuple(parts) + tuple(sorted(kwargs.items()))
+    try:
+        hash(key)
+    except TypeError:
+        return None
+    return key
+
+
+def _hf_repo_files(repo_id, repo_type="dataset", **kwargs) -> dict:
+    """Map every file in a repo to its size in bytes (memoized).
+
+    ``list_repo_tree`` already carries the sizes that ``list_repo_files`` throws away,
+    so one listing serves both the callers that only want names
+    (:func:`_hf_list_files`) and the ones that need sizes (:func:`_hf_list_h5_files`).
+
+    The returned mapping is shared between callers and must not be mutated.
+    """
+
+    def _list():
+        entries = _hf_call(list_repo_tree, repo_id, recursive=True, repo_type=repo_type, **kwargs)
+        return {entry.path: entry.size for entry in entries if isinstance(entry, RepoFile)}
+
+    return _LISTING_CACHE.get_or_call(_cache_key(repo_id, repo_type, **kwargs), _list)
+
+
+def _hf_list_files(repo_id, repo_type="dataset", **kwargs) -> list:
+    """List the paths of all files in a Hugging Face repository."""
+    return list(_hf_repo_files(repo_id, repo_type=repo_type, **kwargs))
+
+
+def _hf_download(repo_id, filename, cache_dir=None, repo_type="dataset", **kwargs):
+    """Download a single file from a repo and return its local path (memoized).
+
+    Args:
+        repo_id (str): The ``{org}/{repo}`` identifier.
+        filename (str): Path of the file inside the repository.
+        cache_dir (str or Path, optional): Local cache directory. Defaults to the zea
+            cache for ``repo_type``.
+        repo_type (str, optional): One of ``"dataset"``, ``"model"`` or ``"space"``.
+        **kwargs: Forwarded to :func:`~huggingface_hub.hf_hub_download`.
+    """
+    if cache_dir is None:
+        cache_dir = _HF_CACHE_DIRS.get(repo_type, HF_DATASETS_DIR)
+
+    def _download():
+        return _hf_call(
+            hf_hub_download,
+            retry_on=_HF_DOWNLOAD_RETRY_ERRORS,
+            repo_id=repo_id,
+            filename=filename,
+            cache_dir=cache_dir,
+            repo_type=repo_type,
+            **kwargs,
+        )
+
+    key = _cache_key(repo_id, filename, str(cache_dir), repo_type, **kwargs)
+    return _DOWNLOAD_CACHE.get_or_call(key, _download, valid=os.path.exists)
 
 
 def _get_snapshot_dir_from_downloaded_file(downloaded_file_path: str | Path) -> Path:
@@ -79,6 +231,11 @@ def _get_snapshot_dir_from_downloaded_file(downloaded_file_path: str | Path) -> 
     raise FileNotFoundError(f"Could not find snapshot directory for {downloaded_file_path}")
 
 
+# Downloads are network-bound, so a small pool overlaps their round trips instead of
+# paying for them one after another. Matches huggingface_hub's own default for snapshots.
+_HF_DOWNLOAD_WORKERS = 8
+
+
 def _download_files_in_path(
     repo_id: str,
     files: list,
@@ -87,20 +244,28 @@ def _download_files_in_path(
     repo_type="dataset",
     **kwargs,
 ) -> list[str]:
-    """Download all files matching the path filter."""
-    downloaded_files = []
-    for f in files:
-        if path_filter is None or f.startswith(path_filter):
-            downloaded_path = _hf_download(
-                repo_id,
-                f,
-                cache_dir=cache_dir,
-                repo_type=repo_type,
-                **kwargs,
-            )
-            downloaded_files.append(downloaded_path)
+    """Download all files matching the path filter, concurrently.
 
-    return downloaded_files
+    Returns the local paths in the same order as the matching entries of ``files``.
+    """
+    matched = [f for f in files if path_filter is None or f.startswith(path_filter)]
+
+    def _download(filename):
+        return _hf_download(
+            repo_id,
+            filename,
+            cache_dir=cache_dir,
+            repo_type=repo_type,
+            **kwargs,
+        )
+
+    if len(matched) <= 1:
+        return [_download(filename) for filename in matched]
+
+    with ThreadPoolExecutor(max_workers=min(_HF_DOWNLOAD_WORKERS, len(matched))) as pool:
+        # ``map`` keeps the input order and re-raises the first failure, like the
+        # sequential loop it replaces.
+        return list(pool.map(_download, matched))
 
 
 _HF_H5_EXTENSIONS = (".hdf5", ".h5")
@@ -118,29 +283,15 @@ def _hf_list_h5_files(hf_path: str, **kwargs) -> list[tuple[str, int]]:
     - hf://org/repo/file.h5   — [(file.h5, size)] if it exists as a single file
     """
     repo_id, subpath = _hf_parse_path(hf_path)
-    try:
-        entries = {
-            e.path: e.size
-            for e in list_repo_tree(repo_id, recursive=True, repo_type="dataset", **kwargs)
-            if isinstance(e, RepoFile)
-        }
-    except (RepositoryNotFoundError, HFValidationError, EntryNotFoundError):
-        _hf_login()
-        entries = {
-            e.path: e.size
-            for e in list_repo_tree(repo_id, recursive=True, repo_type="dataset", **kwargs)
-            if isinstance(e, RepoFile)
-        }
+    entries = _hf_repo_files(repo_id, repo_type="dataset", **kwargs)
 
-    all_files = list(entries)
-
-    if subpath and any(f == subpath for f in all_files):
+    if subpath and subpath in entries:
         matched = [subpath]
     elif subpath:
         prefix = subpath.rstrip("/") + "/"
-        matched = [f for f in all_files if f.startswith(prefix) and f.endswith(_HF_H5_EXTENSIONS)]
+        matched = [f for f in entries if f.startswith(prefix) and f.endswith(_HF_H5_EXTENSIONS)]
     else:
-        matched = [f for f in all_files if f.endswith(_HF_H5_EXTENSIONS)]
+        matched = [f for f in entries if f.endswith(_HF_H5_EXTENSIONS)]
 
     return [(f, entries[f]) for f in matched]
 
@@ -166,12 +317,13 @@ def _hf_resolve_path(
     )
 
     if subpath:
+        prefix = subpath + "/"
         # Directory case
-        if any(f.startswith(subpath + "/") for f in files):
+        if any(f.startswith(prefix) for f in files):
             downloaded_files = _download_files_in_path(
                 repo_id,
                 files,
-                subpath + "/",
+                prefix,
                 cache_dir=cache_dir,
                 repo_type=repo_type,
                 **kwargs,
@@ -210,11 +362,6 @@ def _hf_resolve_path(
         return _get_snapshot_dir_from_downloaded_file(downloaded_files[0])
 
 
-# Maps huggingface_hub ``repo_type`` values to the path prefix that
-# :class:`~huggingface_hub.HfFileSystem` expects.
-_HF_FS_PREFIX = {"dataset": "datasets/", "model": "", "space": "spaces/"}
-
-
 # This file object only serves h5py's metadata reads; chunk_reader fetches the array chunks
 # itself. The paged layout keeps that metadata to ~0.26 MB in one request, so the block just has
 # to cover it. Keep it aligned with chunk_cache.CachedFile's block size. Overridable via File().
@@ -225,9 +372,6 @@ _HF_STREAM_BLOCK_SIZE = 1024 * 1024  # 1 MiB
 # Host serving the file bytes. Range requests for chunk reads go straight here rather than
 # through :class:`~huggingface_hub.HfFileSystem`, which issues them one at a time.
 _HF_HOST = "https://huggingface.co"
-
-# The ``resolve`` endpoint of a repo type, as it appears in a download URL.
-_HF_URL_PREFIX = {"dataset": "datasets/", "model": "", "space": "spaces/"}
 
 
 def _hf_stream_url(
@@ -257,11 +401,7 @@ def _hf_stream_url(
     repo_id, subpath = _hf_parse_path(hf_path)
     if not subpath:
         raise ValueError(f"Expected an 'hf://' path to a single file, got '{hf_path}'.")
-    prefix = _HF_URL_PREFIX.get(repo_type)
-    if prefix is None:  # "model" maps to "", so test membership, not truthiness
-        raise ValueError(
-            f"Unsupported repo_type '{repo_type}'. Expected one of {list(_HF_URL_PREFIX)}."
-        )
+    prefix = _hf_repo_type_prefix(repo_type)
     return f"{_HF_HOST}/{prefix}{repo_id}/resolve/{revision or 'main'}/{subpath}"
 
 
@@ -309,11 +449,7 @@ def _hf_stream_open(
             "Point at a specific '.hdf5'/'.h5' file, or pass stream=False to download."
         )
 
-    prefix = _HF_FS_PREFIX.get(repo_type)
-    if prefix is None:
-        raise ValueError(
-            f"Unsupported repo_type '{repo_type}'. Expected one of {list(_HF_FS_PREFIX)}."
-        )
+    prefix = _hf_repo_type_prefix(repo_type)
     ref = f"@{revision}" if revision else ""
     fs_path = f"{prefix}{repo_id}{ref}/{subpath}"
 
@@ -323,8 +459,5 @@ def _hf_stream_open(
         cache_type = _HF_STREAM_CACHE_TYPE
 
     open_kwargs = {"cache_type": cache_type, "block_size": block_size, **kwargs}
-    try:
-        return HfFileSystem().open(fs_path, "rb", **open_kwargs)
-    except (RepositoryNotFoundError, HFValidationError, EntryNotFoundError):
-        _hf_login()
-        return HfFileSystem().open(fs_path, "rb", **open_kwargs)
+    # A fresh filesystem is built per attempt so the retry picks up the new credentials.
+    return _hf_call(lambda: HfFileSystem().open(fs_path, "rb", **open_kwargs))

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -82,22 +82,20 @@ def _hf_repo_type_prefix(repo_type: str) -> str:
     return prefix
 
 
-# The hub answers 404 (rather than 403) for repos an anonymous client may not see, so a
-# "not found" can really mean "not authenticated". Retrying once after a login turns
-# those into a successful call whenever a token is available.
+# The hub answers 404 for repos an anonymous client may not see, so "not found" can
+# really mean "not authenticated".
 _HF_LOGIN_RETRY_ERRORS = (RepositoryNotFoundError, HFValidationError, EntryNotFoundError)
 
-# A missing *file* in a repo we can already reach is a genuine 404, and
-# ``check_file_exists`` relies on it being reported quickly, so downloads only retry on
-# errors that a login can plausibly fix.
+# A missing *file* in a repo we can reach is a genuine 404, and `check_file_exists`
+# needs it reported quickly.
 _HF_DOWNLOAD_RETRY_ERRORS = (RepositoryNotFoundError,)
 
 
 def _hf_call(func, *args, retry_on=_HF_LOGIN_RETRY_ERRORS, **kwargs):
     """Call a hub function, retrying it once after a login attempt.
 
-    :func:`_hf_login` is a no-op when no token is available and never prompts
-    interactively, so a failure it cannot fix is simply raised again by the retry.
+    :func:`_hf_login` is a no-op without a token and never prompts interactively, so a
+    failure it cannot fix is raised again by the retry.
     """
     try:
         return func(*args, **kwargs)
@@ -124,11 +122,8 @@ def _hf_cache_ttl() -> float:
         return _DEFAULT_HF_CACHE_TTL
 
 
-# Repository listings and resolved download paths are stable over the lifetime of a
-# single operation, which asks for them repeatedly (a dataset scan lists the same repo
-# once per path it inspects, and loading a preset asks for `config.json` once to check
-# that it exists and once to read it). Memoizing them briefly turns those into a single
-# hub round trip. Set ``ZEA_HF_CACHE_TTL=0`` to disable.
+# A single operation asks for the same listing or file repeatedly (a dataset scan lists
+# the repo once per path it inspects), so hub answers are reused briefly.
 _HF_CACHE_TTL = _hf_cache_ttl()
 
 
@@ -163,8 +158,7 @@ class _TTLCache:
         value = func()
         now = time.monotonic()
         with self._lock:
-            # Expired entries are only dropped here, so a long-lived process (the data
-            # explorer, a dataset scan over thousands of files) does not accumulate them.
+            # The only place expired entries are dropped, so they cannot pile up.
             self._entries = {k: v for k, v in self._entries.items() if v[0] > now}
             self._entries[key] = (now + self.ttl, value)
         return value
@@ -283,21 +277,14 @@ def _download_files_in_path(
     matched = [f for f in files if path_filter is None or f.startswith(path_filter)]
 
     def _download(filename):
-        return _hf_download(
-            repo_id,
-            filename,
-            cache_dir=cache_dir,
-            repo_type=repo_type,
-            **kwargs,
-        )
+        return _hf_download(repo_id, filename, cache_dir=cache_dir, repo_type=repo_type, **kwargs)
 
     if len(matched) <= 1:
         return [_download(filename) for filename in matched]
 
     with ThreadPoolExecutor(max_workers=min(_HF_DOWNLOAD_WORKERS, len(matched))) as pool:
-        # ``map`` keeps the input order and raises the first failure, as the sequential
-        # loop did. Unlike that loop it does not stop at the first one: the downloads
-        # already in flight run to completion before the error surfaces.
+        # ``map`` keeps the input order and raises the first failure, though unlike the
+        # sequential loop it lets the downloads already in flight finish first.
         return list(pool.map(_download, matched))
 
 
@@ -329,9 +316,7 @@ def _hf_list_h5_files(hf_path: str, **kwargs) -> list[tuple[str, int]]:
     return [(f, entries[f]) for f in matched]
 
 
-def _hf_resolve_path(
-    hf_path: str, cache_dir=HF_DATASETS_DIR, repo_type="dataset", **kwargs
-) -> Path:
+def _hf_resolve_path(hf_path: str, cache_dir=None, repo_type="dataset", **kwargs) -> Path:
     """Resolve a Hugging Face path to a local cache directory path.
 
     Downloads files from a HuggingFace dataset repository and returns
@@ -343,11 +328,7 @@ def _hf_resolve_path(
     Note that we also support streaming, so this should not be used that often!
     """
     repo_id, subpath = _hf_parse_path(hf_path)
-    files = _hf_list_files(
-        repo_id,
-        repo_type=repo_type,
-        **kwargs,
-    )
+    files = _hf_list_files(repo_id, repo_type=repo_type, **kwargs)
 
     if subpath:
         prefix = subpath + "/"

--- a/zea/internal/preset_utils.py
+++ b/zea/internal/preset_utils.py
@@ -350,6 +350,9 @@ def _hf_resolve_path(
     )
 
     if subpath:
+        # A trailing slash is how you spell "the directory" (and the docstring
+        # advertises it), so strip it like `_hf_list_h5_files` does.
+        subpath = subpath.rstrip("/")
         prefix = subpath + "/"
         # Directory case
         if any(f.startswith(prefix) for f in files):
@@ -492,5 +495,6 @@ def _hf_stream_open(
         cache_type = _HF_STREAM_CACHE_TYPE
 
     open_kwargs = {"cache_type": cache_type, "block_size": block_size, **kwargs}
-    # A fresh filesystem is built per attempt so the retry picks up the new credentials.
+    # We never pass a token, so `HfFileSystem` resolves one per request: the retry
+    # picks up a login even though fsspec may hand back the same cached instance.
     return _hf_call(lambda: HfFileSystem().open(fs_path, "rb", **open_kwargs))

--- a/zea/models/base.py
+++ b/zea/models/base.py
@@ -129,14 +129,19 @@ class BaseModel(keras.models.Model):
                 )
         return loader.load_model(cls, load_weights, **kwargs)
 
-    def save_to_preset(self, preset_dir):
+    def save_to_preset(self, preset_dir, max_shard_size=10):
         """Save backbone to a preset directory.
 
         Args:
             preset_dir: The path to the local model preset directory.
+            max_shard_size: ``int`` or ``float``. Maximum size in GB of each
+                weights file. A model larger than this is written as shards
+                alongside a ``model.weights.json`` index, which
+                :meth:`from_preset` loads transparently. If ``None``, the
+                weights are always written as a single file. Defaults to ``10``.
         """
         saver = get_preset_saver(preset_dir)
-        saver.save_model(self)
+        saver.save_model(self, max_shard_size=max_shard_size)
 
 
 def deserialize_zea_object(config, cls=None):

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -87,12 +87,11 @@ def _get_hf_file(preset, path):
             f"'hf://username/bert_base_en'. Received: preset={preset}."
         ) from e
     except EntryNotFoundError as e:
-        message = str(e)
-        if message.find("403 Client Error"):
-            raise FileNotFoundError(
-                f"`{path}` doesn't exist in preset directory `{preset}`."
-            ) from e
-        raise ValueError(message) from e
+        # The hub raises this when the file is not in the repo, which is exactly
+        # what `check_file_exists` asks about. (keras-hub branches on a
+        # `403 Client Error` here, but its condition is `str.find(...)`, which is
+        # truthy at -1 too, so that branch never runs there either.)
+        raise FileNotFoundError(f"`{path}` doesn't exist in preset directory `{preset}`.") from e
 
 
 def _get_local_file(preset, path):

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -20,16 +20,8 @@ from huggingface_hub.utils import EntryNotFoundError, HFValidationError
 
 import zea
 import zea.models.base
-from zea.internal.preset_utils import (
-    HF_MODELS_DIR,  # noqa: F401 — re-exported, this module used to define it
-    HF_PREFIX,  # noqa: F401 — idem
-    HF_SCHEME,
-    _hf_download,
-    _hf_parse_path,
-)
+from zea.internal.preset_utils import HF_SCHEME, _hf_download, _hf_parse_path
 from zea.internal.registry import model_registry
-
-ASSET_DIR = "assets"
 
 # Config file names.
 CONFIG_FILE = "config.json"
@@ -40,10 +32,6 @@ METADATA_FILE = "metadata.json"
 # Weight file names.
 MODEL_WEIGHTS_FILE = "model.weights.h5"
 SHARDED_MODEL_WEIGHTS_CONFIG_FILE = "model.weights.json"
-
-# HuggingFace filenames.
-README_FILE = "README.md"
-HF_CONFIG_FILE = "config.json"
 
 # Global state for preset registry.
 BUILTIN_PRESETS = {}
@@ -90,10 +78,8 @@ def _get_hf_file(preset, path):
             f"'hf://username/bert_base_en'. Received: preset={preset}."
         ) from e
     except EntryNotFoundError as e:
-        # The hub raises this when the file is not in the repo, which is exactly
-        # what `check_file_exists` asks about. (keras-hub branches on a
-        # `403 Client Error` here, but its condition is `str.find(...)`, which is
-        # truthy at -1 too, so that branch never runs there either.)
+        # The hub raises this when the file is not in the repo, which is what
+        # `check_file_exists` asks about.
         raise FileNotFoundError(f"`{path}` doesn't exist in preset directory `{preset}`.") from e
 
 
@@ -157,7 +143,6 @@ def load_serialized_object(config, cls, **kwargs):
     config = set_dtype_in_config(config, dtype)
 
     config["config"] = {**config["config"], **kwargs}
-    # return keras.saving.deserialize_keras_object(config)
     return zea.models.base.deserialize_zea_object(config, cls)
 
 
@@ -166,19 +151,7 @@ def check_config_class(config):
     registered_name = config["registered_name"]
     if registered_name in ("Functional", "Sequential"):
         return keras.Model
-    # cls = keras.saving.get_registered_object(registered_name)
-    name = keras_to_zea_registry(registered_name, model_registry)
-
-    cls = model_registry[name]
-
-    if cls is None:
-        raise ValueError(
-            f"Attempting to load class {registered_name} with "
-            "`from_preset()`, but there is no class registered with zea "
-            f"for {registered_name}. Make sure to register any custom "
-            "classes with `zea.registry.model_registry()`."
-        )
-    return cls
+    return model_registry[keras_to_zea_registry(registered_name, model_registry)]
 
 
 def jax_memory_cleanup(layer):

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -10,7 +10,9 @@ import collections
 import datetime
 import inspect
 import json
+import math
 import os
+import re
 from pathlib import Path
 
 import keras
@@ -37,6 +39,7 @@ METADATA_FILE = "metadata.json"
 
 # Weight file names.
 MODEL_WEIGHTS_FILE = "model.weights.h5"
+SHARDED_MODEL_WEIGHTS_CONFIG_FILE = "model.weights.json"
 
 # HuggingFace filenames.
 README_FILE = "README.md"
@@ -99,7 +102,7 @@ def _get_local_file(preset, path):
     preset_dir = Path(preset).resolve()
     local_path = (preset_dir / path).resolve()
     # Guard against a `path` that escapes the preset directory (keras-hub does the
-    # same for its cache directory).
+    # same for its cache directory, see keras-team/keras-hub#2716).
     if preset_dir != local_path and preset_dir not in local_path.parents:
         raise ValueError(f"Invalid path: '{path}'. It escapes the preset directory.")
     if not local_path.exists():
@@ -184,7 +187,8 @@ def jax_memory_cleanup(layer):
         for weight in layer.weights:
             value = getattr(weight, "_value", None)
             # Do not delete sharded arrays, as they may be referenced in JAX's
-            # distributed computation graph and deletion can cause errors.
+            # distributed computation graph and deletion can cause errors
+            # (keras-team/keras-hub#2431).
             if value is not None and getattr(value, "sharding", None) is None:
                 value.delete()
 
@@ -230,6 +234,23 @@ def _assert_file_exists(preset, path):
             "directory you are trying to load is a valid KerasHub preset and "
             "and that you have permissions to read/download from this location."
         ) from e
+
+
+def _dtype_size_in_bits(dtype):
+    """Size of a dtype in bits, e.g. ``"float32"`` -> 32."""
+    dtype = keras.backend.standardize_dtype(dtype)
+    if dtype == "bool":
+        return 1
+    return int(re.sub(r"bfloat|float|uint|int", "", dtype))
+
+
+def _variables_size_in_bytes(variables):
+    """Total size of ``variables`` in bytes, counting shared variables once."""
+    unique_variables = {id(v): (v.shape, v.dtype) for v in variables}
+    total_bits = sum(
+        math.prod(shape) * _dtype_size_in_bits(dtype) for shape, dtype in unique_variables.values()
+    )
+    return total_bits / 8
 
 
 def keras_to_zea_registry(keras_name, zea_registry):
@@ -316,9 +337,30 @@ class KerasPresetLoader(PresetLoader):
                     "Model could not be built. Make sure to add a build_config to the json "
                     "or set the input_shape or image_shape attribute before loading weights."
                 )
-        model.load_weights(get_file(self.preset, MODEL_WEIGHTS_FILE))
+        self._load_model_weights(model)
 
         return model
+
+    def _get_sharded_filenames(self, config_path):
+        """The shard files listed in a sharded weights config."""
+        with open(config_path, encoding="utf-8") as config_file:
+            weight_map = json.load(config_file)["weight_map"]
+        filenames = set()
+        for value in weight_map.values():
+            filenames.update(value if isinstance(value, list) else [value])
+        return sorted(filenames)
+
+    def _load_model_weights(self, model):
+        """Load the preset weights, whether they are a single file or sharded."""
+        if check_file_exists(self.preset, MODEL_WEIGHTS_FILE):
+            filepath = get_file(self.preset, MODEL_WEIGHTS_FILE)
+        else:
+            # Sharded: the config maps each weight to the shard holding it, and
+            # Keras expects every shard to sit next to the config when loading.
+            filepath = get_file(self.preset, SHARDED_MODEL_WEIGHTS_CONFIG_FILE)
+            for shard in self._get_sharded_filenames(filepath):
+                get_file(self.preset, shard)
+        model.load_weights(filepath)
 
     def load_image_converter(self, cls, **kwargs):
         """Load an image converter from the preset."""
@@ -353,12 +395,28 @@ class KerasPresetSaver:
         os.makedirs(preset_dir, exist_ok=True)
         self.preset_dir = preset_dir
 
-    def save_model(self, model):
-        """Save a model to a preset."""
+    def save_model(self, model, max_shard_size=10):
+        """Save a model to a preset.
+
+        Args:
+            model (keras.Model): The model to save.
+            max_shard_size (int or float, optional): Maximum size in GB of each
+                weights file. Models larger than this are saved as shards next to a
+                ``model.weights.json`` index. ``None`` always writes a single file.
+                Defaults to ``10``.
+        """
         self._save_serialized_object(model, config_file=CONFIG_FILE)
-        model_weight_path = os.path.join(self.preset_dir, MODEL_WEIGHTS_FILE)
-        model.save_weights(model_weight_path)
+        self._save_model_weights(model, max_shard_size)
         self._save_metadata(model)
+
+    def _save_model_weights(self, model, max_shard_size):
+        """Write the weights as a single file, or as shards when too large."""
+        size_in_gb = _variables_size_in_bytes(model.variables) / (1024**3)
+        if max_shard_size is not None and size_in_gb > max_shard_size:
+            weights_path = os.path.join(self.preset_dir, SHARDED_MODEL_WEIGHTS_CONFIG_FILE)
+            model.save_weights(weights_path, max_shard_size=max_shard_size)
+        else:
+            model.save_weights(os.path.join(self.preset_dir, MODEL_WEIGHTS_FILE))
 
     def save_image_converter(self, converter):
         """Save an image converter to a preset."""

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -239,12 +239,21 @@ def _assert_file_exists(preset, path):
         ) from e
 
 
+# What to assume for a dtype we cannot size (`complex64`, `float8_e4m3fn`, ...). This
+# only feeds the shard-size estimate, so guessing beats keras-hub's uncaught ValueError
+# out of `save_to_preset`.
+_DEFAULT_DTYPE_BITS = 32
+
+
 def _dtype_size_in_bits(dtype):
     """Size of a dtype in bits, e.g. ``"float32"`` -> 32."""
     dtype = keras.backend.standardize_dtype(dtype)
     if dtype == "bool":
         return 1
-    return int(re.sub(r"bfloat|float|uint|int", "", dtype))
+    try:
+        return int(re.sub(r"bfloat|float|uint|int", "", dtype))
+    except ValueError:
+        return _DEFAULT_DTYPE_BITS
 
 
 def _variables_size_in_bytes(variables):

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -1,4 +1,10 @@
-"""Mostly from keras_hub.src.models import preset_utils"""
+"""Loading and saving of zea model presets.
+
+Mostly from ``keras_hub.src.utils.preset_utils``, trimmed to what zea needs and
+routed through the zea model registry. The Hugging Face plumbing (handle parsing,
+authentication, downloading) is shared with the data stack and lives in
+:mod:`zea.internal.preset_utils`.
+"""
 
 import collections
 import datetime
@@ -7,19 +13,19 @@ import json
 import os
 from pathlib import Path
 
-import huggingface_hub
 import keras
 from huggingface_hub.utils import EntryNotFoundError, HFValidationError
 
 import zea
 import zea.models.base
-from zea.internal.cache import ZEA_CACHE_DIR
-from zea.internal.preset_utils import _hf_login, _hf_parse_path
+from zea.internal.preset_utils import (
+    HF_MODELS_DIR,
+    HF_PREFIX,  # noqa: F401 — re-exported, this module used to define it
+    HF_SCHEME,
+    _hf_download,
+    _hf_parse_path,
+)
 from zea.internal.registry import model_registry
-
-HF_PREFIX = "hf://"
-
-HF_SCHEME = "hf"
 
 ASSET_DIR = "assets"
 
@@ -35,9 +41,6 @@ MODEL_WEIGHTS_FILE = "model.weights.h5"
 # HuggingFace filenames.
 README_FILE = "README.md"
 HF_CONFIG_FILE = "config.json"
-
-HF_MODELS_DIR = ZEA_CACHE_DIR / "huggingface" / "models"
-HF_MODELS_DIR.mkdir(parents=True, exist_ok=True)
 
 # Global state for preset registry.
 BUILTIN_PRESETS = {}
@@ -63,64 +66,64 @@ def builtin_presets(cls):
     return presets
 
 
+def _resolve_builtin_preset(preset):
+    """Resolve a built-in preset identifier to its handle or local path."""
+    entry = BUILTIN_PRESETS.get(preset)
+    if entry is None:
+        return preset
+    return entry["hf_handle"] if "hf_handle" in entry else entry["path"]
+
+
+def _get_hf_file(preset, path):
+    """Download ``path`` from a ``hf://`` preset and return the local path."""
+    repo_id, subpath = _hf_parse_path(preset)
+    filename = f"{subpath}/{path}" if subpath else path
+    try:
+        return _hf_download(repo_id, filename, cache_dir=HF_MODELS_DIR, repo_type="model")
+    except HFValidationError as e:
+        raise ValueError(
+            "Unexpected Hugging Face preset. Hugging Face model handles "
+            "should have the form 'hf://{org}/{model}'. For example, "
+            f"'hf://username/bert_base_en'. Received: preset={preset}."
+        ) from e
+    except EntryNotFoundError as e:
+        message = str(e)
+        if message.find("403 Client Error"):
+            raise FileNotFoundError(
+                f"`{path}` doesn't exist in preset directory `{preset}`."
+            ) from e
+        raise ValueError(message) from e
+
+
+def _get_local_file(preset, path):
+    """Return the local path of ``path`` inside a local preset directory."""
+    preset_dir = Path(preset).resolve()
+    local_path = (preset_dir / path).resolve()
+    # Guard against a `path` that escapes the preset directory (keras-hub does the
+    # same for its cache directory).
+    if preset_dir != local_path and preset_dir not in local_path.parents:
+        raise ValueError(f"Invalid path: '{path}'. It escapes the preset directory.")
+    if not local_path.exists():
+        raise FileNotFoundError(f"`{path}` doesn't exist in preset directory `{preset}`.")
+    return str(Path(preset) / path)
+
+
 def get_file(preset, path):
     """Download a preset file in necessary and return the local path."""
     if not isinstance(preset, str):
         raise ValueError(f"A preset identifier must be a string. Received: preset={preset}")
 
-    if preset in BUILTIN_PRESETS:
-        if "hf_handle" in BUILTIN_PRESETS[preset]:
-            preset = BUILTIN_PRESETS[preset]["hf_handle"]
-        else:
-            preset = BUILTIN_PRESETS[preset]["path"]
+    preset = _resolve_builtin_preset(preset)
 
     scheme = None
     if "://" in preset:
         scheme = preset.split("://")[0].lower()
 
     if scheme == HF_SCHEME:
-        if huggingface_hub is None:
-            raise ImportError(
-                f"`from_preset()` requires the `huggingface_hub` package to load from '{preset}'. "
-                "Please install with `pip install huggingface_hub`."
-            )
-        repo_id, subpath = _hf_parse_path(preset)
-        filename = f"{subpath}/{path}" if subpath else path
-
-        def _download_from_hf(repo_id, filename):
-            return huggingface_hub.hf_hub_download(
-                repo_id=repo_id,
-                filename=filename,
-                cache_dir=HF_MODELS_DIR,
-            )
-
-        try:
-            # Try without login first
-            return _download_from_hf(repo_id, filename)
-        except huggingface_hub.utils.RepositoryNotFoundError:
-            # Retry after login; _hf_login is a no-op when no token is available
-            # and never prompts interactively, so re-raise if login didn't help.
-            _hf_login()
-            return _download_from_hf(repo_id, filename)
-        except HFValidationError as e:
-            raise ValueError(
-                "Unexpected Hugging Face preset. Hugging Face model handles "
-                "should have the form 'hf://{org}/{model}'. For example, "
-                f"'hf://username/bert_base_en'. Received: preset={preset}."
-            ) from e
-        except EntryNotFoundError as e:
-            message = str(e)
-            if message.find("403 Client Error"):
-                raise FileNotFoundError(
-                    f"`{path}` doesn't exist in preset directory `{preset}`."
-                ) from e
-            raise ValueError(message) from e
+        return _get_hf_file(preset, path)
     elif Path(preset).exists():
         # Assume a local filepath
-        local_path = Path(preset) / path
-        if not local_path.exists():
-            raise FileNotFoundError(f"`{path}` doesn't exist in preset directory `{preset}`.")
-        return str(local_path)
+        return _get_local_file(preset, path)
     else:
         raise ValueError(
             "Unknown preset identifier. A preset must be a one of:\n"
@@ -180,8 +183,11 @@ def jax_memory_cleanup(layer):
     # variable types and do not need this fix.
     if keras.config.backend() == "jax":
         for weight in layer.weights:
-            if getattr(weight, "_value", None) is not None:
-                weight._value.delete()
+            value = getattr(weight, "_value", None)
+            # Do not delete sharded arrays, as they may be referenced in JAX's
+            # distributed computation graph and deletion can cause errors.
+            if value is not None and getattr(value, "sharding", None) is None:
+                value.delete()
 
 
 def set_dtype_in_config(config, dtype=None):

--- a/zea/models/preset_utils.py
+++ b/zea/models/preset_utils.py
@@ -21,8 +21,8 @@ from huggingface_hub.utils import EntryNotFoundError, HFValidationError
 import zea
 import zea.models.base
 from zea.internal.preset_utils import (
-    HF_MODELS_DIR,
-    HF_PREFIX,  # noqa: F401 — re-exported, this module used to define it
+    HF_MODELS_DIR,  # noqa: F401 — re-exported, this module used to define it
+    HF_PREFIX,  # noqa: F401 — idem
     HF_SCHEME,
     _hf_download,
     _hf_parse_path,
@@ -82,7 +82,7 @@ def _get_hf_file(preset, path):
     repo_id, subpath = _hf_parse_path(preset)
     filename = f"{subpath}/{path}" if subpath else path
     try:
-        return _hf_download(repo_id, filename, cache_dir=HF_MODELS_DIR, repo_type="model")
+        return _hf_download(repo_id, filename, repo_type="model")
     except HFValidationError as e:
         raise ValueError(
             "Unexpected Hugging Face preset. Hugging Face model handles "
@@ -99,15 +99,18 @@ def _get_hf_file(preset, path):
 
 def _get_local_file(preset, path):
     """Return the local path of ``path`` inside a local preset directory."""
-    preset_dir = Path(preset).resolve()
-    local_path = (preset_dir / path).resolve()
+    local_path = Path(preset) / path
     # Guard against a `path` that escapes the preset directory (keras-hub does the
-    # same for its cache directory, see keras-team/keras-hub#2716).
-    if preset_dir != local_path and preset_dir not in local_path.parents:
+    # same for its cache directory, see keras-team/keras-hub#2716). Compare the
+    # paths lexically like upstream: an HF snapshot directory is a valid preset and
+    # stores its files as symlinks into a sibling `blobs/`, which resolving would
+    # (wrongly) read as an escape.
+    preset_dir = os.path.abspath(preset)
+    if os.path.commonpath([preset_dir, os.path.abspath(local_path)]) != preset_dir:
         raise ValueError(f"Invalid path: '{path}'. It escapes the preset directory.")
     if not local_path.exists():
         raise FileNotFoundError(f"`{path}` doesn't exist in preset directory `{preset}`.")
-    return str(Path(preset) / path)
+    return str(local_path)
 
 
 def get_file(preset, path):

--- a/zea/tools/hf.py
+++ b/zea/tools/hf.py
@@ -93,11 +93,12 @@ def upload_folder_to_hf(
         revision=revision,
     )
 
+    # The repo just changed, so anything we remembered about it is stale. Do this
+    # before tagging, which is optional and must not be able to skip it.
+    _hf_clear_caches()
+
     if tag:
         api.create_tag(repo_id, repo_type="model", tag=tag)
-
-    # The repo just changed, so anything we remembered about it is stale.
-    _hf_clear_caches()
 
     if verbose:
         msg = f"Uploaded files from '{local_dir}' to 'https://huggingface.co/{repo_id}'."

--- a/zea/tools/hf.py
+++ b/zea/tools/hf.py
@@ -194,5 +194,5 @@ class HFPath(PurePosixPath):
         if not subpath:
             return True
         # If any file starts with subpath + '/', it's a directory
-        prefix = subpath.rstrip("/") + "/"
+        prefix = subpath + "/"
         return any(f.startswith(prefix) for f in files)

--- a/zea/tools/hf.py
+++ b/zea/tools/hf.py
@@ -5,9 +5,7 @@ from pathlib import Path, PurePosixPath
 from huggingface_hub import HfApi, snapshot_download
 
 from zea import log
-from zea.internal.preset_utils import _hf_list_files, _hf_login, _hf_parse_path
-
-HF_PREFIX = "hf://"
+from zea.internal.preset_utils import HF_PREFIX, _hf_list_files, _hf_login, _hf_parse_path
 
 
 def load_model_from_hf(repo_id, revision="main", verbose=True):

--- a/zea/tools/hf.py
+++ b/zea/tools/hf.py
@@ -108,25 +108,39 @@ def upload_folder_to_hf(
     return f"https://huggingface.co/{repo_id}"
 
 
+# Python 3.12 moved path parsing out of ``PurePath.__new__`` and into ``__init__``, which
+# receives the arguments the caller passed rather than the ones ``__new__`` normalized.
+_PUREPATH_PARSES_IN_INIT = PurePosixPath.__init__ is not object.__init__
+
+
 class HFPath(PurePosixPath):
     """A path-like object that preserves the hf:// scheme and mimics Path API."""
 
     _scheme = HF_PREFIX
 
-    def __new__(cls, *args):
-        # Strip "hf://" from all arguments and normalize
+    @classmethod
+    def _join_without_scheme(cls, args):
+        """Join the arguments into one path, dropping any ``hf://`` prefix."""
         parts = []
         for arg in args:
             s = str(arg)
             if s.startswith(cls._scheme):
                 s = s[len(cls._scheme) :]
             parts.append(s.strip("/"))
-        combined = "/".join(parts)
+        return "/".join(parts)
+
+    def __new__(cls, *args):
         # Store path without scheme
-        self = super().__new__(cls, combined)
+        self = super().__new__(cls, cls._join_without_scheme(args))
         # Mark this as an HF path that needs a scheme when stringified
         self._needs_scheme = True
         return self
+
+    def __init__(self, *args):
+        # On Python < 3.12 ``__new__`` above already parsed the normalized path, and
+        # ``PurePath`` has no ``__init__`` to hand it to.
+        if _PUREPATH_PARSES_IN_INIT:
+            super().__init__(self._join_without_scheme(args))
 
     def __str__(self):
         # Get the raw path string without any scheme

--- a/zea/tools/hf.py
+++ b/zea/tools/hf.py
@@ -5,7 +5,13 @@ from pathlib import Path, PurePosixPath
 from huggingface_hub import HfApi, snapshot_download
 
 from zea import log
-from zea.internal.preset_utils import HF_PREFIX, _hf_list_files, _hf_login, _hf_parse_path
+from zea.internal.preset_utils import (
+    HF_PREFIX,
+    _hf_clear_caches,
+    _hf_list_files,
+    _hf_login,
+    _hf_parse_path,
+)
 
 
 def load_model_from_hf(repo_id, revision="main", verbose=True):
@@ -89,6 +95,9 @@ def upload_folder_to_hf(
 
     if tag:
         api.create_tag(repo_id, repo_type="model", tag=tag)
+
+    # The repo just changed, so anything we remembered about it is stale.
+    _hf_clear_caches()
 
     if verbose:
         msg = f"Uploaded files from '{local_dir}' to 'https://huggingface.co/{repo_id}'."


### PR DESCRIPTION
Closes #69. `zea/models/preset_utils.py` and `zea/internal/preset_utils.py` had each grown their own copy of the Hugging Face logic: handle parsing, login-and-retry, downloading, cache directories. This puts all of it in `zea/internal/preset_utils.py` and makes the model side a consumer of it. The public zea API does not change, just internal refactor :)

### What got merged

- One login-and-retry helper (`_hf_call`) replaces four hand-rolled `try / except / login / retry` blocks.
- One downloader (`_hf_download`), now repo_type-aware, serves both the model and the dataset cache.
- One repo-type prefix table (the fsspec paths and the resolve URLs were duplicate dicts).
- `HF_PREFIX` is defined once instead of in three places.
- Model `get_file` is split into `_resolve_builtin_preset` / `_get_hf_file` / `_get_local_file`.

### Under the hood it also got faster

- Repository listings go through a single `list_repo_tree` call that keeps file sizes, so `_hf_list_files` and `_hf_list_h5_files` no longer make separate round trips for the same repo. (`huggingface_hub` implements `list_repo_files` as exactly this, filtered — so nothing is lost.)
- Listings and resolved download paths are memoized with a short TTL (`ZEA_HF_CACHE_TTL`, default 300s, `0` disables — documented in `environment.rst`). A dataset scan now lists a repo once instead of once per inspected path, and loading a preset fetches `config.json` once rather than once to check it exists and once to read it. `upload_folder_to_hf` invalidates the caches.
- `_download_files_in_path` downloads concurrently instead of one file at a time.

The streaming work from #504 is untouched: `_hf_stream_open`, `_hf_stream_url` and the block-size constants behave exactly as before, and streaming deliberately does not go through the new caches (there's a test for that).

### Picked up from keras-hub

Our fork of [`preset_utils.py`](https://github.com/keras-team/keras-hub/blob/master/keras_hub/src/utils/preset_utils.py) is old; upstream master has moved on. Two fixes and one feature were worth taking:

- **keras-team/keras-hub#2431** — `jax_memory_cleanup` no longer deletes sharded arrays, which breaks references in distributed JAX.
- **keras-team/keras-hub#2716** — local preset paths are checked for directory escape.
- **keras-team/keras-hub#2218** — sharded weight save/load, as its own commit. `save_to_preset(preset_dir, max_shard_size=10)` keeps writing a single `model.weights.h5` for anything under 10 GB, so existing presets are unaffected; bigger models write shards next to a `model.weights.json` index, and `from_preset` fetches every shard. Upstream's `sharded_weights_available()` guard is dropped — it exists for Keras < 3.5 and we require ≥ 3.12.1.

**Not taken: `_resolve_dtype` (keras-team/keras-hub#2367).** It fixes loading *quantized* task models and upstream applies it only in `load_task`, not `load_backbone` — which is what our `load_model` is. zea has no tasks and never writes a `DTypePolicyMap`; our configs carry a plain `DTypePolicy(float32)`, so adopting it would only mean every existing preset silently loads under whatever global dtype policy is set. No upside, and it would put us ahead of keras-hub rather than in line with it.

### Two small behaviour changes, on purpose

- `get_file` no longer keeps a dead branch: it mapped `EntryNotFoundError` to `FileNotFoundError` behind `if message.find("403 Client Error"):`, which is truthy at `-1` too, so the `ValueError` after it could never run (keras-hub still carries the same dead branch). `EntryNotFoundError` already means "not in the repo", which is what `check_file_exists` asks.
- Dataset downloads now retry after a login, like listings always did. The old `_hf_download` had no retry at all.

Also removed: an `if huggingface_hub is None` guard that could never fire, since we import it unconditionally (keras-hub wraps the import in a `try`, we don't).

### Coverage

Refs #42. All new tests are offline — every hub call is faked, so nothing here is network-flaky.

| | before | after |
|---|---|---|
| `zea/internal/preset_utils.py` | 56% | 98% |
| `zea/models/preset_utils.py` | 29% | 98% |
| `zea/models/base.py` | — | 99% |
| `zea/tools/hf.py` | 65% | 91% |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `ZEA_HF_CACHE_TTL` to control Hugging Face cache reuse (default 300s; set to 0 to disable).
  * Enhanced `hf://` preset handling, including concurrent directory downloads and improved streaming/open retry behavior.
  * Added `max_shard_size` (default 10) for saving/loading sharded model weights.
  * Refreshes cached repository info after Hugging Face uploads.

* **Bug Fixes**
  * Improved preset class resolution and strengthened local preset path safety.
  * Relaxed beamforming mask test comparison for floating-point robustness.

* **Tests**
  * Added extensive offline coverage for Hugging Face preset utilities and path/caching behavior.

* **Documentation**
  * Updated environment-variable reference with the new cache TTL entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->