### PR TITLE
Add InversionNet speed-of-sound reconstruction model

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -48,39 +48,59 @@ and the full preset/weight-loading infrastructure for free.
 
 For models originally trained in PyTorch, the typical workflow is:
 
-1. **Vendor the architecture** — copy the PyTorch network code into your module
-   (e.g. inside a ``_build_torch_classes()`` helper that imports ``torch``
-   lazily so that PyTorch is only required for weight conversion, not inference).
+1. **Vendor the architecture** — keep the PyTorch network code at hand while you
+   port it. If you want it in the module long-term (e.g. for ONNX export), put it
+   in a ``_build_torch_classes()`` helper that imports ``torch`` lazily, so that
+   PyTorch is only required for weight conversion and never for inference.
 
 2. **Implement the Keras architecture** — write ``keras.layers.Layer`` subclasses
    that replicate each block. Key API differences to handle:
 
-   * **Padding for stride-2 Conv2D**: Keras ``padding='same'`` is asymmetric for
-     ``stride > 1``; use ``ZeroPadding2D(1) + Conv2D(padding='valid')`` to match
-     PyTorch's symmetric ``padding=1``.
+   * **Padding for strided Conv2D**: Keras ``padding='same'`` is asymmetric for
+     ``stride > 1``; use ``ZeroPadding2D(p) + Conv2D(padding='valid')`` to match
+     PyTorch's symmetric ``padding=p``.
    * **ConvTranspose**: Keras ``Conv2DTranspose(padding='valid')`` gives the full
-     output; crop ``x[:, 1:, 1:, :]`` (NHWC) to reproduce PyTorch's
-     ``ConvTranspose2d(padding=1, output_padding=1)`` alignment.
-   * **InstanceNorm**: use ``GroupNormalization(groups=C, scale=False,
-     center=False, epsilon=1e-5)`` for ``InstanceNorm2d(affine=False)``.
+     output, from which PyTorch's ``padding=p`` crops ``p`` on every side — so
+     follow it with ``Cropping2D(p)``. A PyTorch ``output_padding`` adds to the
+     end only, so ``padding=1, output_padding=1`` becomes ``x[:, 1:, 1:, :]``.
+   * **Normalization**: ``BatchNormalization`` needs ``epsilon=1e-5`` to match
+     PyTorch's ``BatchNorm2d`` default, and takes its weights as ``[weight, bias,
+     running_mean, running_var]``. For ``InstanceNorm2d(affine=False)`` use
+     ``GroupNormalization(groups=C, scale=False, center=False, epsilon=1e-5)``.
    * **Weight axes**: Conv2D — ``(2,3,1,0)``; Conv2DTranspose — ``(2,3,1,0)``
      (same permutation, different semantics).
    * **Input format**: Keras defaults to channels-last (NHWC); transpose
      NCHW → NHWC in ``call()`` and back before returning.
+   * **Layer names**: do not name custom layer *classes* with a leading
+     underscore. Keras derives the layer name from the class name, and the
+     TensorFlow backend rejects names starting with ``_``.
 
 3. **Write a weight-loading helper** — a function that maps PyTorch state-dict
-   keys to the Keras layer tree and calls ``layer.set_weights([...])``.
+   keys to the Keras layer tree and calls ``layer.set_weights([...])``. The
+   weights only exist once the model is built; building it symbolically with
+   ``self(keras.Input(batch_shape=...))`` avoids pushing real data through it.
 
 4. **Add** ``from_pth(path)`` **classmethod** — wraps the weight loader for
    convenient local testing.
 
-5. Optionally **add an ONNX fallback** — for environments that have
+5. **Verify against the reference implementation** — before uploading the
+   converted weights, run both models on the same input and compare. A correct
+   port agrees to ~1e-5 in float32. If it does not, compare block by block: the
+   layer where the difference appears is the one that was ported wrong.
+
+   .. warning::
+      Run that comparison on CPU. On an NVIDIA GPU both JAX and PyTorch use TF32
+      for convolutions by default, which costs ~3 decimal digits and makes a
+      correct port look broken (differences of ~1e-2 instead of ~1e-5).
+
+6. Optionally **add an ONNX fallback** — for environments that have
    ``onnxruntime`` but not ``torch``, you can keep a ``from_onnx(path)``
    classmethod and an ``_onnx_sess`` attribute; override ``call()`` to
    dispatch to the ONNX path when the session is set.
 
-6. Follow steps 3-6 from the standard guide above for HF upload, presets, and
+7. Follow steps 3-6 from the standard guide above for HF upload, presets, and
    registration.
 
-See :mod:`zea.models.speckle2self` for a complete worked example of this
-pattern (native Keras + PyTorch weight loading + optional ONNX fallback).
+Two worked examples of this pattern: :mod:`zea.models.inversionnet` (native Keras
+plus a PyTorch state-dict converter) and :mod:`zea.models.speckle2self` (the same,
+plus a vendored PyTorch architecture and an optional ONNX fallback).

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -50,8 +50,9 @@ For models originally trained in PyTorch, the typical workflow is:
 
 1. **Vendor the architecture** — keep the PyTorch network code at hand while you
    port it. If you want it in the module long-term (e.g. for ONNX export), put it
-   in a ``_build_torch_classes()`` helper that imports ``torch`` lazily, so that
-   PyTorch is only required for weight conversion and never for inference.
+   in a ``_build_torch_classes()`` helper that imports ``torch`` lazily. PyTorch is
+   then required for weight conversion and ONNX export, but never for inference —
+   which is what keeps it out of the runtime dependencies.
 
 2. **Implement the Keras architecture** — write ``keras.layers.Layer`` subclasses
    that replicate each block. Key API differences to handle:
