### PR TITLE
Disable jit autotuner by default to fix slow compile for large grids

### DIFF
--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -29,7 +29,7 @@ Here are the environment variables that ``zea`` uses at runtime. Arguably the mo
      - ``0``, ``1``
    * - ``XLA_FLAGS``
      - Flags passed to XLA. On jax-based backends ``zea`` appends
-       ``--xla_gpu_experimental_enable_fusion_autotuner=false``, because XLA's fusion
+       ``--xla_gpu_experimental_enable_fusion_autotuner=false`` if supported, because XLA's fusion
        autotuner makes jit compilation very slow for pipelines with large grids. Setting
        that flag yourself takes precedence; ``zea`` then warns if you enable the autotuner.
      - ``--xla_gpu_experimental_enable_fusion_autotuner=false`` (jax backends)

--- a/docs/source/environment.rst
+++ b/docs/source/environment.rst
@@ -27,6 +27,13 @@ Here are the environment variables that ``zea`` uses at runtime. Arguably the mo
      - If set to ``1`` will write to a temporary cache directory that is deleted after the program exits.
      - ``0``
      - ``0``, ``1``
+   * - ``XLA_FLAGS``
+     - Flags passed to XLA. On jax-based backends ``zea`` appends
+       ``--xla_gpu_experimental_enable_fusion_autotuner=false``, because XLA's fusion
+       autotuner makes jit compilation very slow for pipelines with large grids. Setting
+       that flag yourself takes precedence; ``zea`` then warns if you enable the autotuner.
+     - ``--xla_gpu_experimental_enable_fusion_autotuner=false`` (jax backends)
+     - Any XLA flags, see the `XLA documentation <https://openxla.org/xla/flags>`_.
    * - ``ZEA_NVIDIA_SMI_TIMEOUT``
      - Timeout in seconds for calling ``nvidia-smi`` to get GPU information during :func:`zea.init_device`.
      - ``30``

--- a/zea/__init__.py
+++ b/zea/__init__.py
@@ -133,6 +133,11 @@ def _bootstrap_backend():
 
     _check_backend_installed()
 
+    # Must happen before any backend initialises XLA, which parses XLA_FLAGS once.
+    from .internal.xla_flags import disable_fusion_autotuner
+
+    disable_fusion_autotuner()
+
     # Read from the env var rather than calling ``keras.backend.backend()``
     # so that importing ``zea`` does not import ``keras``.
     log.info(f"Using backend {os.environ.get('KERAS_BACKEND', 'tensorflow')!r}")

--- a/zea/internal/xla_flags.py
+++ b/zea/internal/xla_flags.py
@@ -18,7 +18,10 @@ FUSION_AUTOTUNER_FLAG = "xla_gpu_experimental_enable_fusion_autotuner"
 
 def flag_supported(flag):
     """Check if ``flag`` shows up in jaxlib's compiled libraries."""
-    spec = importlib.util.find_spec("jaxlib")
+    try:
+        spec = importlib.util.find_spec("jaxlib")
+    except ImportError:
+        return False
     if spec is None or not spec.submodule_search_locations:
         return False
     for root in spec.submodule_search_locations:
@@ -45,7 +48,7 @@ def disable_fusion_autotuner(backend=None):
         bool: whether the flag was added.
     """
     if backend is None:
-        backend = os.environ.get("KERAS_BACKEND", "tensorflow")
+        backend = os.environ.get("KERAS_BACKEND", "jax")
     if backend.lower() not in ("jax", "numpy"):  # numpy falls back to jax for some operations
         return False
 

--- a/zea/internal/xla_flags.py
+++ b/zea/internal/xla_flags.py
@@ -1,12 +1,13 @@
 """XLA flag defaults, applied from :mod:`zea`'s bootstrap before any backend loads.
 
-XLA's GPU fusion autotuner is on by default, and it causes jax jit compilation times to
-explode on large grids. The flag to disable it is part of an experimental feature that
-may disappear in future versions (and invalid XLA flags crash the compiler), so this
-first checks whether jaxlib supports it.
+XLA's GPU fusion autotuner is on by default, and it causes jit compilation times to
+explode on large grids. The flag to disable it is part of an experimental feature
+that may disappear in future versions (and invalid XLA flags crash the compiler),
+so this first checks whether the currently used version supports it.
 """
 
 import importlib.util
+import json
 import mmap
 import os
 from pathlib import Path
@@ -16,10 +17,10 @@ from zea import log
 FUSION_AUTOTUNER_FLAG = "xla_gpu_experimental_enable_fusion_autotuner"
 
 
-def flag_supported(flag):
-    """Check if ``flag`` shows up in jaxlib's compiled libraries."""
+def flag_supported(flag, package):
+    """Check if ``flag`` shows up in the compiled libraries of ``package``."""
     try:
-        spec = importlib.util.find_spec("jaxlib")
+        spec = importlib.util.find_spec(package)
     except ImportError:
         return False
     if spec is None or not spec.submodule_search_locations:
