### PR TITLE
Add `--track` to process CLI

### DIFF
--- a/tests/data/test_process.py
+++ b/tests/data/test_process.py
@@ -8,7 +8,6 @@ import pytest
 
 from tests.data import generate_example_dataset
 
-
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
@@ -61,6 +60,7 @@ def test_cli_defaults():
 
     args = tyro.cli(ProcessArgs, args=["--dataset", "data/", "--config", "cfg.yaml"])
     assert args.key == "data/raw_data"
+    assert args.track is None
     assert args.n_frames is None
     assert args.save_as == "gif"
     assert args.overwrite is False
@@ -269,3 +269,121 @@ def test_main_dispatches_to_run_processing(tmp_path, monkeypatch):
     assert called["key"] == "data/image/values"
     assert called["dataset"] == str(ds_dir)
     assert called["config"] == str(cfg)
+
+
+# ── track selection ───────────────────────────────────────────────────────────
+
+
+def _make_multitrack_file(path: Path, labels=("bmode", "doppler"), n_frames: int = 2) -> Path:
+    """Create a multi-track file whose tracks differ in both image data and scan."""
+    from tests.data import generate_dummy_scan
+    from zea.data.file import File
+    from zea.data.spec import ProbeSpec
+
+    n_el, n_tx, n_ax, n_ch = 4, 2, 8, 1
+    probe_geometry = np.zeros((n_el, 3), dtype=ProbeSpec.get_dtype("probe_geometry"))
+    probe_geometry[:, 0] = np.linspace(-0.02, 0.02, n_el)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    File.create(
+        path,
+        tracks=[
+            {
+                "data": {
+                    "raw_data": np.full((n_frames, n_tx, n_ax, n_el, n_ch), i, dtype=np.float32),
+                    "image": {"values": np.full((n_frames, 8, 8), i, dtype=np.uint8)},
+                },
+                "scan": generate_dummy_scan(n_tx=n_tx, n_el=n_el, sampling_frequency=(i + 1) * 1e7),
+                "label": label,
+            }
+            for i, label in enumerate(labels)
+        ],
+        probe={"name": "generic", "probe_geometry": probe_geometry},
+        overwrite=True,
+        ignore_warnings=True,
+    )
+    return path
+
+
+@pytest.mark.parametrize("track", ["doppler", "1"])
+def test_resolve_track_by_label_or_index(tmp_path, track):
+    """A track selects by label or by index, and rewrites the key to address it."""
+    from zea.data.file import File
+    from zea.data.process import _resolve_track
+
+    path = _make_multitrack_file(tmp_path / "duplex.hdf5")
+    with File(path) as f:
+        index, data_key = _resolve_track(f, "data/image/values", track)
+
+    assert index == 1
+    assert data_key == "tracks/track_1/data/image/values"
+
+
+def test_resolve_track_multitrack_requires_selection(tmp_path):
+    """A multi-track file with no track selected raises, listing the tracks it has."""
+    from zea.data.file import File
+    from zea.data.process import _resolve_track
+
+    path = _make_multitrack_file(tmp_path / "duplex.hdf5")
+    with File(path) as f:
+        with pytest.raises(ValueError, match="2 tracks") as exc:
+            _resolve_track(f, "data/image/values", None)
+
+    assert "'bmode'" in str(exc.value) and "'doppler'" in str(exc.value)
+
+
+def test_resolve_track_unknown_label_raises(tmp_path):
+    """An unknown track label reports the labels the file actually has."""
+    from zea.data.file import File
+    from zea.data.process import _resolve_track
+
+    path = _make_multitrack_file(tmp_path / "duplex.hdf5")
+    with File(path) as f:
+        with pytest.raises(ValueError, match="No track 'flow'"):
+            _resolve_track(f, "data/image/values", "flow")
+
+
+def test_resolve_track_single_track_is_noop(tmp_path):
+    """Single-track files keep the key untouched and need no track addressing."""
+    from zea.data.file import File
+    from zea.data.process import _resolve_track
+
+    path = _make_image_file(tmp_path / "single.hdf5")
+    with File(path) as f:
+        assert _resolve_track(f, "data/image/values", None) == (None, "data/image/values")
+
+
+def test_load_track_parameters_uses_selected_track(tmp_path):
+    """Parameters come from the selected track's scan, not from the file as a whole."""
+    from zea.data.file import File
+    from zea.data.process import _load_track_parameters
+
+    path = _make_multitrack_file(tmp_path / "duplex.hdf5")
+    with File(path) as f:
+        assert _load_track_parameters(f, 0).sampling_frequency == pytest.approx(1e7)
+        assert _load_track_parameters(f, 1).sampling_frequency == pytest.approx(2e7)
+
+
+def test_run_processing_track_selects_data(tmp_path):
+    """run_processing reads the requested track end to end."""
+    from zea.data.file import File
+    from zea.data.process import run_processing
+
+    ds_dir = tmp_path / "ds"
+    _make_multitrack_file(ds_dir / "duplex.hdf5")
+    cfg = _minimal_config(tmp_path / "cfg.yaml", with_pipeline=False)
+    out_dir = tmp_path / "out"
+
+    run_processing(
+        str(ds_dir),
+        str(cfg),
+        key="data/image/values",
+        n_frames=None,
+        save_dir=out_dir,
+        save_as="hdf5",
+        track="doppler",
+    )
+
+    with File(out_dir / "duplex.hdf5") as f:
+        values = f[f.format_key("data/image/values")][:]
+    assert np.all(values == 1), "expected track 1 ('doppler'), which is filled with 1s"

