### PR TITLE
Added option to set scattering exponent 

### DIFF
--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -591,3 +591,28 @@ def test_time_domain_lens_correction_delays_arrivals():
     assert delay == pytest.approx(expected, abs=2), (
         f"Lens correction shifted the echo by {delay} samples, expected ~{expected:.1f}"
     )
+
+
+@pytest.mark.parametrize("simulator", [simulate_rf, simulate_rf_td], ids=["exact", "fast"])
+@pytest.mark.parametrize("scatter_exponent", [-1.0, np.nan, np.inf])
+def test_invalid_scatter_exponent_raises(simulator, scatter_exponent):
+    """A bad exponent must fail loudly, not silently return an all-NaN RF frame."""
+    args = _td_args()
+    args["scatterer_positions"] = np.array([[0.0, 0.0, 30e-3]], dtype=np.float32)
+    args["scatterer_magnitudes"] = np.ones(1, dtype=np.float32)
+
+    with pytest.raises(ValueError, match="scatter_exponent"):
+        simulator(**args, scatter_exponent=scatter_exponent)
+
+
+@pytest.mark.parametrize("simulator", [simulate_rf, simulate_rf_td], ids=["exact", "fast"])
+@pytest.mark.parametrize("scatter_exponent", [0.0, 0.6, 2.0])
+def test_valid_scatter_exponent_gives_finite_rf(simulator, scatter_exponent):
+    """Physical exponents, including the unweighted 0, stay accepted and finite."""
+    args = _td_args()
+    args["scatterer_positions"] = np.array([[0.0, 0.0, 30e-3]], dtype=np.float32)
+    args["scatterer_magnitudes"] = np.ones(1, dtype=np.float32)
+
+    rf = keras.ops.convert_to_numpy(simulator(**args, scatter_exponent=scatter_exponent))
+    assert np.isfinite(rf).all()
+    assert np.abs(rf).max() > 0

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -527,3 +527,67 @@ def test_batched_noise_reference_is_per_item(fish_scan):
     assert 90.0 < ratio < 110.0, (
         f"Noise did not track the per-item peak: 100x brighter item got {ratio:.1f}x the noise"
     )
+
+
+def _td_args(n_el=16, **overrides):
+    """Minimal single-transmit argument set for the time-domain simulator."""
+    probe_geometry = np.stack(
+        [np.linspace(-8e-3, 8e-3, n_el), np.zeros(n_el), np.zeros(n_el)], axis=1
+    ).astype(np.float32)
+    args = {
+        "probe_geometry": probe_geometry,
+        "apply_lens_correction": False,
+        "lens_thickness": 1e-3,
+        "lens_sound_speed": 1000.0,
+        "sound_speed": SOUND_SPEED,
+        "n_ax": 1024,
+        "center_frequency": CENTER_FREQUENCY,
+        "sampling_frequency": CENTER_FREQUENCY * 4,
+        "t0_delays": np.zeros((1, n_el), dtype=np.float32),
+        "initial_times": np.zeros(1, dtype=np.float32),
+        "element_width": 1e-3,
+        "attenuation_coef": 0.0,
+        "tx_apodizations": np.ones((1, n_el), dtype=np.float32),
+        "t_peak": np.full(1, 1 / CENTER_FREQUENCY, dtype=np.float32),
+    }
+    return {**args, **overrides}
+
+
+def test_time_domain_elevation_lens_prunes_out_of_plane_scatterers():
+    """The time-domain simulator drops scatterers outside the elevation slab."""
+    element_height = 5e-3
+    args = _td_args(elevation_lens=True, element_height=element_height)
+    args["scatterer_magnitudes"] = np.ones(1, dtype=np.float32)
+
+    inside = np.array([[0.0, 0.5 * element_height, 30e-3]], dtype=np.float32)
+    outside = np.array([[0.0, 1.5 * element_height, 30e-3]], dtype=np.float32)
+
+    rf_inside = keras.ops.convert_to_numpy(simulate_rf_td(scatterer_positions=inside, **args))
+    rf_outside = keras.ops.convert_to_numpy(simulate_rf_td(scatterer_positions=outside, **args))
+    assert np.abs(rf_inside).max() > 0
+    assert np.abs(rf_outside).max() == 0
+
+
+def test_time_domain_lens_correction_delays_arrivals():
+    """A slow lens lengthens the round trip."""
+    args = _td_args()
+    args["scatterer_positions"] = np.array([[0.0, 0.0, 30e-3]], dtype=np.float32)
+    args["scatterer_magnitudes"] = np.ones(1, dtype=np.float32)
+
+    uncorrected = keras.ops.convert_to_numpy(simulate_rf_td(**args))[0, :, :, 0]
+    corrected = keras.ops.convert_to_numpy(
+        simulate_rf_td(**{**args, "apply_lens_correction": True})
+    )[0, :, :, 0]
+
+    center = args["probe_geometry"].shape[0] // 2
+    delay = np.abs(corrected[:, center]).argmax() - np.abs(uncorrected[:, center]).argmax()
+    # Two lens crossings at 1000 m/s instead of 1540 m/s: ~0.7 us, ~8 samples at 4x fc.
+    expected = (
+        2
+        * args["lens_thickness"]
+        * (1 / args["lens_sound_speed"] - 1 / args["sound_speed"])
+        * args["sampling_frequency"]
+    )
+    assert delay == pytest.approx(expected, abs=2), (
+        f"Lens correction shifted the echo by {delay} samples, expected ~{expected:.1f}"
+    )

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -18,7 +18,7 @@ from zea.simulator import (
     simulate_rf,
 )
 from zea.ops import Simulate