@@ -89,9 +90,12 @@ For models originally trained in PyTorch, the typical workflow is:
    layer where the difference appears is the one that was ported wrong.
 
    .. warning::
-      Run that comparison on CPU. On an NVIDIA GPU both JAX and PyTorch use TF32
-      for convolutions by default, which costs ~3 decimal digits and makes a
-      correct port look broken (differences of ~1e-2 instead of ~1e-5).
+      Run that comparison on CPU. On a supported NVIDIA GPU all three backends —
+      JAX, TensorFlow and PyTorch — use TF32 for convolutions by default, which
+      costs ~3 decimal digits and makes a correct port look broken (differences of
+      ~1e-2 instead of ~1e-5). This applies to any pair of them, so a
+      TensorFlow-versus-PyTorch comparison is no safer than a JAX-versus-PyTorch
+      one.
 
 6. Optionally **add an ONNX fallback** — for environments that have
    ``onnxruntime`` but not ``torch``, you can keep a ``from_onnx(path)``

--- a/tests/models/test_inversionnet.py
+++ b/tests/models/test_inversionnet.py
@@ -1,0 +1,88 @@
+"""Tests for the InversionNet speed-of-sound reconstruction model."""
+
+import keras
+import numpy as np
+import pytest
+from keras import ops
+
+from zea.models.inversionnet import OPENPROS_INPUT_SHAPE, InversionNet
+
+# The pretrained architecture is far too large to run in a test, so the tests below use a
+# miniature configuration with the same structure: a side-strided encoder level, a regular
+# one, a bottleneck that collapses to 1 x 1, and a cropped decoder.
+TINY_INPUT_SHAPE = (40, 9, 3)
+TINY_KWARGS = {
+    "waveform_shape": TINY_INPUT_SHAPE,
+    "enc_ch": (2, 2, 2, 3),
+    "enc_side": (1, 0),
+    "bottle_conv": (5, 5),
+    "bottle_deconv": (5, 3),
+    "dec_ch": (3, 2, 2),
+    "crop": (1, 2, 3, 4),
+}
+TINY_OUTPUT_SHAPE = (17, 5, 1)
+# Trainable parameter count of the original OpenPros checkpoint.
+OPENPROS_PARAMS = 20_447_515
+
+
+@pytest.fixture
+def tiny_model():
+    """Miniature InversionNet with randomly initialized weights."""
+    return InversionNet(**TINY_KWARGS)
+
+
+def test_call_returns_a_single_channel_map(tiny_model, rng):
+    """The network maps waveforms to a one-channel image in ``[-1, 1]``."""
+    x = rng.random((2, *TINY_INPUT_SHAPE)).astype("float32")
+    out = tiny_model(x)
+    assert out.shape == (2, *TINY_OUTPUT_SHAPE)
+    assert float(ops.min(out)) >= -1.0
+    assert float(ops.max(out)) <= 1.0
+
+
+@pytest.mark.parametrize(
+    ("shape", "match"),
+    [
+        ((*TINY_INPUT_SHAPE,), "4 dimensions"),
+        ((1, 40, 9, 5), r"shape \(batch, 40, 9, 3\)"),
+    ],
+)
+def test_call_rejects_bad_input(tiny_model, shape, match):
+    """Only 4D input with the configured number of channels is accepted."""
+    with pytest.raises(ValueError, match=match):
+        tiny_model(np.zeros(shape, dtype="float32"))
+
+
+def test_mismatched_encoder_arguments_raise():
+    """``enc_side`` covers the levels between the input and bottleneck convolutions."""
+    with pytest.raises(ValueError, match="two more entries"):
+        InversionNet(enc_ch=(6, 6, 7), enc_side=(1, 0))
+
+
+def test_config_round_trip(tiny_model, rng):
+    """A model rebuilt from its config has the same architecture."""
+    rebuilt = InversionNet.from_config(tiny_model.get_config())
+    x = rng.random((1, *TINY_INPUT_SHAPE)).astype("float32")
+    assert rebuilt(x).shape == tiny_model(x).shape
+
+
+def test_default_architecture_matches_the_openpros_checkpoint():
+    """The default arguments reproduce the released OpenPros network.
+
+    Built symbolically, so the 20M-parameter network is never actually run.
+    """
+    model = InversionNet()
+    output = model(keras.Input(batch_shape=(None, *OPENPROS_INPUT_SHAPE)))
+    assert tuple(output.shape[1:]) == (401, 161, 1)
+    assert sum(np.prod(w.shape) for w in model.trainable_weights) == OPENPROS_PARAMS
+
+
+def test_weights_round_trip_through_a_preset(tiny_model, tmp_path, rng):
+    """Saving to a preset directory and loading it back preserves the weights."""
+    x = rng.random((1, *TINY_INPUT_SHAPE)).astype("float32")
+    expected = ops.convert_to_numpy(tiny_model(x))
+
+    tiny_model.save_to_preset(str(tmp_path))
+    reloaded = InversionNet.from_preset(str(tmp_path))
+
+    assert np.allclose(ops.convert_to_numpy(reloaded(x)), expected, atol=1e-6)

