### PR TITLE
Don't flag valid pipeline params in warnings

### DIFF
--- a/tests/data/test_process.py
+++ b/tests/data/test_process.py
@@ -406,6 +406,52 @@ def test_check_track_consistency_single_track_is_noop(tmp_path):
         _check_track_consistency(f, None, None)  # does not raise
 
 
+def test_run_processing_does_not_forward_unused_config_params(tmp_path):
+    """Config parameters the pipeline does not need never reach the pipeline.
+
+    ``run_processing`` already merges the config into ``zea.Parameters``, so passing
+    it as overrides too would bypass ``prepare_parameters``' ``needs_keys`` filter and
+    push unused keys (here ``pixels_per_wavelength``) all the way into the pipeline,
+    where they surface as spurious "unused input key" reports.
+    """
+    from zea.data.process import run_processing
+    from zea.ops.pipeline import Pipeline
+
+    ds_dir = tmp_path / "ds"
+    generate_example_dataset(ds_dir / "scan.hdf5", n_frames=1, n_ax=8, n_el=4, n_tx=2)
+
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        "parameters:\n"
+        "  pixels_per_wavelength: 2\n"  # a real parameter this pipeline has no use for
+        "pipeline:\n"
+        "  operations:\n"
+        "    - envelope_detect\n"
+    )
+
+    seen = {}
+    original = Pipeline.prepare_parameters
+
+    def spy(self, parameters=None, device=None, **overrides):
+        prepared = original(self, parameters, device=device, **overrides)
+        seen["overrides"] = set(overrides)
+        seen["prepared"] = set(prepared)
+        return prepared
+
+    with patch.object(Pipeline, "prepare_parameters", spy):
+        run_processing(
+            str(ds_dir),
+            str(cfg),
+            key="data/raw_data",
+            n_frames=1,
+            save_dir=tmp_path / "out",
+            save_as="gif",
+        )
+
+    assert seen["overrides"] == set(), "config must not be forwarded as overrides"
+    assert "pixels_per_wavelength" not in seen["prepared"]
+
+
 def test_run_processing_track_selects_data(tmp_path):
     """run_processing reads the requested track end to end."""
     from zea.data.file import File

--- a/tests/test_ops_infra.py
+++ b/tests/test_ops_infra.py
@@ -1736,6 +1736,30 @@ def test_pipeline_valid_parameter_not_flagged_as_typo(monkeypatch):
     assert any("polar_limits" in m for m in debugs)
 
 
+def test_pipeline_missing_key_does_not_blame_valid_parameter():
+    """A missing key is not blamed on a real ``zea.Parameters`` name.
+
+    ``polar_limits`` fuzzy-matches the missing ``polar_angles``, but suggesting it as
+    the typo would send the user to rename a parameter that is legitimately theirs.
+    """
+    import numpy as np
+
+    @ops_registry("needs_polar_angles_strict")
+    class NeedsPolarAnglesStrict(ops.Operation):
+        def call(self, **kwargs):
+            return {"data": kwargs["polar_angles"]}
+
+    pipeline = ops.Pipeline(
+        [NeedsPolarAnglesStrict()], with_batch_dim=False, jit_options=None, validate=False
+    )
+    with pytest.raises(KeyError) as excinfo:
+        pipeline(data=np.zeros((4, 4), dtype="float32"), polar_limits=(-0.5, 0.5))
+
+    msg = str(excinfo.value)
+    assert "polar_angles" in msg
+    assert "did you mean" not in msg, "polar_limits is a real parameter, not the typo"
+
+
 def test_pipeline_nested_error_not_double_wrapped():
     """An error from a nested pipeline is annotated once, not wrapped twice."""
     import numpy as np

--- a/tests/test_ops_infra.py
+++ b/tests/test_ops_infra.py
@@ -1707,6 +1707,35 @@ def test_pipeline_unused_key_typo_warns(monkeypatch):
     assert any("dynamic_range" in m and "typo" in m for m in messages)
 
 
