### PR TITLE
Prevent error when there is no ImgDataP in workspace

### DIFF
--- a/tests/data/test_conversion_scripts.py
+++ b/tests/data/test_conversion_scripts.py
@@ -1369,6 +1369,35 @@ def test_verasonics_upload_requires_revision(tmp_path, monkeypatch):
         convert_verasonics(args)
 
 
+def copy_verasonics_mat_without_img_data_p(destination_dir):
+    """Copy the Verasonics test .mat and strip its ImgDataP buffer.
+
+    Not every Verasonics workspace reconstructs images, so the ImgDataP buffer can be
+    absent. Removing it from a copy reproduces such a workspace.
+    """
+    mat_file = _hf_resolve_path("hf://zeahub/pytest/verasonics_conversion_test_zea.mat")
+    stripped_file = destination_dir / mat_file.name
+    shutil.copy(mat_file, stripped_file)
+
+    stripped_file.chmod(0o644)
+    with h5py.File(stripped_file, "r+") as file:
+        del file["ImgDataP"]
+    return stripped_file
+
+
+@pytest.mark.heavy
+def test_verasonics_read_without_img_data_p(tmp_path):
+    """Reading a Verasonics file without ImgDataP omits the image buffer element."""
+    stripped_file = copy_verasonics_mat_without_img_data_p(tmp_path)
+
+    with VerasonicsFile(stripped_file, "r") as verasonics_file:
+        assert verasonics_file.read_image_data_p() is None
+        _, _, _, custom_elements = verasonics_file.read_verasonics_file()
+
+    element_names = [element.name for element in custom_elements]
+    assert "verasonics_image_buffer" not in element_names
+
+
 def test_check_output_dir_ownership_empty_dir(tmp_path):
     """test check_output_dir_ownership with empty directory (should pass)."""
 

--- a/zea/data/convert/verasonics.py
+++ b/zea/data/convert/verasonics.py
@@ -1181,8 +1181,9 @@ class VerasonicsFile(h5py.File):
             custom_elements.append(additional_function(self))
 
         # Add Verasonics ImgDataP buffer to additional elements
-        try:
-            verasonics_image_buffer = self.read_image_data_p(frames=frames)
+        verasonics_image_buffer = self.read_image_data_p(frames=frames)
+
+        if verasonics_image_buffer is not None:
             verasonics_image_buffer = CustomElement(
                 name="verasonics_image_buffer",
                 data=verasonics_image_buffer,
@@ -1194,8 +1195,6 @@ class VerasonicsFile(h5py.File):
                 unit="unitless",
             )
             custom_elements.append(verasonics_image_buffer)
-        except Exception as e:
-            log.error(f"Could not read Verasonics ImgDataP buffer: {e}, skipping.")
 
         probe_dict = self.probe.to_probe_spec()
         f_c = self.probe.center_frequency


### PR DESCRIPTION
The verasonics convert function would fail if no `ImgDataP` were present in the workspace file. It was trying to catch the exception, but the function `read_image_data_p` would not raise an exception but just return ` None`.

This PR fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verasonics image data is now processed when the image buffer is available.
  * Files without image data are handled correctly, returning no image content without creating an empty image element.
  * Data read errors are surfaced directly instead of being silently logged and skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->