--- a/tests/models/test_inversionnet.py
+++ b/tests/models/test_inversionnet.py
@@ -86,3 +86,21 @@ def test_weights_round_trip_through_a_preset(tiny_model, tmp_path, rng):
     reloaded = InversionNet.from_preset(str(tmp_path))
 
     assert np.allclose(ops.convert_to_numpy(reloaded(x)), expected, atol=1e-6)
+
+
+def test_training_mode_updates_batch_norm_like_pytorch(tiny_model, rng):
+    """Fine-tuning weights the running statistics the way the original does.
+
+    Keras' ``momentum`` is the weight of the *existing* statistic where PyTorch's is
+    the weight of the *incoming* batch, so PyTorch's default of ``0.1`` is Keras'
+    ``0.9``. Getting this wrong is invisible at inference time and only shows up as
+    running statistics that adapt 10x too slowly during fine-tuning.
+    """
+    x = rng.random((4, *TINY_INPUT_SHAPE)).astype("float32")
+    block = tiny_model.encoder[0]
+
+    tiny_model(x, training=True)
+
+    batch_mean = ops.convert_to_numpy(block.conv(block.pad(x))).mean(axis=(0, 1, 2))
+    # The moving mean starts at zero, so one update leaves it at 0.1 * the batch mean.
+    assert np.allclose(ops.convert_to_numpy(block.norm.moving_mean), 0.1 * batch_mean, atol=1e-5)

--- a/tests/models/test_inversionnet.py
+++ b/tests/models/test_inversionnet.py
@@ -88,19 +88,47 @@ def test_weights_round_trip_through_a_preset(tiny_model, tmp_path, rng):
     assert np.allclose(ops.convert_to_numpy(reloaded(x)), expected, atol=1e-6)
 
 
-def test_training_mode_updates_batch_norm_like_pytorch(tiny_model, rng):
-    """Fine-tuning weights the running statistics the way the original does.
+def test_fit_updates_batch_norm_like_pytorch(tiny_model, rng):
+    """Fine-tuning updates the running statistics, with the original's weighting.
+
+    Goes through ``fit()`` rather than a direct ``training=True`` call on purpose:
+    the moving statistics only update if ``call()`` forwards ``training`` down to the
+    normalization layers, and the direct call papers over a model that does not.
 
     Keras' ``momentum`` is the weight of the *existing* statistic where PyTorch's is
     the weight of the *incoming* batch, so PyTorch's default of ``0.1`` is Keras'