--- a/tests/data/test_process.py
+++ b/tests/data/test_process.py
@@ -364,6 +364,48 @@ def test_load_track_parameters_uses_selected_track(tmp_path):
         assert _load_track_parameters(f, 1).sampling_frequency == pytest.approx(2e7)
 
 
+def test_check_track_consistency_accepts_matching_label(tmp_path):
+    """The track the key addresses by index carries the expected label."""
+    from zea.data.file import File
+    from zea.data.process import _check_track_consistency
+
+    path = _make_multitrack_file(tmp_path / "duplex.hdf5")
+    with File(path) as f:
+        _check_track_consistency(f, 1, "doppler")  # does not raise
+
+
+def test_check_track_consistency_rejects_reordered_label(tmp_path):
+    """A file with the same tracks in a different order is refused."""
+    from zea.data.file import File
+    from zea.data.process import _check_track_consistency
+
+    path = _make_multitrack_file(tmp_path / "reversed.hdf5", labels=("doppler", "bmode"))
+    with File(path) as f:
+        with pytest.raises(ValueError, match="ordered consistently"):
+            _check_track_consistency(f, 1, "doppler")
+
+
+def test_check_track_consistency_rejects_missing_index(tmp_path):
+    """An index past the end of a file's tracks is reported, not an IndexError."""
+    from zea.data.file import File
+    from zea.data.process import _check_track_consistency
+
+    path = _make_multitrack_file(tmp_path / "duplex.hdf5")
+    with File(path) as f:
+        with pytest.raises(ValueError, match="ordered consistently"):
+            _check_track_consistency(f, 5, "doppler")
+
+
+def test_check_track_consistency_single_track_is_noop(tmp_path):
+    """Without a resolved track there is no index to keep consistent."""
+    from zea.data.file import File
+    from zea.data.process import _check_track_consistency
+
+    path = _make_image_file(tmp_path / "single.hdf5")
+    with File(path) as f:
+        _check_track_consistency(f, None, None)  # does not raise
+
+
 def test_run_processing_track_selects_data(tmp_path):
     """run_processing reads the requested track end to end."""
     from zea.data.file import File
@@ -387,3 +429,55 @@ def test_run_processing_track_selects_data(tmp_path):
     with File(out_dir / "duplex.hdf5") as f:
         values = f[f.format_key("data/image/values")][:]
     assert np.all(values == 1), "expected track 1 ('doppler'), which is filled with 1s"