@@ -48,8 +49,16 @@ def disable_fusion_autotuner(backend=None):
         bool: whether the flag was added.
     """
     if backend is None:
-        backend = os.environ.get("KERAS_BACKEND", "jax")
-    if backend.lower() not in ("jax", "numpy"):  # numpy falls back to jax for some operations
+        # Resolve the backend the way keras does: env var, then keras.json, then tensorflow.
+        config = Path(os.environ.get("KERAS_HOME", Path.home() / ".keras")) / "keras.json"
+        try:
+            default = json.loads(config.read_text()).get("backend", "tensorflow")
+        except (OSError, ValueError, AttributeError):
+            default = "tensorflow"
+        backend = os.environ.get("KERAS_BACKEND", default)
+    # Which XLA build gets to see the flag; numpy falls back to jax for some operations.
+    package = {"jax": "jaxlib", "numpy": "jaxlib", "tensorflow": "tensorflow"}.get(backend.lower())
+    if package is None:  # torch does not go through XLA
         return False
 
     xla_flags = os.environ.get("XLA_FLAGS", "")
@@ -61,7 +70,7 @@ def disable_fusion_autotuner(backend=None):
             )
         return False
 
-    if not flag_supported(FUSION_AUTOTUNER_FLAG):
+    if not flag_supported(FUSION_AUTOTUNER_FLAG, package):
         return False
 
     os.environ["XLA_FLAGS"] = f"{xla_flags} --{FUSION_AUTOTUNER_FLAG}=false".strip()

--- a/zea/internal/xla_flags.py
+++ b/zea/internal/xla_flags.py
@@ -1,0 +1,65 @@
+"""XLA flag defaults, applied from :mod:`zea`'s bootstrap before any backend loads.
+
+XLA's GPU fusion autotuner is on by default, and it causes jax jit compilation times to
+explode on large grids. The flag to disable it is part of an experimental feature that
+may disappear in future versions (and invalid XLA flags crash the compiler), so this
+first checks whether jaxlib supports it.
+"""
+
+import importlib.util
+import mmap
+import os
+from pathlib import Path
+
+from zea import log
+
+FUSION_AUTOTUNER_FLAG = "xla_gpu_experimental_enable_fusion_autotuner"
+
+
+def flag_supported(flag):
+    """Check if ``flag`` shows up in jaxlib's compiled libraries."""
+    spec = importlib.util.find_spec("jaxlib")
+    if spec is None or not spec.submodule_search_locations:
+        return False
+    for root in spec.submodule_search_locations:
+        for lib in sorted(Path(root).rglob("*.so")):
+            try:
+                if lib.stat().st_size < 5 * 1024**2:
+                    continue
+                with open(lib, "rb") as handle:
+                    with mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ) as mapped:
+                        if mapped.find(flag.encode()) != -1:
+                            return True
+            except OSError:
+                continue
+    return False
+
+
+def disable_fusion_autotuner(backend=None):
+    """Turn the autotuner off via ``XLA_FLAGS``, unless the user asked for it.
+
+    Args:
+        backend (str, optional): Keras backend in use. Defaults to ``KERAS_BACKEND``.
+
+    Returns:
+        bool: whether the flag was added.
+    """
+    if backend is None:
+        backend = os.environ.get("KERAS_BACKEND", "tensorflow")
+    if backend.lower() not in ("jax", "numpy"):  # keras' numpy backend runs on jax
+        return False
+
+    xla_flags = os.environ.get("XLA_FLAGS", "")
+    if FUSION_AUTOTUNER_FLAG in xla_flags:
+        if f"--{FUSION_AUTOTUNER_FLAG}=false" not in xla_flags:
+            log.warning(
+                "The XLA fusion autotuner is enabled. This may cause excessive jit "
+                "compilation times when beamforming large grids."
+            )
+        return False
+
+    if not flag_supported(FUSION_AUTOTUNER_FLAG):
+        return False
+
+    os.environ["XLA_FLAGS"] = f"{xla_flags} --{FUSION_AUTOTUNER_FLAG}=false".strip()
+    return True

--- a/zea/internal/xla_flags.py
+++ b/zea/internal/xla_flags.py
@@ -46,7 +46,7 @@ def disable_fusion_autotuner(backend=None):
     """
     if backend is None:
         backend = os.environ.get("KERAS_BACKEND", "tensorflow")
-    if backend.lower() not in ("jax", "numpy"):  # keras' numpy backend runs on jax
+    if backend.lower() not in ("jax", "numpy"):  # numpy falls back to jax for some operations
         return False
 
     xla_flags = os.environ.get("XLA_FLAGS", "")


### PR DESCRIPTION
See #599 : 

<img width="1650" height="630" alt="image" src="https://github.com/user-attachments/assets/7bea700e-713e-4100-9134-00ad9cb341ff" />



This PR disables the autotuner unless the user has explicitly enabled it in `XLA_FLAGS`. 

#596 addresses the same issue, but I think that one is good to merge as well for different reasons (i.e. being able to set a memory budget instead of having to tweak magic numbers until the pipeline fits on your GPU).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic handling for a supported XLA GPU fusion setting during startup.
  - Existing user configuration is preserved, with a warning shown when it conflicts with the automatic setting.
  - The adjustment applies only when supported and does not affect non-JAX or NumPy-based Keras backends.

- **Documentation**
  - Documented the `XLA_FLAGS` environment variable, including supported values, defaults, and override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->