-    ``0.9``. Getting this wrong is invisible at inference time and only shows up as
-    running statistics that adapt 10x too slowly during fine-tuning.
+    ``0.9``. Getting that wrong is invisible at inference time and shows up only as
+    running statistics that adapt 10x too slowly.
     """
     x = rng.random((4, *TINY_INPUT_SHAPE)).astype("float32")
+    y = np.zeros((4, *TINY_OUTPUT_SHAPE), dtype="float32")
     block = tiny_model.encoder[0]
+    tiny_model(x)  # build
 
-    tiny_model(x, training=True)
-
+    # Read the statistic the normalization layer will see, before the optimizer step
+    # of the single training batch moves the convolution that produces it.
     batch_mean = ops.convert_to_numpy(block.conv(block.pad(x))).mean(axis=(0, 1, 2))
+
+    tiny_model.compile(optimizer="sgd", loss="mse")
+    tiny_model.fit(x, y, epochs=1, batch_size=4, verbose=0)
+
     # The moving mean starts at zero, so one update leaves it at 0.1 * the batch mean.
     assert np.allclose(ops.convert_to_numpy(block.norm.moving_mean), 0.1 * batch_mean, atol=1e-5)
+
+
+def test_architecture_that_does_not_collapse_to_a_point_is_rejected():
+    """A ``waveform_shape`` the encoder cannot reduce to 1 x 1 fails at construction.
+
+    Left unchecked, the bottleneck convolution passes the leftover extent on and the
+    decoder upsamples it into a wrongly sized map, with nothing raised anywhere.
+    """
+    # Twice the time samples the rest of TINY_KWARGS is sized for.
+    kwargs = {**TINY_KWARGS, "waveform_shape": (80, 9, 3)}
+
+    with pytest.raises(ValueError, match=r"collapse to 1 x 1.*bottle_conv=\(10, 5\)"):
+        InversionNet(**kwargs)
+
+    # The size the error suggests is the one that works.
+    model = InversionNet(**{**kwargs, "bottle_conv": (10, 5)})
+    output = model(keras.Input(batch_shape=(None, 80, 9, 3)))
+    assert tuple(output.shape[1:]) == TINY_OUTPUT_SHAPE

--- a/zea/models/__init__.py
+++ b/zea/models/__init__.py
@@ -16,6 +16,7 @@ See the following dropdown for a list of available models:
     - :class:`zea.models.regional_quality.MobileNetv2RegionalQuality`: A scoring model for myocardial regions in apical views.
     - :class:`zea.models.lv_segmentation.AugmentedCamusSeg`: A nnU-Net based left ventricle and myocardium segmentation model.
     - :class:`zea.models.speckle2self.Speckle2Self`: A self-supervised speckle reduction model for ultrasound images.
+    - :class:`zea.models.inversionnet.InversionNet`: A speed-of-sound reconstruction model for ultrasound computed tomography.
 
 Presets for these models can be found in :mod:`zea.models.presets`. Presets are pre-trained weights for the models, which can be used to initialize the models for inference or further training. Each model class has a :attr:`presets` attribute that lists the available presets for that model. We store the presets on `Hugging Face Hub <https://huggingface.co/zeahub/models>`__, and they are downloaded automatically when loading a model with a preset.
 
@@ -87,6 +88,7 @@ from . import (
     generative,
     gmm,
     hvae,
+    inversionnet,
     layers,
     lista,
     lpips,

--- a/zea/models/inversionnet.py
+++ b/zea/models/inversionnet.py
@@ -1,4 +1,4 @@
-"""InversionNet: full-waveform inversion of ultrasound computed tomography data.
+r"""InversionNet: full-waveform inversion of ultrasound computed tomography data.
 
 InversionNet is an encoder-decoder network that maps raw multi-source waveform
 data straight to a speed-of-sound (SOS) map, without an iterative solver. It was
@@ -14,6 +14,30 @@ Usage
 
     model = InversionNet.from_preset("inversionnet-openpros")
     sos = model(waveforms)  # (B, 1000, 161, 40) -> (B, 401, 161, 1) in [-1, 1]
+
+Input preprocessing
+-------------------
+The preset only works on input scaled the way it was trained, and mis-scaled input
+degrades the reconstruction silently rather than raising. Reproduce the OpenPros
+preprocessing exactly:
+
+1. Sign-preserving log compression, :math:`t(x) = \mathrm{sign}(x)\log(1 + |kx|)`,
+   with ``k = 1e5``.
+2. Min-max normalize ``[t(data_min), t(data_max)]`` to ``[-1, 1]``, with the OpenPros
+   dataset constants ``data_min = -0.25`` and ``data_max = 0.45``.
+
+The output is in ``[-1, 1]`` and maps linearly onto the OpenPros label range of
+``1300-3600 m/s`` — undo it with
+``Normalize(input_range=(-1, 1), output_range=(1300, 3600))``.
+
+.. note::
+
+    ``k`` is effectively part of the weights, not a free parameter. The OpenPros job
+    scripts pass ``--k 1e9``, but ``k = 1e5`` is what reproduces the released
+    checkpoint on the released data: on the OpenPros sample it gives a mean absolute
+    error of 14 m/s against the ground-truth map, where ``k = 1e9`` gives 244 m/s.
+    The optimum is sharp — an order of magnitude either way costs roughly 3x in
+    error — so do not tune it.
 
 Architecture notes
 ------------------
@@ -72,6 +96,11 @@ _BN_EPSILON = 1e-5
 _BN_MOMENTUM = 0.9
 
 
+def _conv_out_size(size, kernel, stride, padding):
+    """Spatial size after a convolution, following PyTorch's floor convention."""
+    return (size + 2 * padding - kernel) // stride + 1
+
+
 class ConvBlock(keras.layers.Layer):
     """Conv2D + BatchNorm + LeakyReLU (or ``tanh``), channels-last.
 
@@ -96,10 +125,10 @@ class ConvBlock(keras.layers.Layer):
             else keras.layers.LeakyReLU(negative_slope=0.2)
         )
 
-    def call(self, x):
+    def call(self, x, training=None):
         if self.pad is not None:
             x = self.pad(x)
-        return self.act(self.norm(self.conv(x)))
+        return self.act(self.norm(self.conv(x), training=training))
 
 
 class DeconvBlock(keras.layers.Layer):
@@ -119,11 +148,11 @@ class DeconvBlock(keras.layers.Layer):
         self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON, momentum=_BN_MOMENTUM)
         self.act = keras.layers.LeakyReLU(negative_slope=0.2)
 
-    def call(self, x):
+    def call(self, x, training=None):
         x = self.conv(x)
         if self.crop is not None:
             x = self.crop(x)
-        return self.act(self.norm(x))
+        return self.act(self.norm(x, training=training))
 
 
 @model_registry(name="inversionnet")
@@ -187,15 +216,32 @@ class InversionNet(BaseModel):
         self.crop = tuple(crop)
 
         widths = [2**c for c in self.enc_ch]
+        # Track the feature map alongside the blocks: the bottleneck convolution is
+        # "valid", so it only collapses to 1 x 1 if it matches what is left here.
+        height, receivers = self.waveform_shape[:2]
         encoder = [ConvBlock(widths[0], kernel_size=(7, 1), strides=(2, 1), padding=(3, 0))]
+        height = _conv_out_size(height, 7, 2, 3)
         for level, side in enumerate(self.enc_side, start=1):
-            width = widths[level]
+            channels = widths[level]
             if side:
-                encoder.append(ConvBlock(width, kernel_size=(3, 1), strides=(2, 1), padding=(1, 0)))
-                encoder.append(ConvBlock(width, kernel_size=(3, 1), padding=(1, 0)))
+                encoder.append(
+                    ConvBlock(channels, kernel_size=(3, 1), strides=(2, 1), padding=(1, 0))
+                )
+                encoder.append(ConvBlock(channels, kernel_size=(3, 1), padding=(1, 0)))
             else:
-                encoder.append(ConvBlock(width, strides=2))
-                encoder.append(ConvBlock(width))
+                encoder.append(ConvBlock(channels, strides=2))
+                encoder.append(ConvBlock(channels))
+                receivers = _conv_out_size(receivers, 3, 2, 1)
+            height = _conv_out_size(height, 3, 2, 1)
+        if (height, receivers) != self.bottle_conv:
+            raise ValueError(
+                f"The encoder must collapse to 1 x 1 before the decoder, but "
+                f"waveform_shape={self.waveform_shape} leaves a {height} x {receivers} "
+                f"feature map at the bottleneck, which bottle_conv={self.bottle_conv} does "
+                f"not match. Pass bottle_conv=({height}, {receivers}), or change "
+                f"waveform_shape / enc_side. Left alone, the decoder would upsample the "
+                f"leftover extent and silently return a wrongly sized map."
+            )
         encoder.append(ConvBlock(widths[-1], kernel_size=self.bottle_conv, padding=0))
         self.encoder = encoder
 
@@ -213,14 +259,16 @@ class InversionNet(BaseModel):
         self.output_crop = keras.layers.Cropping2D(((top, bottom), (left, right)))
         self.output_block = ConvBlock(1, activation="tanh")
 
-    def call(self, inputs):
+    def call(self, inputs, training=None):
         """Reconstruct a speed-of-sound map from waveform data.
 
         Args:
             inputs (array-like): Waveforms of shape ``(B, time, receivers, channels)``,
