### PR TITLE
Fix matplotlib backend and opencv extras in the dev setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,13 +111,24 @@ docs = [
     "PyStemmer",
     "IPython",
 ]
-# The full dev environment: the tooling groups plus the runtime extras
+# The full dev environment: the tooling groups plus the runtime extras. Takes
+# opencv-python-headless directly, not via `zea[display-headless]`: uv only activates a
+# conflicting extra when it is named, so the indirection would leave `uv sync` without cv2.
 dev = [
     { include-group = "tests" },
     { include-group = "docs" },
     { include-group = "lint" },
-    "zea[display-headless]",
+    "opencv-python-headless>=4",
     "zea[models]",
+]
+
+# Both extras provide `cv2`, so co-installing them leaves whichever landed last, and
+# uninstalling either takes the shared `cv2/` with it. `dev` already brings the headless
+# build, hence the second pair.
+[tool.uv]
+conflicts = [
+    [{ extra = "display" }, { extra = "display-headless" }],
+    [{ extra = "display" }, { group = "dev" }],
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,13 +7,8 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-# Pin the matplotlib backend for the whole suite, before pyplot is imported anywhere in
-# this process. An interactive MPLBACKEND exported in a developer's shell is otherwise
-# inherited by the papermill kernels in test_notebooks.py, where it survives ipykernel's
-# ``if not os.environ.get("MPLBACKEND")`` guard and fails the notebook with "Failed to
-# import any of the following Qt binding modules". matplotlib's backend_fallback hides
-# this on headless machines and in CI, so it only shows up on a workstation with a
-# display.
+# Must be set before pyplot is imported, and inherited by the papermill kernels in
+# test_notebooks.py, which would otherwise pick up an interactive backend from the shell.
 os.environ["MPLBACKEND"] = "Agg"
 
 import pytest  # noqa: E402

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,18 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import pytest
+# Pin the matplotlib backend for the whole suite, before pyplot is imported anywhere in
+# this process. An interactive MPLBACKEND exported in a developer's shell is otherwise
+# inherited by the papermill kernels in test_notebooks.py, where it survives ipykernel's
+# ``if not os.environ.get("MPLBACKEND")`` guard and fails the notebook with "Failed to
+# import any of the following Qt binding modules". matplotlib's backend_fallback hides
+# this on headless machines and in CI, so it only shows up on a workstation with a
+# display.
+os.environ["MPLBACKEND"] = "Agg"
 
-from .data import generate_example_dataset
+import pytest  # noqa: E402
+
+from .data import generate_example_dataset  # noqa: E402
 
 
 def _gpu_available() -> bool:
@@ -72,8 +80,6 @@ from .backend_utils import (  # noqa: E402
     missing_required_backends,
     unavailable_test_backends,
 )
-
-plt.rcParams["backend"] = "agg"
 
 
 def _skip_unavailable_backends_enabled(config):

--- a/tests/test_getting_started.py
+++ b/tests/test_getting_started.py
@@ -11,14 +11,10 @@ Run with:
     pytest -s -m 'heavy' tests/test_getting_started.py
 """
 
-import os
 import re
 from pathlib import Path
 
-# Must be set before matplotlib.pyplot is imported anywhere in this process.
-os.environ.setdefault("MPLBACKEND", "Agg")
-
-import pytest  # noqa: E402
+import pytest
 
 RST_PATH = Path("docs/source/getting-started.rst")
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,20 +2,26 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version < '3.12' and sys_platform == 'win32'",
     "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_version < '0'",
 ]
+conflicts = [[
+    { package = "zea", extra = "display" },
+    { package = "zea", extra = "display-headless" },
+], [
+    { package = "zea", extra = "display" },
+    { package = "zea", group = "dev" },
+]]
 
 [[package]]
 name = "absl-py"
@@ -58,7 +64,7 @@ dependencies = [
     { name = "frozenlist" },
     { name = "multidict" },
     { name = "propcache" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
@@ -171,7 +177,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -211,7 +217,7 @@ version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -438,7 +444,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -606,7 +612,7 @@ name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
@@ -823,7 +829,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 
 [[package]]
@@ -836,14 +842,19 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
     { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f7/0e35987a21914f84068061dcf4b61466ccbce1c62ddc9727596d5ed0c26f/cuda_bindings-13.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:507b0e19e7f934c5e30f30f0244ad70a75812619a7d3a0d742543caae1bd50f1", size = 5664286, upload-time = "2026-05-29T23:11:47.719Z" },
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
     { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/872a0392122f1fb43fcb06869790ef3171f37beee9f7db8f441739113570/cuda_bindings-13.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:b134dd8c5c66ae4c4ad814f7aee88fd215353c077010cbc47e3b55ed35ec9eff", size = 5875099, upload-time = "2026-05-29T23:11:54.635Z" },
     { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
     { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2f/6a0dd496550c6fafbf6aeb1bf40242eeabb2fd138a43892aabb4be8224c2/cuda_bindings-13.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:18c8c167c8907b8f02531ca810534315c458dabef31f7965095619bf647b9202", size = 5830027, upload-time = "2026-05-29T23:12:01.205Z" },
     { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
     { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/2734be44dbc80ac082ec23a86b41c8294992dcb90033645ed1bc50aafe4c/cuda_bindings-13.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:8de12ef60bf40756852cb62bbb40460609269f6ece522903d1cc93d73a3ececb", size = 5961055, upload-time = "2026-05-29T23:12:07.971Z" },
     { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
     { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+    { url = "https://files.pythonhosted.org/packages/27/2a/b59bcac016ab9985d6b48a5d05b0d698461a159ca03ee11c4abd54da2ac4/cuda_bindings-13.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:61120b5e4f4a63f67efd7e7396914cb9ef871bb1f0021e990fb70277be240a4d", size = 6740329, upload-time = "2026-05-29T23:12:15.153Z" },
 ]
 
 [[package]]
@@ -864,43 +875,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 
 [[package]]
@@ -1237,8 +1248,8 @@ dependencies = [
     { name = "accessible-pygments" },
     { name = "beautifulsoup4" },
     { name = "pygments" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "sphinx-basic-ng" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
@@ -1273,7 +1284,7 @@ version = "6.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "brotli" },
     { name = "fastapi" },
     { name = "gradio-client" },
@@ -1328,7 +1339,7 @@ version = "0.2.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
-    { name = "array-record", marker = "sys_platform != 'win32'" },
+    { name = "array-record", marker = "sys_platform != 'win32' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "cloudpickle" },
     { name = "etils", extra = ["epath", "epy"] },
     { name = "numpy" },
@@ -1572,7 +1583,7 @@ dependencies = [
     { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -1658,7 +1669,7 @@ name = "ipykernel"
 version = "7.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1682,18 +1693,18 @@ name = "ipython"
 version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "decorator" },
     { name = "ipython-pygments-lexers" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "psutil", marker = "sys_platform != 'emscripten' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -1783,18 +1794,18 @@ wheels = [
 
 [package.optional-dependencies]
 with-cuda = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 
 [[package]]
@@ -2480,8 +2491,8 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "mdit-py-plugins" },
     { name = "pyyaml" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/dc/603751677fff302f34396e206b610f556a59d7fe58b9a2145f54e96b48e8/myst_parser-5.1.0.tar.gz", hash = "sha256:ab69322dc6719dcc7f296479dbb70181b66df6ed315064f92dbc85c0e1bf2f02", size = 101182, upload-time = "2026-05-13T09:38:19.361Z" }
 wheels = [
@@ -2570,8 +2581,8 @@ dependencies = [
     { name = "jinja2" },
     { name = "nbconvert" },
     { name = "nbformat" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/d1/82081750f8a78ad0399c6ed831d42623b891904e8e7b8a75878225cf1dce/nbsphinx-0.9.8.tar.gz", hash = "sha256:d0765908399a8ee2b57be7ae881cf2ea58d66db3af7bbf33e6eb48f83bea5495", size = 417469, upload-time = "2025-11-28T17:41:02.336Z" }
@@ -2727,6 +2738,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
     { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/45/9e/2f562daf80eb8f7a685fb7bea4fda71f6048e4f359d6fdd1b6e70206cb2f/nvidia_cublas-13.1.1.3-py3-none-win_amd64.whl", hash = "sha256:b6cdce694e47ff6aadf0a69df1cab6628d696f5ff56e8d16af50309d855fa20f", size = 404358158, upload-time = "2026-04-08T18:47:26.987Z" },
 ]
 
 [[package]]
@@ -2734,11 +2746,12 @@ name = "nvidia-cublas-cu12"
 version = "12.9.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
     { url = "https://files.pythonhosted.org/packages/cb/c0/0a517bfe63ccd3b92eb254d264e28fca3c7cab75d07daea315250fb1bf73/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e4f53a8ca8c5d6e8c492d0d0a3d565ecb59a751b19cfdaa4f6da0ab2104c1702", size = 581240110, upload-time = "2026-04-08T18:52:31.532Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e2/fc9a0e985249d873150276d5afb02e39a66817fedbf1a385724393e505ed/nvidia_cublas_cu12-12.9.2.10-py3-none-win_amd64.whl", hash = "sha256:623f43027d40d44ceadf0043f002bd25cf353e8f13ce90b9a87057019f560661", size = 553162896, upload-time = "2026-04-08T18:53:10.035Z" },
 ]
 
 [[package]]
@@ -2748,6 +2761,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
     { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9b/1daf405620c7ac371b76b823c6336dd742673d41a150d9a04eec2c690379/nvidia_cuda_cccl_cu12-12.9.27-py3-none-win_amd64.whl", hash = "sha256:72106f95a9bb3be18472806b4f663ebf0f9248a86d14b4ae3305725b855d9d92", size = 3152175, upload-time = "2025-05-01T19:45:11.372Z" },
 ]
 
 [[package]]
@@ -2757,6 +2771,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -2766,6 +2781,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/78/351b5c8cdbd9a6b4fb0d6ee73fb176dcdc1b6b6ad47c2ffff5ae8ca4a1f7/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:791853b030602c6a11d08b5578edfb957cadea06e9d3b26adbf8d036135a4afe", size = 10077166, upload-time = "2025-06-05T20:01:01.385Z" },
     { url = "https://files.pythonhosted.org/packages/c1/2e/b84e32197e33f39907b455b83395a017e697c07a449a2b15fd07fc1c9981/nvidia_cuda_cupti_cu12-12.9.79-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:096bcf334f13e1984ba36685ad4c1d6347db214de03dbb6eebb237b41d9d934f", size = 10814997, upload-time = "2025-06-05T20:01:10.168Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b4/298983ab1a83de500f77d0add86d16d63b19d1a82c59f8eaf04f90445703/nvidia_cuda_cupti_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:1848a9380067560d5bee10ed240eecc22991713e672c0515f9c3d9396adf93c8", size = 7730496, upload-time = "2025-06-05T20:11:26.444Z" },
 ]
 
 [[package]]
@@ -2775,6 +2791,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
     { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9e/c71c53655a65d7531c89421c282359e2f626838762f1ce6180ea0bbebd29/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:8ed7f0b17dea662755395be029376db3b94fed5cbb17c2d35cc866c5b1b84099", size = 34669845, upload-time = "2025-06-05T20:11:56.308Z" },
 ]
 
 [[package]]
@@ -2784,6 +2801,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -2793,6 +2811,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
     { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/52/de/823919be3b9d0ccbf1f784035423c5f18f4267fb0123558d58b813c6ec86/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:72972ebdcf504d69462d3bcd67e7b81edd25d0fb85a2c46d3ea3517666636349", size = 76408187, upload-time = "2025-06-05T20:12:27.819Z" },
 ]
 
 [[package]]
@@ -2802,6 +2821,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -2811,6 +2831,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/e0/0279bd94539fda525e0c8538db29b72a5a8495b0c12173113471d28bce78/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83469a846206f2a733db0c42e223589ab62fd2fabac4432d2f8802de4bded0a4", size = 3515012, upload-time = "2025-06-05T20:00:35.519Z" },
     { url = "https://files.pythonhosted.org/packages/bc/46/a92db19b8309581092a3add7e6fceb4c301a3fd233969856a8cbf042cd3c/nvidia_cuda_runtime_cu12-12.9.79-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:25bba2dfb01d48a9b59ca474a1ac43c6ebf7011f1b0b8cc44f54eb6ac48a96c3", size = 3493179, upload-time = "2025-06-05T20:00:53.735Z" },
+    { url = "https://files.pythonhosted.org/packages/59/df/e7c3a360be4f7b93cee39271b792669baeb3846c58a4df6dfcf187a7ffab/nvidia_cuda_runtime_cu12-12.9.79-py3-none-win_amd64.whl", hash = "sha256:8e018af8fa02363876860388bd10ccb89eb9ab8fb0aa749aaf58430a9f7c4891", size = 3591604, upload-time = "2025-06-05T20:11:17.036Z" },
 ]
 
 [[package]]
@@ -2818,11 +2839,12 @@ name = "nvidia-cudnn-cu12"
 version = "9.23.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/30/ecca1c8194c8077c4b57a3d96b56d96f15852551b01b919bae6429d92218/nvidia_cudnn_cu12-9.23.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6dbc18f05aab2a323a4ffd43d985410608f7db7db9a8596e189cddbd3e527441", size = 778220760, upload-time = "2026-06-09T19:38:19.281Z" },
     { url = "https://files.pythonhosted.org/packages/a0/7e/e0a5d44bf070a1ff945050abc02ef1cff5ca9c6ab5dc6a16ab6322593a32/nvidia_cudnn_cu12-9.23.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:272d4815eef8f0dd21ecca768bfa18a618fb76ec31547dd0885cd49e76ebcd1d", size = 721095859, upload-time = "2026-06-09T19:41:00.27Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ec/62b56fc5e8219a268c6f62c4e9fb1369ebec049512328e650d1a9a28bcc8/nvidia_cudnn_cu12-9.23.1.3-py3-none-win_amd64.whl", hash = "sha256:b874af5bfab5e1010ae88bfead14bf8e9da6b20283582288f1c05f056090a398", size = 689996767, upload-time = "2026-06-09T19:44:25.343Z" },
 ]
 
 [[package]]
@@ -2835,6 +2857,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
     { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+    { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
 ]
 
 [[package]]
@@ -2847,6 +2870,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -2854,11 +2878,12 @@ name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
     { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ee/29955203338515b940bd4f60ffdbc073428f25ef9bfbce44c9a066aedc5c/nvidia_cufft_cu12-11.4.1.4-py3-none-win_amd64.whl", hash = "sha256:8e5bfaac795e93f80611f807d42844e8e27e340e0cde270dcb6c65386d795b80", size = 200067309, upload-time = "2025-06-05T20:13:59.762Z" },
 ]
 
 [[package]]
@@ -2877,6 +2902,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -2891,6 +2917,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -2898,13 +2925,14 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.5.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cusparse-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
     { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/feb7f86b809f89b14193beffebe24cf2e4bf7af08372ab8cdd34d19a65a0/nvidia_cusolver_cu12-11.7.5.82-py3-none-win_amd64.whl", hash = "sha256:77666337237716783c6269a658dea310195cddbd80a5b2919b1ba8735cec8efd", size = 326215953, upload-time = "2025-06-05T20:14:41.76Z" },
 ]
 
 [[package]]
@@ -2917,6 +2945,7 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -2924,11 +2953,12 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.10.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
     { url = "https://files.pythonhosted.org/packages/12/46/b0fd4b04f86577921feb97d8e2cf028afe04f614d17fb5013de9282c9216/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:73060ce019ac064a057267c585bf1fd5a353734151f87472ff02b2c5c9984e78", size = 366465088, upload-time = "2025-06-05T20:08:20.413Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ef/063500c25670fbd1cbb0cd3eb7c8a061585b53adb4dd8bf3492bb49b0df3/nvidia_cusparse_cu12-12.5.10.65-py3-none-win_amd64.whl", hash = "sha256:9e487468a22a1eaf1fbd1d2035936a905feb79c4ce5c2f67626764ee4f90227c", size = 362504719, upload-time = "2025-06-05T20:15:17.947Z" },
 ]
 
 [[package]]
@@ -2938,6 +2968,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
     { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+    { url = "https://files.pythonhosted.org/packages/31/83/f3647ce26916c94a6ca4ff1810623e2c405cff2dea6e78d29516b2514df9/nvidia_cusparselt_cu13-0.8.1-py3-none-win_amd64.whl", hash = "sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215", size = 156885108, upload-time = "2025-09-05T18:51:35.958Z" },
 ]
 
 [[package]]
@@ -2965,6 +2996,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
 ]
 
 [[package]]
@@ -2974,6 +3006,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/0c/c75bbfb967457a0b7670b8ad267bfc4fffdf341c074e0a80db06c24ccfd4/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:e3f1171dbdc83c5932a45f0f4c99180a70de9bd2718c1ab77d14104f6d7147f9", size = 39748338, upload-time = "2025-06-05T20:10:25.613Z" },
     { url = "https://files.pythonhosted.org/packages/97/bc/2dcba8e70cf3115b400fef54f213bcd6715a3195eba000f8330f11e40c45/nvidia_nvjitlink_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:994a05ef08ef4b0b299829cde613a424382aff7efb08a7172c1fa616cc3af2ca", size = 39514880, upload-time = "2025-06-05T20:10:04.89Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/7e/2eecb277d8a98184d881fb98a738363fd4f14577a4d2d7f8264266e82623/nvidia_nvjitlink_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:cc6fcec260ca843c10e34c936921a1c426b351753587fdd638e8cff7b16bb9db", size = 35584936, upload-time = "2025-06-05T20:16:08.525Z" },
 ]
 
 [[package]]
@@ -2981,7 +3014,7 @@ name = "nvidia-nvshmem-cu12"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-cccl-cu12" },
+    { name = "nvidia-cuda-cccl-cu12", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'emscripten' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform == 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/4f/2d705ab9a090fe946dc2be0a3c30f9241e99c49058d2f9c269459b445edc/nvidia_nvshmem_cu12-3.7.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06426cd421093a63529d90a95e57ddf884c9ca43f93016d7a27b903f0a0acaed", size = 230116748, upload-time = "2026-06-11T12:40:27.683Z" },
@@ -3004,6 +3037,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -3067,7 +3101,7 @@ name = "opencv-python-headless"
 version = "5.0.0.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "extra == 'extra-3-zea-display-headless' or extra == 'group-3-zea-dev'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
 wheels = [
@@ -3262,7 +3296,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -3329,7 +3363,7 @@ name = "papermill"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp", marker = "python_full_version == '3.12.*'" },
+    { name = "aiohttp", marker = "python_full_version == '3.12.*' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "click" },
     { name = "entrypoints" },
     { name = "nbclient" },
@@ -3917,7 +3951,7 @@ name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -4045,7 +4079,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -4105,7 +4139,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -4335,8 +4369,8 @@ dependencies = [
     { name = "packaging" },
     { name = "pillow" },
     { name = "scipy" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "tifffile", version = "2026.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "tifffile", version = "2026.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
 wheels = [
@@ -4601,23 +4635,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "babel", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "colorama", marker = "(python_full_version < '3.12' and sys_platform == 'win32') or (python_full_version >= '3.12' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (python_full_version >= '3.12' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "docutils", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "imagesize", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "jinja2", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "packaging", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "pygments", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "requests", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "roman-numerals", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -4629,34 +4663,34 @@ name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "babel", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "colorama", marker = "(python_full_version >= '3.12' and sys_platform == 'win32') or (python_full_version < '3.12' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (python_full_version < '3.12' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'win32' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "docutils", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "imagesize", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "jinja2", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "packaging", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "pygments", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "requests", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -4669,8 +4703,8 @@ version = "2025.8.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "starlette" },
     { name = "uvicorn" },
     { name = "watchfiles" },
@@ -4691,7 +4725,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1d/f6/bdd93582b2aaad2cfe9eb5695a44883c8bc44572dd3c351a947acbb13789/sphinx_autodoc_typehints-3.6.1.tar.gz", hash = "sha256:fa0b686ae1b85965116c88260e5e4b82faec3687c2e94d6a10f9b36c3743e2fe", size = 37563, upload-time = "2026-01-02T15:23:46.543Z" }
 wheels = [
@@ -4703,18 +4737,18 @@ name = "sphinx-autodoc-typehints"
 version = "3.10.5"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/88/f4698f838b8cc030f3df73cf529f96d7c9e6dd3e3ff40968b7fe4d86c748/sphinx_autodoc_typehints-3.10.5.tar.gz", hash = "sha256:a54dfab95a6b5e8601543d25474497e98ed59268ac0ab01b3daba9817cf9707e", size = 79721, upload-time = "2026-06-03T15:30:28.181Z" }
 wheels = [
@@ -4726,8 +4760,8 @@ name = "sphinx-basic-ng"
 version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/0b/a866924ded68efec7a1759587a4e478aec7559d8165fac8b2ad1c0e774d6/sphinx_basic_ng-1.0.0b2.tar.gz", hash = "sha256:9ec55a47c90c8c002b5960c57492ec3021f5193cb26cebc2dc4ea226848651c9", size = 20736, upload-time = "2023-07-08T18:40:54.166Z" }
 wheels = [
@@ -4739,8 +4773,8 @@ name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/2b/a964715e7f5295f77509e59309959f4125122d648f86b4fe7d70ca1d882c/sphinx-copybutton-0.5.2.tar.gz", hash = "sha256:4cf17c82fb9646d1bc9ca92ac280813a3b605d8c421225fd9913154103ee1fbd", size = 23039, upload-time = "2023-04-14T08:10:22.998Z" }
 wheels = [
@@ -4752,8 +4786,8 @@ name = "sphinx-design"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/13/7b/804f311da4663a4aecc6cf7abd83443f3d4ded970826d0c958edc77d4527/sphinx_design-0.7.0.tar.gz", hash = "sha256:d2a3f5b19c24b916adb52f97c5f00efab4009ca337812001109084a740ec9b7a", size = 2203582, upload-time = "2026-01-19T13:12:53.297Z" }
 wheels = [
@@ -4765,8 +4799,8 @@ name = "sphinx-reredirects"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1b/8d/0e39fe2740d7d71417edf9a6424aa80ca2c27c17fc21282cdc39f90d5a40/sphinx_reredirects-1.1.0.tar.gz", hash = "sha256:fb9b195335ab14b43f8273287d0c7eeb637ba6c56c66581c11b47202f6718b29", size = 614624, upload-time = "2025-12-22T08:28:02.792Z" }
 wheels = [
@@ -4790,8 +4824,8 @@ dependencies = [
     { name = "docutils" },
     { name = "pybtex" },
     { name = "pybtex-docutils" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/6a/8e0b2c2420286389e7fed78ff361ec30e2f1d58c8560af8d64df5e7b61e0/sphinxcontrib_bibtex-2.7.0.tar.gz", hash = "sha256:fee700f7aae29bb8f654c62913f00d34ac44fc0b8ca0fa67ac922ff4453addee", size = 120669, upload-time = "2026-05-06T09:29:24.935Z" }
 wheels = [
@@ -4863,7 +4897,7 @@ version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
@@ -4991,7 +5025,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -5003,18 +5037,18 @@ name = "tifffile"
 version = "2026.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
@@ -5101,19 +5135,19 @@ name = "torch"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "cuda-bindings", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (python_full_version >= '3.15' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform != 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "triton", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (python_full_version >= '3.15' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev') or (sys_platform != 'linux' and extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (sys_platform != 'linux' and extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -5161,7 +5195,7 @@ name = "tqdm"
 version = "4.70.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
@@ -5807,6 +5841,7 @@ dev = [
     { name = "ipywidgets" },
     { name = "myst-parser" },
     { name = "nbsphinx" },
+    { name = "opencv-python-headless" },
     { name = "papermill" },
     { name = "pre-commit" },
     { name = "pybtex" },
@@ -5815,17 +5850,17 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "simpleitk" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and extra == 'group-3-zea-dev') or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'group-3-zea-dev') or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.12' and extra == 'group-3-zea-dev') or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx-autodoc-typehints", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and extra == 'group-3-zea-dev') or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-reredirects" },
     { name = "sphinxcontrib-bibtex" },
     { name = "ty" },
-    { name = "zea", extra = ["app", "display-headless", "models"] },
+    { name = "zea", extra = ["app", "models"], marker = "(extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra != 'extra-3-zea-display-headless' and extra == 'group-3-zea-dev') or (extra != 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
 ]
 docs = [
     { name = "furo" },
@@ -5834,11 +5869,11 @@ docs = [
     { name = "nbsphinx" },
     { name = "pybtex" },
     { name = "pystemmer" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "sphinx-autodoc-typehints", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
+    { name = "sphinx-autodoc-typehints", version = "3.10.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' or (extra == 'extra-3-zea-display' and extra == 'extra-3-zea-display-headless') or (extra == 'extra-3-zea-display' and extra == 'group-3-zea-dev')" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-reredirects" },
@@ -5902,6 +5937,7 @@ dev = [
     { name = "ipywidgets" },
     { name = "myst-parser" },
     { name = "nbsphinx" },
+    { name = "opencv-python-headless", specifier = ">=4" },
     { name = "papermill", specifier = ">=2.4" },
     { name = "pre-commit" },
     { name = "pybtex", specifier = ">=0.26.1" },
@@ -5919,7 +5955,6 @@ dev = [
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
     { name = "ty", specifier = "==0.0.64" },
     { name = "zea", extras = ["app"] },
-    { name = "zea", extras = ["display-headless"] },
     { name = "zea", extras = ["models"] },
 ]
 docs = [


### PR DESCRIPTION
Fixes #543. Two independent setup fixes.

## 1. Pin `MPLBACKEND=Agg` for the test suite

Notebook tests fail on a developer machine with:

```
ImportError: Failed to import any of the following Qt binding modules: PyQt6, PySide6, PyQt5, PySide2
```

Nothing to do with the lockfile — `pyqt6` isn't a dependency of anything here. The trigger is an interactive `MPLBACKEND` exported in the developer's shell, and two things let it through:

- `ipykernel` forces the inline backend, but only `if not os.environ.get("MPLBACKEND")` — an exported value survives into the papermill kernel.
- matplotlib's `backend_fallback` throws away an explicit interactive backend when there's no usable display. So headless machines and CI silently degrade to Agg and never see it; a workstation with a display does.

Setting `MPLBACKEND=Agg` in `conftest.py` before pyplot is imported fixes both the pytest process and every kernel it spawns. This replaces two weaker guards: `plt.rcParams["backend"] = "agg"` in `conftest.py`, which only affected the pytest process, and `os.environ.setdefault(...)` in `test_getting_started.py`, which was a no-op whenever a backend was already exported.

Not touching the notebooks: `Agg` makes `plt.show()` a no-op, and the pre-commit hook requires committed outputs, so the five notebooks that use it would silently lose their inline figures and the Colab links would render no plots.

## 2. Stop `display` and `display-headless` co-installing

Both extras provide `cv2`, so `uv sync --all-extras` installed both and kept whichever landed last. Uninstalling either then removed the shared `cv2/` directory, leaving the survivor recorded as installed but broken:

```
$ uv sync
Audited 196 packages in 1ms          # environment reported as fine
$ python -c "import cv2"
ModuleNotFoundError: No module named 'cv2'
```

Declaring the extras conflicting makes that an error at sync time instead. Two details worth knowing while reviewing:

- `dev` now depends on `opencv-python-headless` directly instead of `zea[display-headless]`. uv only activates a conflicting extra when it's named, so keeping the indirection left a plain `uv sync` with **no** cv2 at all.
- The second conflict pair (`display` vs `dev`) covers `--all-groups --extra display`, which would otherwise co-install both again through the dev group.

The `uv.lock` delta is large but mechanical: conflict markers only, no package added, removed, or changed version.

## Verification

Repro for #543, with `MPLBACKEND=QtAgg` and a virtual display:

```bash
MPLBACKEND=QtAgg xvfb-run -a uv run -m pytest \
  "tests/test_notebooks.py::test_notebook_runs[zea_simulation_example.ipynb]"
```
`1 failed in 97.71s` (PapermillExecutionError) before, `1 passed in 134.42s` after. `test_visualize.py`, `test_io_lib.py` and `test_generative.py` pass; full suite left to CI.

Every sync path, from a clean `.venv`:

| command | result |
|---|---|
| `uv sync` (contributing.rst) | headless cv2 |
| `uv sync --all-groups` | headless cv2 |
| `uv sync --all-extras` | error, names both extras |
| `uv sync --all-extras --all-groups` | error, names both extras |
| `uv sync --all-groups --extra display` | error, names extra + group |
| `uv sync --no-default-groups --extra display` | GUI cv2, for anyone who wants it |
| `uv sync --no-default-groups --group docs --extra jax` (readthedocs) | unchanged |
| `uv sync --frozen --inexact --dev` / `--no-dev` (Dockerfile) | unchanged |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless test and development environments by ensuring plotting runs without requiring a display.
  * Prevented conflicting display configurations from being selected together.

* **Tests**
  * Standardized non-interactive plotting behavior across test processes.
  * Simplified test setup and removed redundant environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->