+def test_pipeline_valid_parameter_not_flagged_as_typo(monkeypatch):
+    """A real ``zea.Parameters`` field is never reported as a typo.
+
+    ``polar_limits`` fuzzy-matches the pipeline's ``polar_angles``, but it is a
+    legitimate parameter that shapes *derived* inputs (the beamforming grid), so
+    it belongs in the benign debug list rather than the typo warning.
+    """
+    import numpy as np
+
+    from zea.ops import pipeline as pipeline_module
+
+    warnings_, debugs = [], []
+    monkeypatch.setattr(pipeline_module.log, "warning", lambda msg, *a, **k: warnings_.append(msg))
+    monkeypatch.setattr(pipeline_module.log, "debug", lambda msg, *a, **k: debugs.append(msg))
+
+    @ops_registry("needs_polar_angles")
+    class NeedsPolarAngles(ops.Operation):
+        def call(self, polar_angles=None, **kwargs):
+            return {"data": kwargs["data"]}
+
+    pipeline = ops.Pipeline(
+        [NeedsPolarAngles()], with_batch_dim=False, jit_options=None, validate=False
+    )
+    pipeline(data=np.zeros((4, 4), dtype="float32"), polar_limits=(-0.5, 0.5))
+
+    assert not any("typo" in m for m in warnings_)
+    assert any("polar_limits" in m for m in debugs)
+
+
 def test_pipeline_nested_error_not_double_wrapped():
     """An error from a nested pipeline is annotated once, not wrapped twice."""
     import numpy as np