-                preprocessed exactly as during training. For the OpenPros preset that
-                is a sign-preserving ``log1p`` compression followed by a min-max
-                normalization to ``[-1, 1]``.
+                scaled exactly as during training — see the preprocessing section in
+                the module documentation, which the preset depends on.
+
+            training (bool, optional): Forwarded to the batch normalization layers,
+                which use the running statistics unless this is ``True``.
 
         Returns:
             Tensor: Speed-of-sound maps of shape ``(B, height, width, 1)``, in
@@ -238,10 +286,10 @@ class InversionNet(BaseModel):
             )
         x = inputs
         for block in self.encoder:
-            x = block(x)
+            x = block(x, training=training)
         for block in self.decoder:
-            x = block(x)
-        return self.output_block(self.output_crop(x))
+            x = block(x, training=training)
+        return self.output_block(self.output_crop(x), training=training)
 
     def get_config(self):
         """Serialize the architecture arguments."""

--- a/zea/models/inversionnet.py
+++ b/zea/models/inversionnet.py
@@ -65,8 +65,11 @@ __all__ = ["InversionNet", "OPENPROS_INPUT_SHAPE"]
 #: Input shape ``(time, receivers, sources)`` the OpenPros preset was trained on.
 OPENPROS_INPUT_SHAPE = (1000, 161, 40)
 
-# PyTorch's BatchNorm2d default, which Keras does not share.
+# PyTorch BatchNorm2d defaults, which Keras does not share. Keras' ``momentum`` weights
+# the *existing* running statistic where PyTorch's weights the *incoming* batch, so
+# PyTorch's default of 0.1 is Keras' 0.9. Only matters when training or fine-tuning.
 _BN_EPSILON = 1e-5
+_BN_MOMENTUM = 0.9
 
 
 class ConvBlock(keras.layers.Layer):
@@ -86,7 +89,7 @@ class ConvBlock(keras.layers.Layer):
             else None
         )
         self.conv = keras.layers.Conv2D(out_ch, kernel_size, strides=strides, padding="valid")
-        self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON)
+        self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON, momentum=_BN_MOMENTUM)
         self.act = (
             keras.layers.Activation("tanh")
             if activation == "tanh"
@@ -113,7 +116,7 @@ class DeconvBlock(keras.layers.Layer):
             out_ch, kernel_size, strides=strides, padding="valid"
         )
         self.crop = keras.layers.Cropping2D(padding) if padding else None
-        self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON)
+        self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON, momentum=_BN_MOMENTUM)
         self.act = keras.layers.LeakyReLU(negative_slope=0.2)
 
     def call(self, x):

