### PR TITLE
Fixed non-unit gain in upmix/downmix roundtrip

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -23,6 +23,7 @@ from zea.func.ultrasound import (
     compute_time_to_peak_stack,
     construct_acquisition_from_synthetic_aperture,
     decode_hadamard,
+    get_low_pass_iq_filter,
     make_tgc_curve,
     square_wave_apodization,
 )
@@ -286,6 +287,60 @@ def test_fir_filter_complex_channels():
     return result
 
 
+def test_get_low_pass_iq_filter():
+    """Filter taps are complex, of the requested length, and reject out-of-band tones."""
+    num_taps, sampling_frequency = 63, 12.5e6
+    taps = get_low_pass_iq_filter(num_taps, sampling_frequency, 0.0, 2e6)
+
+    assert taps.shape == (num_taps,)
+    assert np.iscomplexobj(taps)
+
+    # At center_frequency 0 the modulation is a no-op, so the taps stay real-valued
+    # and sum to unit DC gain.
+    np.testing.assert_allclose(taps.imag, 0, atol=1e-12)
+    np.testing.assert_allclose(np.sum(taps.real), 1.0, atol=1e-6)
+
+    for bandwidth in (0.0, -1e6, 2 * sampling_frequency):
+        with pytest.raises(ValueError, match="Cutoff frequency"):
+            get_low_pass_iq_filter(num_taps, sampling_frequency, 0.0, bandwidth)
+
+
+@backend_equality_check(decimal=4, backends=["tensorflow", "jax"])
+def test_low_pass_filter_iq():
+    """LowPassFilterIQ keeps a baseband IQ tone and rejects one outside the passband."""
+    import keras
+
+    from zea import ops
+
+    n_ax, n_el = 256, 4
+    sampling_frequency, bandwidth = 12.5e6, 2e6
+
+    t = np.arange(n_ax) / sampling_frequency
+    in_band = np.exp(1j * 2 * np.pi * 0.3e6 * t)
+    out_band = np.exp(1j * 2 * np.pi * 5e6 * t)
+    iq = np.stack([in_band + out_band] * n_el, axis=-1)
+    data = np.stack([iq.real, iq.imag], axis=-1).reshape(1, n_ax, n_el, 2).astype("float32")
+
+    output = ops.LowPassFilterIQ(num_taps=63)(
+        data=keras.ops.convert_to_tensor(data),
+        bandwidth=bandwidth,
+        sampling_frequency=sampling_frequency,
+        center_frequency=0.0,
+    )["data"]
+    output = keras.ops.convert_to_numpy(output)
+    assert output.shape == data.shape
+
+    filtered = output[..., 0] + 1j * output[..., 1]
+    # Skip the edges, where the FIR transient dominates.
+    middle = slice(64, 192)
+    kept = np.abs(np.mean(filtered[0, middle, 0] * np.conj(in_band[middle])))
+    rejected = np.abs(np.mean(filtered[0, middle, 0] * np.conj(out_band[middle])))
+    assert kept > 0.9, f"passband tone attenuated to {kept:.3f}."
+    assert rejected < 0.05, f"stopband tone only attenuated to {rejected:.3f}."
+
+    return output
+
+
 @pytest.mark.parametrize(
     "factor, batch_size",
     [
@@ -399,6 +454,53 @@ def test_up_and_down_conversion(factor, batch_size):
         f"downmix-> upmix not cycle-consistent: {error:.2%} of peak "
         f"exceeds {tolerance:.2%} tolerance at {factor}x."
     )
+
+
+@pytest.mark.parametrize("factor", [1, 2, 4])
+@backend_equality_check(decimal=4, backends=["tensorflow", "jax"])
+def test_demodulate_upmix_roundtrip(factor):
+    """
+    Same as test_up_and_down_conversion, but without the simulator in the loop. Force eager
+    execution so codecov doesn't falsely flag it as not covered (codecov doesn't detect tensorflow
+    jit code properly)
+    """
+    import keras
+
+    from zea import ops
+
+    tolerance = {1: 1e-3, 2: 0.08, 4: 0.25}[factor]
+
+    n_ax, n_el = 256, 8
+    sampling_frequency, center_frequency = 12.5e6, 3.125e6
+
+    t = np.arange(n_ax) / sampling_frequency
+    envelope = np.exp(-(((t - t[n_ax // 2]) * center_frequency / 2) ** 2))
+    burst = envelope * np.sin(2 * np.pi * center_frequency * t)
+    # Stagger the elements so the axes are not interchangeable.
+    rf = np.stack([np.roll(burst, 3 * el) for el in range(n_el)], axis=-1)
+    rf = rf.reshape(1, n_ax, n_el, 1).astype("float32")
+
+    pipeline = ops.Pipeline(
+        [
+            ops.Demodulate(),
+            ops.Downsample(factor=factor),
+            ops.UpMix(upsampling_rate=factor),
+        ]
+    )
+    output = pipeline(
+        data=keras.ops.convert_to_tensor(rf),
+        sampling_frequency=sampling_frequency,
+        demodulation_frequency=center_frequency,
+    )["data"]
+    output = keras.ops.convert_to_numpy(output)
+
+    error = np.max(np.abs(output - rf)) / np.max(np.abs(rf))
+    assert error < tolerance, (
+        f"downmix-> upmix not cycle-consistent: {error:.2%} of peak "
+        f"exceeds {tolerance:.2%} tolerance at {factor}x."
+    )
+
+    return output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -295,7 +295,13 @@ def test_fir_filter_complex_channels():
     ],
 )
 def test_up_and_down_conversion(factor, batch_size):
-    """Test rf2iq and iq2rf in sequence"""
+    """Test rf2iq and iq2rf in sequence.
+
+    Tolerance dependent on downsampling factor (no anti-alias filter in downsample, so quite lossy
+    at high factors). Tolerance is defined relative to the RF peak.
+    """
+    tolerance = {1: 1e-3, 2: 0.08, 4: 0.25}[factor]
+
     n_el = 128
     n_scat = 3
     n_tx = 2
@@ -388,11 +394,10 @@ def test_up_and_down_conversion(factor, batch_size):
     data = np.concatenate(data)
     _data = np.concatenate(_data)
 
-    np.testing.assert_almost_equal(
-        data,
-        _data,
-        decimal=2,
-        err_msg="Data is not equal after up and down conversion.",
+    error = np.max(np.abs(data - _data)) / np.max(np.abs(_data))
+    assert error < tolerance, (
+        f"downmix-> upmix not cycle-consistent: {error:.2%} of peak "
+        f"exceeds {tolerance:.2%} tolerance at {factor}x."
     )
 
 

--- a/tests/test_tensor_ops.py
+++ b/tests/test_tensor_ops.py
@@ -1183,3 +1183,25 @@ def test_complex_resize():
     assert magnitude.max() <= np.abs(data).max() + 1e-4
 
     return ops.abs(upsampled)
+
+
+@backend_equality_check(decimal=4)
+def test_resample_complex():
+    """``resample`` interpolates complex input without discarding the imaginary part."""
+    from zea.func.tensor import resample
+
+    rng = default_rng(DEFAULT_TEST_SEED)
+    data = (rng.standard_normal((2, 16, 3)) + 1j * rng.standard_normal((2, 16, 3))).astype(
+        "complex64"
+    )
+    tensor = ops.convert_to_tensor(data)
+
+    same = ops.convert_to_numpy(resample(tensor, 16, axis=1))
+    np.testing.assert_allclose(same, data, rtol=1e-4, atol=1e-4)
+
+    upsampled = resample(tensor, 32, axis=1)
+    assert upsampled.shape == (2, 32, 3)
+    assert "complex" in str(upsampled.dtype)
+    assert np.any(np.imag(ops.convert_to_numpy(upsampled)) != 0)
+
+    return ops.stack([ops.real(upsampled), ops.imag(upsampled)])

--- a/zea/func/tensor.py
+++ b/zea/func/tensor.py
@@ -1504,6 +1504,12 @@ def resample(x, n_samples, axis=-2, order=1):
     Returns:
         Resampled tensor.
     """
+    # map_coordinates is real-only on tensorflow, so interpolate the two parts separately.
+    if "complex" in ops.dtype(x):
+        real = resample(ops.real(x), n_samples, axis=axis, order=order)
+        imag = resample(ops.imag(x), n_samples, axis=axis, order=order)
+        return ops.cast(real, ops.dtype(x)) + 1j * ops.cast(imag, ops.dtype(x))
+
     shape = ops.shape(x)
     rank = len(shape)
 

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -153,7 +153,7 @@ def upmix(iq_data, sampling_frequency, demodulation_frequency, upsampling_rate=6
     Returns:
         rf_data (ndarray): output real valued rf data.
     """
-    assert iq_data.dtype in [
+    assert ops.dtype(iq_data) in [
         "complex64",
         "complex128",
     ], "IQ must contain all complex signals."
@@ -187,7 +187,7 @@ def upmix(iq_data, sampling_frequency, demodulation_frequency, upsampling_rate=6
     carrier = ops.reshape(carrier, (*[1] * (n_dim - 2), n_ax_up, 1))
 
     rf_data = iq_data_upsampled * carrier
-    rf_data = ops.real(rf_data) * ops.sqrt(2)
+    rf_data = ops.real(rf_data)
 
     return ops.cast(rf_data, "float32")
 


### PR DESCRIPTION
Fix for #564. A bug in upmix/downmix was hiding behind an absolute error check on very quiet simulator output. There was a `*sqrt(2)` in upmix but not in downmix, so a roundtrip had non-unit gain. Now both directions preserve the envelope amplitude. 

This also fixes another bug in the same path: `resample` with complex inputs on `tensorflow` silently dropped the imaginary part. Fixed by splitting the components. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resampling complex-valued tensors while preserving their dtype and signal components.
  * Improved IQ and RF processing across demodulation, downsampling, and upmixing workflows.
  * Added robust handling for low-pass IQ filtering, including complex taps and signal preservation.

* **Bug Fixes**
  * Corrected RF output scaling during upmixing.
  * Improved round-trip accuracy across supported processing factors.

* **Tests**
  * Expanded coverage for filtering, resampling, signal integrity, and passband/stopband behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->