--- a/zea/data/process.py
+++ b/zea/data/process.py
@@ -372,7 +372,7 @@ def run_processing(
                 except (ValueError, AttributeError):
                     fps = _DEFAULT_FPS
 
-                params = prepare_parameters(parameters, **config_params)
+                params = prepare_parameters(parameters)
 
             # Sentinel iteration (no more data — also covers an empty dataset
             # where total_batches == 0); nothing to process, so stop here.

--- a/zea/log.py
+++ b/zea/log.py
@@ -34,7 +34,10 @@ file_logger: logging.Logger | None = None
 
 LOG_DIR = Path("log")
 
-ZEA_LOG_LEVEL = os.getenv("ZEA_LOG_LEVEL", "DEBUG").upper()
+# Default to INFO: ``log.info`` is zea's user-facing output channel (progress,
+# saved paths, cache summaries), while ``log.debug`` is diagnostic detail that
+# should be opted into via ZEA_LOG_LEVEL=DEBUG.
+ZEA_LOG_LEVEL = os.getenv("ZEA_LOG_LEVEL", "INFO").upper()
 
 DEPRECATED_LEVEL_NUM = logging.WARNING + 5
 logging.addLevelName(DEPRECATED_LEVEL_NUM, "DEPRECATED")

--- a/zea/ops/pipeline.py
+++ b/zea/ops/pipeline.py
@@ -1,6 +1,7 @@
 import difflib
 import inspect
 import json
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, List, Sequence, Union, cast
 
 import keras
@@ -36,6 +37,20 @@ if TYPE_CHECKING:
     # Imported lazily at runtime (inside prepare_parameters) to avoid a circular
     # import: zea.parameters imports the data specs, which can pull in this module.
     from zea.parameters import Parameters
+
+
+@lru_cache(maxsize=1)
+def _valid_parameter_names() -> frozenset:
+    """Names recognized by :class:`~zea.Parameters`.
+
+    Such keys are never typos when handed to a pipeline: many of them configure
+    *derived* inputs (``polar_limits`` shapes ``grid``, ``pfield_kwargs`` shapes
+    ``flat_pfield``) and are therefore legitimately unused by the pipeline itself.
+    """
+    # Local import for the circular-import reason described above.
+    from zea.parameters import Parameters
+
+    return frozenset(Parameters.VALID_PARAMS)
 
 
 class PipelineError(RuntimeError):
@@ -430,7 +445,11 @@ class Pipeline:
     def _raise_missing_key(self, operation, exc: KeyError, inputs: Dict[str, Any]):
         """Re-raise a bare ``KeyError`` from an operation with actionable context."""
         missing = exc.args[0] if exc.args else "?"
-        unused = [k for k in (set(inputs.keys()) - self.valid_keys) if k != "kwargs"]
+        unused = [
+            k
+            for k in (set(inputs.keys()) - self.valid_keys - _valid_parameter_names())
+            if k != "kwargs"
+        ]
         # If the caller passed something close to the missing key, it is likely a typo.
         typo = difflib.get_close_matches(str(missing), unused, n=1, cutoff=0.6)
         hint = (
@@ -506,7 +525,7 @@ class Pipeline:
                 candidates = self.valid_keys - {"kwargs"}
                 matches = {
                     key: difflib.get_close_matches(key, candidates, n=1, cutoff=0.6)
-                    for key in difference_keys
+                    for key in difference_keys - _valid_parameter_names()
                 }
                 typos = {key: match[0] for key, match in matches.items() if match}
                 benign = difference_keys - set(typos)

--- a/zea/ops/pipeline.py
+++ b/zea/ops/pipeline.py
@@ -43,9 +43,13 @@ if TYPE_CHECKING:
 def _valid_parameter_names() -> frozenset:
     """Names recognized by :class:`~zea.Parameters`.
 
-    Such keys are never typos when handed to a pipeline: many of them configure
-    *derived* inputs (``polar_limits`` shapes ``grid``, ``pfield_kwargs`` shapes
-    ``flat_pfield``) and are therefore legitimately unused by the pipeline itself.
+    Used to tell two kinds of unused input apart. A name in this set is a real
+    parameter, so it is reported as unused but never guessed at as a typo. A name
+    outside it is unknown to zea entirely, so a close match is worth suggesting.
+
+    Reaching the pipeline at all still means a caller passed the key by hand:
+    :meth:`Pipeline.prepare_parameters` only draws the keys the pipeline needs
+    out of a :class:`~zea.Parameters` object.
     """
     # Local import for the circular-import reason described above.
     from zea.parameters import Parameters
@@ -520,8 +524,9 @@ class Pipeline:
         if not self._logged_difference_keys:
             difference_keys = set(inputs.keys()) - self.valid_keys
             if difference_keys:
-                # Separate likely typos (close to a key the pipeline actually uses)
-                # from benign pass-through keys (e.g. extra `zea.Parameters` fields).
+                # Split unknown names, where a close match is a useful typo hint,
+                # from real `zea.Parameters` names, which this pipeline simply does
+                # not consume. Both are unused; only the first is likely a mistake.
                 candidates = self.valid_keys - {"kwargs"}
                 matches = {
                     key: difflib.get_close_matches(key, candidates, n=1, cutoff=0.6)


### PR DESCRIPTION
I was running the following:

```bash
zea process --dataset hf://zeahub/zea-cardiac-2026/20251222_s3_a4ch_line_dw_0000.hdf5 --config hf://zeahub/zea-cardiac-2026/config.yaml
```

This emits a typo warning for polar_limits ("did you mean 'polar_angles'?") plus a debug line for pfield_kwargs/pixels_per_wavelength. All three are false alarms. they're legitimate `VALID_PARAMS` fields shaping derived inputs (grid, theta_range, flat_pfield, grid_size_*), consumed in prepare_parameters and passed through to __call__.

Turns out `zea process` was passing parameters outside `prepare_parameters` and directly to the pipeline call so these were not filtered properly. 

Also decided to change default logging level to INFO, so not showing DEBUG by default, which I think makes sense? @wesselvannierop 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Valid pipeline parameters, including grid and related derived inputs, are no longer incorrectly reported as typos or unused inputs.
  * Unused configuration parameters are filtered out before processing, preventing them from being passed as pipeline overrides.
  * Legitimate parameter names now produce quieter diagnostic output instead of unnecessary warnings.

* **Changes**
  * The default logging level is now `INFO`; detailed debug output remains available when debug logging is explicitly enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->