--- a/zea/models/inversionnet.py
+++ b/zea/models/inversionnet.py
@@ -1,0 +1,352 @@
+"""InversionNet: full-waveform inversion of ultrasound computed tomography data.
+
+InversionNet is an encoder-decoder network that maps raw multi-source waveform
+data straight to a speed-of-sound (SOS) map, without an iterative solver. It was
+introduced for seismic FWI (Wu & Lin, 2020), and is the reference baseline of the
+`OpenPros <https://open-pros.github.io/>`_ limited-view prostate USCT benchmark.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from zea.models.inversionnet import InversionNet
+
+    model = InversionNet.from_preset("inversionnet-openpros")
+    sos = model(waveforms)  # (B, 1000, 161, 40) -> (B, 401, 161, 1) in [-1, 1]
+
+Architecture notes
+------------------
+- Encoder: a stride-2 stack that collapses the ``(time, receiver)`` plane to
+  ``1 x 1`` at 512 channels. The first levels stride over time only, because the
+  waveform axis (1000 samples) is much longer than the receiver axis (161).
+- Decoder: transposed convolutions back up to ``448 x 192``, cropped to the
+  ``401 x 161`` image grid, followed by a ``tanh`` output block.
+- The output is in ``[-1, 1]``; map it to physical units with
+  :class:`~zea.ops.Normalize` (OpenPros uses ``1300-3600 m/s``).
+
+.. admonition:: References
+
+   Y. Wu and Y. Lin. *InversionNet: An Efficient and Accurate Data-Driven Full
+   Waveform Inversion.* IEEE Transactions on Computational Imaging, 6:419-433, 2020.
+   `DOI: 10.1109/TCI.2019.2956866 <https://doi.org/10.1109/TCI.2019.2956866>`_
+   (`arXiv:1811.07875 <https://arxiv.org/abs/1811.07875>`_)
+
+   H. Wang, Y. Wu, Y. Feng, P. Jin, L. Zhang, S. Feng, J. Wiskin, B. Turkbey,
+   P. A. Pinto, B. J. Wood, S. Luo, Y. Chen, E. Boctor and Y. Lin.
+   *OpenPros: A Large-Scale Dataset for Limited View Prostate Ultrasound Computed
+   Tomography.* 2025. `arXiv:2505.12261 <https://arxiv.org/abs/2505.12261>`_
+
+.. important::
+
+    This is a ``zea`` implementation of the model. The ``inversionnet-openpros``
+    weights are the pretrained baseline released with the OpenPros benchmark
+    (`dataset <https://open-pros.github.io/>`_,
+    `code <https://github.com/hanchenwang/OpenPros>`_, CC-BY-4.0). Please cite both
+    papers above when you use them.
+
+.. note::
+
+    Because the encoder ends in a fixed ``8 x 6`` convolution and the decoder in a
+    fixed crop, the input size is part of the architecture. The OpenPros preset
+    expects exactly :data:`OPENPROS_INPUT_SHAPE`.
+"""
+
+import keras
+import numpy as np
+
+from zea.internal.registry import model_registry
+from zea.models.base import BaseModel
+from zea.models.preset_utils import get_preset_loader, register_presets
+from zea.models.presets import inversionnet_presets
+
+__all__ = ["InversionNet", "OPENPROS_INPUT_SHAPE"]
+
+#: Input shape ``(time, receivers, sources)`` the OpenPros preset was trained on.
+OPENPROS_INPUT_SHAPE = (1000, 161, 40)
+
+# PyTorch's BatchNorm2d default, which Keras does not share.
+_BN_EPSILON = 1e-5
+
+
+class ConvBlock(keras.layers.Layer):
+    """Conv2D + BatchNorm + LeakyReLU (or ``tanh``), channels-last.
+
+    PyTorch pads symmetrically, which Keras' ``padding="same"`` does not do for
+    ``stride > 1``, so the padding is always made explicit with
+    :class:`~keras.layers.ZeroPadding2D` + ``padding="valid"``.
+    """
+
+    def __init__(self, out_ch, kernel_size=3, strides=1, padding=1, activation="leaky_relu", **kw):
+        super().__init__(**kw)
+        pad_h, pad_w = (padding, padding) if isinstance(padding, int) else padding
+        self.pad = (
+            keras.layers.ZeroPadding2D(((pad_h, pad_h), (pad_w, pad_w)))
+            if (pad_h or pad_w)
+            else None
+        )
+        self.conv = keras.layers.Conv2D(out_ch, kernel_size, strides=strides, padding="valid")
+        self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON)
+        self.act = (
+            keras.layers.Activation("tanh")
+            if activation == "tanh"
+            else keras.layers.LeakyReLU(negative_slope=0.2)
+        )
+
+    def call(self, x):
+        if self.pad is not None:
+            x = self.pad(x)
+        return self.act(self.norm(self.conv(x)))
+
+
+class DeconvBlock(keras.layers.Layer):
+    """Conv2DTranspose + BatchNorm + LeakyReLU, channels-last.
+
+    Keras' ``padding="valid"`` returns the full transposed-convolution output;
+    PyTorch's ``padding=p`` crops ``p`` from each side of it, which is what the
+    :class:`~keras.layers.Cropping2D` here reproduces.
+    """
+
+    def __init__(self, out_ch, kernel_size, strides, padding=0, **kw):
+        super().__init__(**kw)
+        self.conv = keras.layers.Conv2DTranspose(
+            out_ch, kernel_size, strides=strides, padding="valid"
+        )
+        self.crop = keras.layers.Cropping2D(padding) if padding else None
+        self.norm = keras.layers.BatchNormalization(epsilon=_BN_EPSILON)
+        self.act = keras.layers.LeakyReLU(negative_slope=0.2)
+
+    def call(self, x):
+        x = self.conv(x)
+        if self.crop is not None:
+            x = self.crop(x)
+        return self.act(self.norm(x))
+
+
+@model_registry(name="inversionnet")
+class InversionNet(BaseModel):
+    """Encoder-decoder network mapping USCT waveforms to a speed-of-sound map.
+
+    Args:
+        waveform_shape (tuple): Input shape ``(time, receivers, channels)``, without
+            the batch axis. The architecture is tied to it — see the module note —
+            so it is part of the config. Defaults to :data:`OPENPROS_INPUT_SHAPE`.
+        enc_ch (tuple): Base-2 exponents of the encoder channel widths. The first
+            and last entry are the input and bottleneck convolution; the entries
+            in between each become a stride-2 block plus a stride-1 block.
+        enc_side (tuple): Per intermediate encoder level, whether to stride over
+            the time axis only (``1``) instead of both axes (``0``). Must have
+            ``len(enc_ch) - 2`` entries.
+        bottle_conv (tuple): Kernel of the final, ``"valid"`` encoder convolution.
+            It collapses the feature map to ``1 x 1``, so it must equal that map's
+            spatial size.
+        bottle_deconv (tuple): Kernel of the first decoder transposed convolution,
+            which expands ``1 x 1`` back to ``bottle_deconv``.
+        dec_ch (tuple): Base-2 exponents of the decoder channel widths. Every
+            entry past the first doubles the spatial size.
+        crop (tuple): ``(top, bottom, left, right)`` pixels to remove from the
+            decoder output to reach the image grid.
+
+    Example:
+        .. code-block:: python
+
+            import numpy as np
+            from zea.models.inversionnet import InversionNet, OPENPROS_INPUT_SHAPE
+
+            model = InversionNet.from_preset("inversionnet-openpros")
+            waveforms = np.zeros((1, *OPENPROS_INPUT_SHAPE), dtype="float32")
+            sos = model(waveforms)  # (1, 401, 161, 1), in [-1, 1]
+    """
+
+    def __init__(
+        self,
+        waveform_shape=OPENPROS_INPUT_SHAPE,
+        enc_ch=(6, 6, 6, 7, 7, 8, 8, 9),
+        enc_side=(1, 0, 0, 0, 0, 0),
+        bottle_conv=(8, 6),
+        bottle_deconv=(7, 3),
+        dec_ch=(9, 8, 7, 6, 5, 4, 3),
+        crop=(23, 24, 15, 16),
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        if len(enc_ch) != len(enc_side) + 2:
+            raise ValueError(
+                f"enc_ch must have two more entries than enc_side (the input and bottleneck "
+                f"convolutions), got {len(enc_ch)} and {len(enc_side)}."
+            )
+        self.waveform_shape = tuple(waveform_shape)
+        self.enc_ch = tuple(enc_ch)
+        self.enc_side = tuple(enc_side)
+        self.bottle_conv = tuple(bottle_conv)
+        self.bottle_deconv = tuple(bottle_deconv)
+        self.dec_ch = tuple(dec_ch)
+        self.crop = tuple(crop)
+
+        widths = [2**c for c in self.enc_ch]
+        encoder = [ConvBlock(widths[0], kernel_size=(7, 1), strides=(2, 1), padding=(3, 0))]
+        for level, side in enumerate(self.enc_side, start=1):
+            width = widths[level]
+            if side:
+                encoder.append(ConvBlock(width, kernel_size=(3, 1), strides=(2, 1), padding=(1, 0)))
+                encoder.append(ConvBlock(width, kernel_size=(3, 1), padding=(1, 0)))
+            else:
+                encoder.append(ConvBlock(width, strides=2))
+                encoder.append(ConvBlock(width))
+        encoder.append(ConvBlock(widths[-1], kernel_size=self.bottle_conv, padding=0))
+        self.encoder = encoder
+
+        decoder = []
+        for i, exponent in enumerate(self.dec_ch):
+            width = 2**exponent
+            if i == 0:
+                decoder.append(DeconvBlock(width, self.bottle_deconv, strides=2))
+            else:
+                decoder.append(DeconvBlock(width, 4, strides=2, padding=1))
+            decoder.append(ConvBlock(width))
+        self.decoder = decoder
+
+        top, bottom, left, right = self.crop
+        self.output_crop = keras.layers.Cropping2D(((top, bottom), (left, right)))
+        self.output_block = ConvBlock(1, activation="tanh")
+
+    def call(self, inputs):
+        """Reconstruct a speed-of-sound map from waveform data.
+
+        Args:
+            inputs (array-like): Waveforms of shape ``(B, time, receivers, channels)``,
+                preprocessed exactly as during training. For the OpenPros preset that
+                is a sign-preserving ``log1p`` compression followed by a min-max
+                normalization to ``[-1, 1]``.
+
+        Returns:
+            Tensor: Speed-of-sound maps of shape ``(B, height, width, 1)``, in
+            ``[-1, 1]``.
+        """
+        if len(inputs.shape) != 4:
+            raise ValueError(
+                f"Input should have 4 dimensions (batch, time, receivers, channels), "
+                f"but has {len(inputs.shape)}."
+            )
+        if tuple(inputs.shape[1:]) != self.waveform_shape:
+            raise ValueError(
+                f"Input should have shape (batch, {', '.join(map(str, self.waveform_shape))}), "
+                f"but has {tuple(inputs.shape)}."
+            )
+        x = inputs
+        for block in self.encoder:
+            x = block(x)
+        for block in self.decoder:
+            x = block(x)
+        return self.output_block(self.output_crop(x))
+
+    def get_config(self):
+        """Serialize the architecture arguments."""
+        config = super().get_config()
+        config.update(
+            {
+                "waveform_shape": self.waveform_shape,
+                "enc_ch": self.enc_ch,
+                "enc_side": self.enc_side,
+                "bottle_conv": self.bottle_conv,
+                "bottle_deconv": self.bottle_deconv,
+                "dec_ch": self.dec_ch,
+                "crop": self.crop,
+            }
+        )
+        return config
+
+    def _build(self):
+        """Materialize the weights (symbolically, so no data is pushed through)."""
+        if not self.built:
+            self(keras.Input(batch_shape=(None, *self.waveform_shape)))
+
+    def _load_from_pth(self, pth_path):  # pragma: no cover
+        """Load an original PyTorch checkpoint into this Keras model.
+
+        Args:
+            pth_path (str): Path to the ``.pth`` state dict.
+        """
+        import torch  # only needed for weight conversion
+
+        self._build()
+        state_dict = torch.load(pth_path, map_location="cpu", weights_only=True)
+        load_torch_state_dict(self, state_dict)
+
+    def custom_load_weights(self, preset, backend="keras", **kwargs):
+        """Load weights from a preset (Hugging Face handle or local directory).
+
+        Args:
+            preset (str): Preset identifier passed from :meth:`from_preset`.
+            backend (str): ``"keras"`` loads ``model.weights.h5``; ``"torch"``
+                converts the original ``model.pth`` checkpoint and needs PyTorch.
+        """
+        loader = get_preset_loader(preset)
+        if backend == "keras":
+            filename = loader.get_file("model.weights.h5")
+            self._build()
+            self.load_weights(filename)
+        elif backend == "torch":  # pragma: no cover
+            self._load_from_pth(loader.get_file("model.pth"))
+        else:
+            raise ValueError(f"Unsupported backend '{backend}' for InversionNet preset")
+
+    @classmethod
+    def from_pth(cls, pth_path, **kwargs):  # pragma: no cover
+        """Create an :class:`InversionNet` from an original PyTorch checkpoint.
+
+        Args:
+            pth_path (str): Path to the ``.pth`` state dict.
+            **kwargs: Passed to the constructor.
+
+        Returns:
+            InversionNet: Model with the converted weights.
+        """
+        model = cls(**kwargs)
+        model._load_from_pth(pth_path)
+        return model
+
+
+def load_torch_state_dict(model, state_dict):  # pragma: no cover
+    """Copy an original InversionNet PyTorch state dict into a Keras model.
+
+    The PyTorch model is a flat ``nn.Sequential`` encoder and decoder, so its keys
+    are ``{encoder,decoder}.{block}.layers.{0,1}.*`` (convolution, batch norm) and
+    map one-to-one onto this model's block lists. Kernels are permuted from
+    PyTorch's ``(out, in, h, w)`` to Keras' ``(h, w, in, out)``; the same
+    permutation applies to transposed convolutions, whose PyTorch layout is
+    ``(in, out, h, w)``.
+
+    Args:
+        model (InversionNet): Built model to load the weights into.
+        state_dict (dict): ``{key: tensor}`` mapping from PyTorch.
+
+    Raises:
+        KeyError: If the state dict does not match the model's architecture.
+    """
+    arrays = {
+        k: (v.numpy() if hasattr(v, "numpy") else np.asarray(v)) for k, v in state_dict.items()
+    }
+
+    def _set_block(block, prefix):
+        block.conv.set_weights(
+            [
+                np.transpose(arrays[f"{prefix}.layers.0.weight"], (2, 3, 1, 0)),
+                arrays[f"{prefix}.layers.0.bias"],
+            ]
+        )
+        block.norm.set_weights(
+            [
+                arrays[f"{prefix}.layers.1.{name}"]
+                for name in ("weight", "bias", "running_mean", "running_var")
+            ]
+        )
+
+    for i, block in enumerate(model.encoder):
+        _set_block(block, f"encoder.{i}")
+    for i, block in enumerate(model.decoder):
+        _set_block(block, f"decoder.{i}")
+    _set_block(model.output_block, "output")
+
+
+register_presets(inversionnet_presets, InversionNet)

--- a/zea/models/presets.py
+++ b/zea/models/presets.py
@@ -262,3 +262,18 @@ hvae_presets = {
         "hf_handle": "hf://zeahub/hvae",
     },
 }