+
+
+@pytest.mark.parametrize("track", ["doppler", "1"])
+def test_run_processing_rejects_reordered_tracks(tmp_path, track):
+    """A file whose tracks are ordered differently is refused, not silently misread.
+
+    ``--track 1`` resolves to index 1 in every file, so only the label at that index
+    reveals the reordering; both ways of naming the track must be caught.
+    """
+    from zea.data.process import run_processing
+
+    ds_dir = tmp_path / "ds"
+    _make_multitrack_file(ds_dir / "a_first.hdf5", labels=("bmode", "doppler"))
+    _make_multitrack_file(ds_dir / "b_second.hdf5", labels=("doppler", "bmode"))
+    cfg = _minimal_config(tmp_path / "cfg.yaml", with_pipeline=False)
+
+    with pytest.raises(ValueError, match="ordered consistently"):
+        run_processing(
+            str(ds_dir),
+            str(cfg),
+            key="data/image/values",
+            n_frames=None,
+            save_dir=tmp_path / "out",
+            save_as="hdf5",
+            track=track,
+        )
+
+
+def test_run_processing_accepts_consistently_ordered_tracks(tmp_path):
+    """The consistency check passes for a dataset whose files agree on track order."""
+    from zea.data.file import File
+    from zea.data.process import run_processing
+
+    ds_dir = tmp_path / "ds"
+    _make_multitrack_file(ds_dir / "a_first.hdf5")
+    _make_multitrack_file(ds_dir / "b_second.hdf5")
+    cfg = _minimal_config(tmp_path / "cfg.yaml", with_pipeline=False)
+    out_dir = tmp_path / "out"
+
+    run_processing(
+        str(ds_dir),
+        str(cfg),
+        key="data/image/values",
+        n_frames=None,
+        save_dir=out_dir,
+        save_as="hdf5",
+        track="doppler",
+    )
+
+    for name in ("a_first.hdf5", "b_second.hdf5"):
+        with File(out_dir / name) as f:
+            assert np.all(f[f.format_key("data/image/values")][:] == 1)

--- a/zea/cli_args.py
+++ b/zea/cli_args.py
@@ -126,6 +126,13 @@ class ProcessArgs:
             help="Data key to load from each file (e.g. data/raw_data, data/image/values).",
         ),
     ] = "data/raw_data"