-from zea.simulator_time_domain import simulate_rf_td
+from zea.simulator_time_domain import get_pulse_waveform, simulate_rf_td
 
 N_EL = 80
 APERTURE = 32e-3
@@ -28,6 +28,29 @@ SOUND_SPEED = 1540.0  # m/s
 XLIMS = (-24e-3, 24e-3)
 ZLIMS = (10e-3, 35e-3)
 DYNAMIC_RANGE = (-50.0, 0.0)
+
+
+def test_time_domain_scatter_exponent_weights_pulse_spectrum():
+    """The time-domain approximation applies scatter frequency dependence to its pulse."""
+    n_samples = 129
+    unweighted = np.asarray(
+        keras.ops.convert_to_numpy(
+            get_pulse_waveform(CENTER_FREQUENCY, CENTER_FREQUENCY * 4, n_samples=n_samples)
+        )
+    )
+    weighted = np.asarray(
+        keras.ops.convert_to_numpy(
+            get_pulse_waveform(
+                CENTER_FREQUENCY,
+                CENTER_FREQUENCY * 4,
+                n_samples=n_samples,
+                scatter_exponent=2.0,
+            )
+        )
+    )
+    frequencies = np.fft.rfftfreq(n_samples, 1 / (CENTER_FREQUENCY * 4))
+    expected = np.fft.rfft(unweighted) * (frequencies / CENTER_FREQUENCY) ** 2
+    np.testing.assert_allclose(np.fft.rfft(weighted), expected, rtol=2e-5, atol=2e-5)
 
 
 def _parameters(probe_geometry):

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -104,12 +104,12 @@ class Simulate(Operation):
         method="exact",
         elevation_lens=False,
         element_height=None,
-        scatter_exponent=2.0,
         max_chunk_gb=10.0,
         noise_level_db=None,
         tgc_max_db=0.0,
         noise_seed=0,
         noise_reference=None,
+        scatter_exponent=2.0,
         **kwargs,
     ):
         if method not in simulator_settings:

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -49,8 +49,9 @@ class Simulate(Operation):
     ``method`` switches between different approximation models. ``"exact"`` is the highest fidelity
     version. ``"frequency_approximation"`` is an alias for ``exact``; future versions that sacrifice
     speed for accuracy or accuracy for speed will use these two paths respectively.