+
+inversionnet_presets = {
+    "inversionnet-openpros": {
+        "metadata": {
+            "description": (
+                "InversionNet baseline for the OpenPros limited-view prostate USCT "
+                "benchmark, mapping waveform data to a speed-of-sound map. "
+                "Original paper and code: https://arxiv.org/abs/2505.12261"
+            ),
+            "params": 20_447_515,
+            "path": "inversionnet",
+        },
+        "hf_handle": "hf://zeahub/openpros-inversion-net",
+    },
+}


### PR DESCRIPTION
Adds `zea.models.inversionnet.InversionNet`: a Keras 3 port of the pretrained [InversionNet](https://doi.org/10.1109/TCI.2019.2956866) baseline released with the [OpenPros](https://open-pros.github.io/) limited-view prostate USCT benchmark. It reconstructs a speed-of-sound map directly from multi-source waveform data.

The original is PyTorch-only. The port runs on JAX, TensorFlow and PyTorch, and reproduces the original output to within float32 round-off (max abs. difference 3.6e-5 on the real weights, verified on CPU).

```python
model = InversionNet.from_preset("inversionnet-openpros")
sos = model(waveforms)  # (B, 1000, 161, 40) -> (B, 401, 161, 1), in [-1, 1]
```

**What's here**

- `zea/models/inversionnet.py` — the model, plus `load_torch_state_dict()` / `from_pth()` for converting the original checkpoint.
- Preset `inversionnet-openpros` → [`zeahub/openpros-inversion-net`](https://huggingface.co/zeahub/openpros-inversion-net) (weights, config, and the original `.pth` for provenance).
- Tests on a miniature configuration, since the real one is 20M parameters. The default architecture is checked symbolically against the released checkpoint's output shape and parameter count.
- `docs/source/models.rst` — a few corrections to the PyTorch conversion guide from doing this port: `BatchNorm` epsilon and weight order, the general `ConvTranspose` padding rule, why layer classes must not start with an underscore, and a warning that TF32 on GPU makes a correct conversion look broken.

This lets the OpenPros [OpenH-RF submission](https://github.com/open-h/OpenH-RF) drop its vendored network and its 82 MB checkpoint and just load the preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the InversionNet model for reconstructing ultrasound computed tomography speed-of-sound maps.
  * Added a pretrained OpenPros InversionNet preset with support for loading model weights.
  * Made InversionNet available through the models package.

* **Documentation**
  * Expanded custom model porting guidance, including padding, normalization, symbolic construction, validation, and ONNX workflows.
  * Added InversionNet as a documented worked example.

* **Tests**
  * Added coverage for model outputs, input validation, configuration serialization, architecture compatibility, batch normalization behavior, and preset weight loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->