+    track: Annotated[
+        str | None,
+        tyro.conf.arg(
+            help="Which track to process in a multi-track file: a label (e.g. 'doppler') or "
+            "an index (e.g. '1'). Required for multi-track files, ignored for single-track ones.",
+        ),
+    ] = None
     n_frames: Annotated[
         int | None,
         tyro.conf.arg(
@@ -202,6 +209,7 @@ class ProcessArgs:
             keep_dynamic_range=self.keep_dynamic_range,
             revision=self.revision,
             config_revision=self.config_revision,
+            track=self.track,
         )
 
 

--- a/zea/data/process.py
+++ b/zea/data/process.py
@@ -69,28 +69,27 @@ def _key_requires_pipeline(key: str) -> bool:
 def _resolve_track(file: File, key: str, track: str | None) -> tuple[int | None, str]:
     """Pick the track to process and return ``(track_index, data_key)``.
 
-    ``track`` is matched against the file's labels first and read as an index
-    only when no label matches, so a numeric label still wins. Files with a
-    single track have nothing to address and return ``(None, key)`` unchanged.
+    Resolution is delegated to :meth:`File.get_track`, which matches ``track`` against
+    the file's labels first and reads it as an index only when no label matches, so a
+    numeric label still wins. Files with a single track have nothing to address and
+    return ``(None, key)`` unchanged.
 
     Raises:
         ValueError: If the file has several tracks and none was selected, or the
             requested track does not exist in this file.
     """
-    labels = file.track_labels
     if file._n_tracks <= 1:
         return None, key
+    labels = file.track_labels
     if track is None:
         raise ValueError(
             f"{file.path} has {len(labels)} tracks {labels} but no track was selected. "
             "Pass --track <label|index> to pick one."
         )
     try:
-        index = labels.index(track) if track in labels else int(track)
-    except ValueError:
-        index = -1  # neither a label nor a number: report it like a bad index
-    if not 0 <= index < len(labels):
-        raise ValueError(f"No track {track!r} in {file.path}. Available tracks: {labels}.")
+        index = file.get_track(track).index
+    except KeyError as exc:
+        raise ValueError(f"No track {track!r} in {file.path}. Available tracks: {labels}.") from exc
     return index, f"tracks/track_{index}/data/{strip_track_prefix(key).removeprefix('data/')}"
 
 
@@ -101,6 +100,25 @@ def _load_track_parameters(file: File, track_index: int | None):
     return file.tracks[track_index].load_parameters()
 
 
+def _check_track_consistency(file: File, track_index: int | None, track_label: str | None) -> None:
+    """Raise unless ``file`` carries the same track at ``track_index`` as the first file.
+
+    The data key resolved from the first file addresses its track by index, so a file
+    whose tracks are ordered differently is silently read at the wrong one. The label is
+    what reveals it: ``--track 1`` resolves to index 1 in every file however they are
+    ordered, so the index alone can never catch a reordering.
+    """
+    if track_index is None:
+        return
+    labels = file.track_labels
+    label = labels[track_index] if track_index < len(labels) else None
+    if label != track_label:
+        raise ValueError(
+            f"Track at index {track_index} is {label!r} in {file.path} but {track_label!r} "
+            "in the first file; tracks must be ordered consistently across the dataset."
+        )
+
+
 def _run_passthrough(
     dataset_path: str,
     key: str,
@@ -108,6 +126,8 @@ def _run_passthrough(
     save_dir: Path,
     save_as: str,
     overwrite: bool,
+    track_index: int | None = None,
+    track_label: str | None = None,
     **hf_kwargs,
 ) -> None:
     """Save data frames directly without a beamforming pipeline."""
@@ -119,6 +139,9 @@ def _run_passthrough(
         pbar = ProgressBar(len(ds))
         for i in range(len(ds)):
             f = ds[i]  # lazy download for hf:// paths; returns cached File handle
+            # ``key`` addresses the track by index, so every file must agree on which
+            # track sits there — the pipeline path checks the same thing.
+            _check_track_consistency(f, track_index, track_label)
             data_key = f.format_key(key)
             _dset = f.dataset(data_key)
             # A map-style key such as "image" resolves to a group, not a dataset: read its
@@ -193,6 +216,7 @@ def run_processing(
     # streams hf:// paths, fetching only the chunks the peek touches; validate=False
     # because the Dataloader validates these same files anyway.
     track_index: int | None = None
+    track_label: str | None = None
     data_key = key
     axis_selections: dict | None = None
     with Dataset(
@@ -201,6 +225,10 @@ def run_processing(
         if len(_peek_ds) > 0:
             _peek_f = _peek_ds[0]
             track_index, data_key = _resolve_track(_peek_f, key, track)
+            if track_index is not None:
+                # Baseline for the per-file check below: every other file must carry the
+                # same track at this index, since ``data_key`` addresses it by index.
+                track_label = _peek_f.track_labels[track_index]
             if _key_requires_pipeline(data_key):
                 try:
                     _peek_params = _load_track_parameters(_peek_f, track_index)
@@ -220,7 +248,15 @@ def run_processing(
         )
         save_dir.mkdir(parents=True, exist_ok=True)
         _run_passthrough(
-            dataset_path, data_key, n_frames, save_dir, save_as, overwrite, **dataset_hf_kwargs
+            dataset_path,
+            data_key,
+            n_frames,
+            save_dir,
+            save_as,
+            overwrite,
+            track_index=track_index,
+            track_label=track_label,
+            **dataset_hf_kwargs,
         )
         return
 
@@ -325,13 +361,9 @@ def run_processing(
                 # Already validated by the Dataloader that handed us this path.
                 with File(file_path, validate=False) as f:
                     filestem = f.stem
-                    # Re-resolve rather than trust the peek: a file whose tracks are
+                    # Re-check rather than trust the peek: a file whose tracks are
                     # ordered differently would otherwise be read at the wrong index.
-                    if _resolve_track(f, key, track)[0] != track_index:
-                        raise ValueError(
-                            f"Track {track!r} is not at index {track_index} in {file_path} as "
-                            "it is in the first file; tracks must be ordered consistently."
-                        )
+                    _check_track_consistency(f, track_index, track_label)
                     parameters = _load_track_parameters(f, track_index)
                 parameters.update(config_params)
 

--- a/zea/data/process.py
+++ b/zea/data/process.py
@@ -66,6 +66,41 @@ def _key_requires_pipeline(key: str) -> bool:
     return normalized in _NON_IMAGE_DATA_TYPES
 
 
+def _resolve_track(file: File, key: str, track: str | None) -> tuple[int | None, str]:
+    """Pick the track to process and return ``(track_index, data_key)``.
+
+    ``track`` is matched against the file's labels first and read as an index
+    only when no label matches, so a numeric label still wins. Files with a
+    single track have nothing to address and return ``(None, key)`` unchanged.
+
+    Raises:
+        ValueError: If the file has several tracks and none was selected, or the
+            requested track does not exist in this file.
+    """
+    labels = file.track_labels
+    if file._n_tracks <= 1:
+        return None, key
+    if track is None:
+        raise ValueError(
+            f"{file.path} has {len(labels)} tracks {labels} but no track was selected. "
+            "Pass --track <label|index> to pick one."
+        )
+    try:
+        index = labels.index(track) if track in labels else int(track)
+    except ValueError:
+        index = -1  # neither a label nor a number: report it like a bad index
+    if not 0 <= index < len(labels):
+        raise ValueError(f"No track {track!r} in {file.path}. Available tracks: {labels}.")
+    return index, f"tracks/track_{index}/data/{strip_track_prefix(key).removeprefix('data/')}"
+
+
+def _load_track_parameters(file: File, track_index: int | None):
+    """Load the acquisition parameters of ``track_index`` (or of the whole file)."""
+    if track_index is None:
+        return file.load_parameters()
+    return file.tracks[track_index].load_parameters()
+
+
 def _run_passthrough(
     dataset_path: str,
     key: str,
@@ -134,6 +169,7 @@ def run_processing(
     keep_dynamic_range=False,
     revision: str | None = None,
     config_revision: str | None = None,
+    track: str | None = None,
 ) -> None:
     if keep_dynamic_range and save_as != "hdf5":
         raise ValueError("--keep_dynamic_range is only supported with --save_as hdf5.")
@@ -150,43 +186,49 @@ def run_processing(
     )
     config = Config.from_path(config_path, **config_hf_kwargs)
     config_params = _get_config_parameters(config)
+
+    # Peek at the first file for the track to read (the Dataloader takes one key for
+    # the whole dataset, so ``data_key`` has to name it) and for selected_transmits,
+    # letting the dataloader pre-filter the transmit axis at HDF5 read time. lazy=True
+    # streams hf:// paths, fetching only the chunks the peek touches; validate=False
+    # because the Dataloader validates these same files anyway.
+    track_index: int | None = None
+    data_key = key
+    axis_selections: dict | None = None
+    with Dataset(
+        dataset_path, validate=False, lazy=True, _suggest_lazy=False, **dataset_hf_kwargs
+    ) as _peek_ds:
+        if len(_peek_ds) > 0:
+            _peek_f = _peek_ds[0]
+            track_index, data_key = _resolve_track(_peek_f, key, track)
+            if _key_requires_pipeline(data_key):
+                try:
+                    _peek_params = _load_track_parameters(_peek_f, track_index)
+                    _peek_params.update(config_params)
+                    axis_selections = _axis_selections_from_params(_peek_params)
+                except Exception:
+                    pass  # fall back to runtime slicing if the peek fails
+
     try:
         pipeline = Pipeline.from_path(config_path, with_batch_dim=False, **config_hf_kwargs)
     except (ValueError, KeyError) as exc:
-        if _key_requires_pipeline(key):
+        if _key_requires_pipeline(data_key):
             raise
         log.warning(
             f"No pipeline found in config ({exc}). "
-            f"Key '{key}' does not require beamforming — saving data as-is."
+            f"Key '{data_key}' does not require beamforming — saving data as-is."
         )
         save_dir.mkdir(parents=True, exist_ok=True)
         _run_passthrough(
-            dataset_path, key, n_frames, save_dir, save_as, overwrite, **dataset_hf_kwargs
+            dataset_path, data_key, n_frames, save_dir, save_as, overwrite, **dataset_hf_kwargs
         )
         return
 
     save_dir.mkdir(parents=True, exist_ok=True)
 
-    # Peek at the first file to get selected_transmits so the dataloader can
-    # pre-filter the transmit axis at HDF5 read time (avoids reading unused data).
-    axis_selections: dict | None = None
-    if _key_requires_pipeline(key):
-        try:
-            # validate=False here and on the peek open below: the Dataloader built from
-            # the same path validates these files, so checking them twice is wasted work.
-            with Dataset(dataset_path, validate=False, **dataset_hf_kwargs) as _peek_ds:
-                _first_path = _peek_ds.file_paths[0] if _peek_ds.file_paths else None
-            if _first_path:
-                with File(_first_path, validate=False) as _peek_f:
-                    _peek_params = _peek_f.load_parameters()
-                _peek_params.update(config_params)
-                axis_selections = _axis_selections_from_params(_peek_params)
-        except Exception:
-            pass  # fall back to runtime slicing if peek fails
-
     dataloader = Dataloader(
         dataset_path,
-        key=key,
+        key=data_key,
         batch_size=None,
         shuffle=False,
         return_metadata=True,
@@ -283,7 +325,14 @@ def run_processing(
                 # Already validated by the Dataloader that handed us this path.
                 with File(file_path, validate=False) as f:
                     filestem = f.stem
-                    parameters = f.load_parameters()
+                    # Re-resolve rather than trust the peek: a file whose tracks are
+                    # ordered differently would otherwise be read at the wrong index.
+                    if _resolve_track(f, key, track)[0] != track_index:
+                        raise ValueError(
+                            f"Track {track!r} is not at index {track_index} in {file_path} as "
+                            "it is in the first file; tracks must be ordered consistently."
+                        )
+                    parameters = _load_track_parameters(f, track_index)
                 parameters.update(config_params)
 
                 try:
@@ -316,6 +365,13 @@ def run_processing(
             if timings:
                 for tname in timer.timings.keys():
                     timer.append_to_yaml(save_dir / f"timings_{tname}.yaml", tname)
+
+        # Re-raise anything the last save hit. Every other save is awaited before
+        # the next one is submitted, but the final one is not: leaving its result
+        # unread swallows the exception, and a run that wrote nothing at all still
+        # exits 0.
+        if save_future is not None:
+            save_future.result()
 
     if timings:
         timer.print()


### PR DESCRIPTION
**Problem:**
`zea process` CLI could not read a multi-track file. Whatever `--key` pointed at, the run died on `File.load_parameters()`, which refuses any file with more than one track, so duplex/triplex acquisitions had no batch beamforming path at all.

**This PR:**
Adds `--track <label|index>`:

    zea process -d <dataset> -c <config.yaml> --track focused_bmode

The selected track's key is what the dataloader reads, and that track's scan is what drives the pipeline and lands in the saved `scan`/`probe`. Multi-track files will now require a `--track` to be specified, and single-track files are unaffected.

---

Example usage (see config yaml below, paths on `us-act`):
```bash
zea process   --dataset /data/qcasl/verasonics/L11-5v/02-09-2026/raw_20260902_083452.hdf5   --config config.yaml   --track focused_bmode   --save-as mp4 --overwrite --save-dir /data/qcasl/verasonics/L11-5v/02-09-2026
```


sample config.yaml
```yaml
parameters:
  f_number: 1.0
  xlims: [-0.020, 0.020]
  zlims: [0.0, 0.060]
  grid_size_x: 400
  grid_size_z: 600
  demodulation_frequency: 10000000.0
  pfield_kwargs: {downsample: 5}
display: {dynamic_range: [-45.0, 0.0]}
pipeline:
  operations:
    - {name: cast, params: {dtype: float32}}
    - {name: apply_window}
    - {name: demodulate}
    - {name: beamform, params: {beamformer: delay_and_sum, num_patches: 200, enable_pfield: true}}
    - {name: envelope_detect}
    - {name: normalize}
    - {name: log_compress}
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting a specific track when processing multi-track HDF5 files by label or index.
  - Added the `zea tools select` command for image, video, and HDF5 annotation workflows.
  - Added device selection options with an automatic default.

- **Bug Fixes**
  - Processing now validates track consistency across files and reports mismatched ordering instead of silently reading incorrect data.
  - Improved output-file protection, including overwrite-aware behavior.
  - Preserved compatibility with single-track files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->