-    ``"time_approximation"`` solves in the time domain, evaluating only at the center frequency;
-    less accurate than the others, but much faster in some settings.
+    ``"time_approximation"`` solves in the time domain. Its geometry-dependent factors are
+    evaluated at the center frequency, making it less accurate than the others but much faster in
+    some settings.
     """
 
     # Define operation-specific static parameters
@@ -62,6 +63,7 @@ class Simulate(Operation):
         "max_chunk_gb",
         "center_frequency",
         "sampling_frequency",
+        "scatter_exponent",
         "noise_level_db",
         "tgc_max_db",
         "noise_seed",
@@ -102,6 +104,7 @@ class Simulate(Operation):
         method="exact",
         elevation_lens=False,
         element_height=None,
+        scatter_exponent=2.0,
         max_chunk_gb=10.0,
         noise_level_db=None,
         tgc_max_db=0.0,
@@ -129,6 +132,7 @@ class Simulate(Operation):
             "t_peak": t_peak,
             "elevation_lens": elevation_lens,
             "element_height": element_height,
+            "scatter_exponent": scatter_exponent,
             "max_chunk_gb": max_chunk_gb,
             "noise_level_db": noise_level_db,
             "tgc_max_db": tgc_max_db,

--- a/zea/simulator.py
+++ b/zea/simulator.py
@@ -125,6 +125,8 @@ def simulate_rf(
 
     """
 
+    _validate_scatter_exponent(scatter_exponent)
+
     n_tx = t0_delays.shape[0]
 
     element_width = _resolve_element_width(probe_geometry, element_width)
@@ -282,6 +284,17 @@ def apply_receive_chain(
         rf_data = rf_data * ops.reshape(10.0 ** (tgc_max_db * ramp / 20.0), (n_ax, 1, 1))
 
     return rf_data
+
+
+def _validate_scatter_exponent(scatter_exponent):
+    """Reject exponents that make the weighting non-finite: the DC bin is zero, so a
+    negative exponent gives infinite gain there, and the NaN spreads over the whole frame."""
+    if not np.isfinite(scatter_exponent) or scatter_exponent < 0:
+        raise ValueError(
+            f"scatter_exponent ({scatter_exponent}) must be finite and non-negative. "
+            "2 is Rayleigh scattering (e.g. blood), myocardium is approximately 1.5, "
+            "soft tissue 0.6-0.8."
+        )
 
 
 def _resolve_element_width(probe_geometry, element_width):

--- a/zea/simulator.py
+++ b/zea/simulator.py
@@ -106,8 +106,8 @@ def simulate_rf(
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
         scatter_exponent (float): Weigh the scattered field by
-            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering, approximately
-            1.5 is typical for soft tissue. Must be static under jit.
+            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering (e.g. blood),
+            myocardium is approximately 1.5, soft tissue 0.6-0.8. Must be static under jit.
         max_chunk_gb (float): Unused here; accepted so :func:`simulate_rf` and
             :func:`zea.simulator_time_domain.simulate_rf_td` share a call signature.
         noise_level_db (float): Electronic noise level in dB relative to the noiseless RF

--- a/zea/simulator.py
+++ b/zea/simulator.py
@@ -105,7 +105,7 @@ def simulate_rf(
             use :class:`zea.ops.Simulate` rather than calling `simulate_rf` directly.
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
-        scatter_exponent (float): Weight the scattered field by
+        scatter_exponent (float): Weigh the scattered field by
             ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering, approximately
             1.5 is typical for soft tissue. Must be static under jit.
         max_chunk_gb (float): Unused here; accepted so :func:`simulate_rf` and

--- a/zea/simulator.py
+++ b/zea/simulator.py
@@ -72,12 +72,12 @@ def simulate_rf(
     t_peak,
     elevation_lens=False,
     element_height=None,
-    scatter_exponent=2.0,
     max_chunk_gb=10.0,
     noise_level_db=None,
     tgc_max_db=0.0,
     noise_seed=0,
     noise_reference=None,
+    scatter_exponent=2.0,
 ):
     """
     Simulates RF data for a given set of scatterers.
@@ -105,9 +105,6 @@ def simulate_rf(
             use :class:`zea.ops.Simulate` rather than calling `simulate_rf` directly.
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
-        scatter_exponent (float): Weigh the scattered field by
-            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering (e.g. blood),
-            myocardium is approximately 1.5, soft tissue 0.6-0.8. Must be static under jit.
         max_chunk_gb (float): Unused here; accepted so :func:`simulate_rf` and
             :func:`zea.simulator_time_domain.simulate_rf_td` share a call signature.
         noise_level_db (float): Electronic noise level in dB relative to the noiseless RF
@@ -119,6 +116,9 @@ def simulate_rf(
         noise_reference (float): Reference amplitude for the noise level. If None, defaults to the
             noiseless RF maximum. Pass a fixed reference to avoid the noise level changing per
             transmit batch. See :func:`apply_receive_chain`.
+        scatter_exponent (float): Weigh the scattered field by
+            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering (e.g. blood),
+            myocardium is approximately 1.5, soft tissue 0.6-0.8. Must be static under jit.
 
     Returns:
         rf_data (array-like): The simulated RF data of shape (n_tx, n_ax, n_el, 1).

--- a/zea/simulator.py
+++ b/zea/simulator.py
@@ -72,6 +72,7 @@ def simulate_rf(
     t_peak,
     elevation_lens=False,
     element_height=None,
+    scatter_exponent=2.0,
     max_chunk_gb=10.0,
     noise_level_db=None,
     tgc_max_db=0.0,
@@ -104,6 +105,9 @@ def simulate_rf(
             use :class:`zea.ops.Simulate` rather than calling `simulate_rf` directly.
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
+        scatter_exponent (float): Weight the scattered field by
+            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering, approximately
+            1.5 is typical for soft tissue. Must be static under jit.
         max_chunk_gb (float): Unused here; accepted so :func:`simulate_rf` and
             :func:`zea.simulator_time_domain.simulate_rf_td` share a call signature.
         noise_level_db (float): Electronic noise level in dB relative to the noiseless RF
@@ -175,6 +179,11 @@ def simulate_rf(
 
     waveform_spectrum = pulse_spectrum_fn(freqs)
 
+    if scatter_exponent:
+        scatter_gain = (freqs / center_frequency) ** scatter_exponent
+    else:
+        scatter_gain = ops.ones_like(freqs)
+
     scat_pos_relative_to_probe = scatterer_positions[:, None] - probe_geometry[None]
     theta = ops.arctan2(scat_pos_relative_to_probe[..., 0], scat_pos_relative_to_probe[..., 2])
     phi = ops.arctan2(scat_pos_relative_to_probe[..., 1], scat_pos_relative_to_probe[..., 2])
@@ -223,7 +232,7 @@ def simulate_rf(
 
         # Explicitly sum over tx dimension before the receive axis exists.
         incident_field = ops.sum(tx_response * tx_element_weights[None], axis=1)
-        scattered_field = incident_field * ops.cast(magnitudes[:, None], "complex64")
+        scattered_field = incident_field * ops.cast(magnitudes[:, None] * scatter_gain, "complex64")
         received_field = scattered_field[:, None] * rx_response * within_record[..., None]
         rf_spectrum = waveform_spectrum * ops.sum(received_field, axis=0)
         parts.append(ops.irfft((ops.real(rf_spectrum), ops.imag(rf_spectrum))))

--- a/zea/simulator_time_domain.py
+++ b/zea/simulator_time_domain.py
@@ -114,8 +114,8 @@ def simulate_rf_td(
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
         scatter_exponent (float): Weigh the scattered waveform spectrum by
-            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering, approximately
-            1.5 is typical for soft tissue. Must be static under jit.
+            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering (e.g. blood),
+            myocardium is approximately 1.5, soft tissue 0.6-0.8. Must be static under jit.
         max_chunk_gb (float): Approximate memory budget [GB] for the (chunk, n_el, n_el)
             tensors held at once while iterating over scatterers. Scatterers are processed
             in chunks sized to this budget, so peak memory no longer scales with the total

--- a/zea/simulator_time_domain.py
+++ b/zea/simulator_time_domain.py
@@ -71,6 +71,7 @@ def simulate_rf_td(
     t_peak,
     elevation_lens=False,
     element_height=None,
+    scatter_exponent=2.0,
     max_chunk_gb=10.0,
     noise_level_db=None,
     tgc_max_db=0.0,
@@ -112,6 +113,9 @@ def simulate_rf_td(
             use :class:`zea.ops.Simulate` rather than calling `simulate_rf_td` directly.
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
+        scatter_exponent (float): Weigh the scattered waveform spectrum by
+            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering, approximately
+            1.5 is typical for soft tissue. Must be static under jit.
         max_chunk_gb (float): Approximate memory budget [GB] for the (chunk, n_el, n_el)
             tensors held at once while iterating over scatterers. Scatterers are processed
             in chunks sized to this budget, so peak memory no longer scales with the total
@@ -137,7 +141,9 @@ def simulate_rf_td(
     n_el = probe_geometry.shape[0]
     n_scat = scatterer_positions.shape[0]
 
-    pulse = get_pulse_waveform(center_frequency, sampling_frequency)
+    pulse = get_pulse_waveform(
+        center_frequency, sampling_frequency, scatter_exponent=scatter_exponent
+    )
 
     # Chunk so the (n_scat, n_el, n_el) tensors never materialize at once. The factor is
     # approximate memory use after jit fusion, not a count of intermediate tensors.
@@ -360,7 +366,9 @@ def _multiply_spectra(signals, kernel, n_full):
     return ops.irfft((product_real, product_imag), fft_length=n_full)
 
 
-def get_pulse_waveform(center_frequency, sampling_frequency, n_period=4, n_samples=129):
+def get_pulse_waveform(
+    center_frequency, sampling_frequency, n_period=4, n_samples=129, scatter_exponent=0.0
+):
     """Generate a real, Hann-windowed sinusoidal transmit pulse in the time domain.
 
     This is the time-domain counterpart of :func:`zea.simulator.get_pulse_spectrum_fn`: an even,
@@ -376,6 +384,8 @@ def get_pulse_waveform(center_frequency, sampling_frequency, n_period=4, n_sampl
         sampling_frequency (float): The sampling frequency [Hz].
         n_period (float): The number of periods spanned by the Hann window.
         n_samples (int): The (odd) number of samples in the pulse.
+        scatter_exponent (float): Exponent applied to the pulse spectrum relative to
+            ``center_frequency``.
 
     Returns:
         array-like: The pulse waveform of shape (n_samples,).
@@ -390,4 +400,12 @@ def get_pulse_waveform(center_frequency, sampling_frequency, n_period=4, n_sampl
         )
     times = (ops.arange(n_samples, dtype="float32") - n_samples // 2) / sampling_frequency
     window = hann_unnormalized(times, width)
-    return window * ops.cos(2 * np.pi * center_frequency * times)
+    pulse = window * ops.cos(2 * np.pi * center_frequency * times)
+    if not scatter_exponent:
+        return pulse
+
+    n_freq = n_samples // 2 + 1
+    freqs = ops.arange(n_freq, dtype="float32") / n_samples * sampling_frequency
+    scatter_gain = (freqs / center_frequency) ** scatter_exponent
+    pulse_real, pulse_imag = ops.rfft(pulse)
+    return ops.irfft((pulse_real * scatter_gain, pulse_imag * scatter_gain), fft_length=n_samples)

--- a/zea/simulator_time_domain.py
+++ b/zea/simulator_time_domain.py
@@ -44,6 +44,7 @@ from zea.func.ultrasound import directivity
 from zea.simulator import (
     _apply_elevation_slab,
     _resolve_element_width,
+    _validate_scatter_exponent,
     _warn_if_elevation_extent,
     attenuate,
     hann_unnormalized,
@@ -390,6 +391,7 @@ def get_pulse_waveform(
     Returns:
         array-like: The pulse waveform of shape (n_samples,).
     """
+    _validate_scatter_exponent(scatter_exponent)
     width = n_period / center_frequency
     support_samples = width * sampling_frequency
     if support_samples > n_samples:

--- a/zea/simulator_time_domain.py
+++ b/zea/simulator_time_domain.py
@@ -71,12 +71,12 @@ def simulate_rf_td(
     t_peak,
     elevation_lens=False,
     element_height=None,
-    scatter_exponent=2.0,
     max_chunk_gb=10.0,
     noise_level_db=None,
     tgc_max_db=0.0,
     noise_seed=0,
     noise_reference=None,
+    scatter_exponent=2.0,
 ):
     """Time-domain (splat-and-convolve) RF simulator.
 
@@ -113,9 +113,6 @@ def simulate_rf_td(
             use :class:`zea.ops.Simulate` rather than calling `simulate_rf_td` directly.
         element_height (float): The elevation height of the elements [m], used for the
             elevation directivity and the elevation slab. If None, defaults to element_width.
-        scatter_exponent (float): Weigh the scattered waveform spectrum by
-            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering (e.g. blood),
-            myocardium is approximately 1.5, soft tissue 0.6-0.8. Must be static under jit.
         max_chunk_gb (float): Approximate memory budget [GB] for the (chunk, n_el, n_el)
             tensors held at once while iterating over scatterers. Scatterers are processed
             in chunks sized to this budget, so peak memory no longer scales with the total
@@ -129,6 +126,9 @@ def simulate_rf_td(
         noise_reference (float): Reference amplitude for the noise level. If None, defaults to the
             noiseless RF maximum. Pass a fixed reference to avoid the noise level changing per
             transmit batch. See :func:`zea.simulator.apply_receive_chain`.
+        scatter_exponent (float): Weigh the scattered waveform spectrum by
+            ``(f / center_frequency)**scatter_exponent``. 2 is Rayleigh scattering (e.g. blood),
+            myocardium is approximately 1.5, soft tissue 0.6-0.8. Must be static under jit.
 
     Returns:
         rf_data (array-like): The simulated RF data of shape (n_tx, n_ax, n_el, 1).


### PR DESCRIPTION
Previously, the `zea` simulator used flat scattering, which gives far more low-frequency response than real scenes would. That isn't a problem in sparse fields, but when simulating a dense scatterer cloud, this gives a lot of spurious structured clutter, especially in 3d scenes:

<img width="1545" height="1009" alt="image" src="https://github.com/user-attachments/assets/614dec06-e3d0-43d4-9ed9-ac3889ca3460" />


The scattering exponent is now an input (global, no per-tissue region exponents supported). By default set to Rayleigh (power⁴=amplitude²), which is pretty close to true for cardiac scenes (blood=Rayleigh, Myocardium is power³ or so).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable frequency-dependent scatter weighting to RF and time-domain ultrasound simulations.
  * Added `scatter_exponent` settings, defaulting to Rayleigh scattering behavior.
  * Added configurable receive noise and time-gain compensation processing.
  * Improved simulation recording to account for pulse-tail timing and active transmit-element arrival times.
  * Time-domain pulse generation now applies the selected scattering response.

* **Tests**
  * Added coverage verifying that pulse spectra are correctly scaled according to the configured scatter exponent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->