### PR TITLE
docs: standardize paper attribution with a `.. citation::` directive backed by BibTeX

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -3,3 +3,38 @@ figure figcaption p {
   color: var(--color-foreground-secondary, #666);
   text-align: center;
 }
+
+/* ``.. citation::`` blocks -- see docs/source/_ext/citation.py.
+   Every paper zea builds on is attributed in this one block style, so a
+   reference looks the same whether it sits in an operation's docstring, a
+   model page or a dataset converter. Colours come from furo's admonition
+   variables so light and dark themes both stay consistent. */
+.admonition.citation-admonition {
+  --color-admonition-title: #4c6ef5;
+  --color-admonition-title--background: rgba(76, 110, 245, 0.1);
+  --icon: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M6 2h9l5 5v15H6a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2zm8 1.5V8h4.5L14 3.5zM8 12h8v1.5H8V12zm0 3.5h8V17H8v-1.5zm0-7h4V10H8V8.5z'/%3E%3C/svg%3E");
+}
+
+body[data-theme="dark"] .admonition.citation-admonition {
+  --color-admonition-title: #91a7ff;
+  --color-admonition-title--background: rgba(145, 167, 255, 0.15);
+}
+
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) .admonition.citation-admonition {
+    --color-admonition-title: #91a7ff;
+    --color-admonition-title--background: rgba(145, 167, 255, 0.15);
+  }
+}
+
+/* Hanging indent, so a block listing several papers reads as a bibliography
+   rather than as a wall of wrapped lines. */
+.admonition.citation-admonition p.citation-entry {
+  padding-left: 1.5rem;
+  text-indent: -1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.admonition.citation-admonition p.citation-entry:last-child {
+  margin-bottom: 0;
+}

--- a/docs/source/_ext/citation.py
+++ b/docs/source/_ext/citation.py
@@ -81,9 +81,20 @@ def _clean(text: str) -> str:
 
 
 def _initials(name: str) -> str:
-    """Initialise one given name, keeping compounds intact (``Jean-Luc`` -> ``J.-L.``)."""
-    parts = [part for part in re.split(r"[-\s]+", name) if part]
-    return "-".join(f"{part[0]}." for part in parts)
+    """Initialise one given name, keeping compounds intact (``Jean-Luc`` -> ``J.-L.``).
+
+    A name BibTeX already spells as compact initials keeps every letter
+    (``J.A.`` -> ``J. A.``): splitting on spaces and hyphens alone would treat
+    it as a single word and drop everything after the first initial.
+    """
+    parts = []
+    for chunk in re.split(r"[-\s]+", name):
+        if not chunk:
+            continue
+        letters = [piece[0] for piece in chunk.split(".") if piece]
+        if letters:
+            parts.append(" ".join(f"{letter}." for letter in letters))
+    return "-".join(parts)
 
 
 def _format_person(person: Person) -> str:
@@ -228,6 +239,18 @@ def _entry_nodes(key: str, entry: Entry) -> nodes.paragraph:
     return para
 
 
+def _clear_bibliography_cache(app) -> None:
+    """Drop the cached bibliography at the start of every build.
+
+    The cache exists to parse each ``.bib`` file once per build rather than
+    once per directive, so it must not outlive the build that filled it.
+    ``sphinx-autobuild`` (``make docs-serve``) rebuilds in the same process
+    with the same source directory, and without this a ``.bib`` edit would
+    keep rendering from the copy read at start-up.
+    """
+    _BIB_CACHE.pop(str(app.srcdir), None)
+
+
 def _load_bibliography(app) -> dict[str, Entry]:
     """Parse every file in :confval:`bibtex_bibfiles` into one key -> entry map.
 
@@ -309,6 +332,7 @@ def setup(app):
     # it, so make sure it exists even if that extension loads after this one.
     app.setup_extension("sphinxcontrib.bibtex")
     app.add_directive("citation", CitationDirective)
+    app.connect("builder-inited", _clear_bibliography_cache)
     return {
         "version": "1.0",
         "parallel_read_safe": True,

--- a/docs/source/_ext/citation.py
+++ b/docs/source/_ext/citation.py
@@ -81,10 +81,10 @@ def _clean(text: str) -> str:
 
 
 def _initials(name: str) -> str:
-    """Initialise one given name, keeping compounds intact (``Jean-Luc`` -> ``J.-L.``).
+    """Initialise one given name, keeping compounds intact (``Foo-Bar`` -> ``F.-B.``).
 
     A name BibTeX already spells as compact initials keeps every letter
-    (``J.A.`` -> ``J. A.``): splitting on spaces and hyphens alone would treat
+    (``F.B.`` -> ``F. B.``): splitting on spaces and hyphens alone would treat
     it as a single word and drop everything after the first initial.
     """
     parts = []

--- a/docs/source/_ext/citation.py
+++ b/docs/source/_ext/citation.py
@@ -1,0 +1,316 @@
+"""Sphinx directive that renders a paper reference from a BibTeX key.
+
+``zea`` builds on a lot of published work, and every operation, model and
+dataset that comes from a paper should say so in the same way.  Before this
+directive that attribution was written by hand, so it drifted: some references
+sat in ``.. admonition:: Reference``, others in ``.. important::`` or
+``.. note::``, each with its own author/title/journal ordering and its own way
+of linking the DOI.  The ``citation`` directive replaces all of those with a
+single block whose content comes from a ``.bib`` file, so a reference is
+written once and rendered identically everywhere it is cited.
+
+Usage in reStructuredText (or in a docstring, which autodoc feeds through the
+same parser)::
+
+    .. citation:: luijten2020adaptive
+
+    .. citation:: bottenus2018recovery, ali2020extending
+
+       See the `REFoCUS <https://github.com/nbottenus/REFoCUS>`_ repository for
+       a reference implementation.
+
+Keys are resolved against every file listed in :confval:`bibtex_bibfiles` --
+:mod:`sphinxcontrib.bibtex`'s own setting -- so ``.. citation::`` and
+``:cite:p:`` share one pool of references.  ``zea`` keeps two files there:
+``paper/paper.bib`` (the JOSS paper and the papers-using-zea list) and
+``docs/source/references.bib`` (everything cited from the API docs).  An
+unknown key is a build warning, which is what keeps typos and silently dropped
+entries from reaching Read the Docs.
+
+Options
+    ``:title:``  Admonition title. Defaults to ``Reference`` for a single key
+                 and ``References`` for several.
+
+The rendered block is a ``citation-admonition``; ``docs/_static/custom.css``
+styles it.  Entry formatting is deliberately close to the IEEE style the
+docstrings already used: authors as initials + surname, quoted title,
+italicised journal or proceedings, then volume/issue/pages/year and a link.
+"""
+
+from __future__ import annotations
+
+import codecs
+import re
+from pathlib import Path
+from typing import Iterable
+
+import latexcodec  # noqa: F401  (registers the "ulatex" codec used below)
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from docutils.parsers.rst.directives import unchanged
+from pybtex.database import Entry, Person, parse_file
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
+
+#: Cache of merged BibTeX databases, keyed by the Sphinx source directory. The
+#: ``.bib`` files are parsed once per build rather than once per directive --
+#: ``zea`` cites a few dozen papers across the API docs.
+_BIB_CACHE: dict[str, dict[str, Entry]] = {}
+
+#: Fields tried in order when building the entry's hyperlink.
+_URL_FIELDS = ("doi", "url", "eprint")
+
+
+def _clean(text: str) -> str:
+    """Turn a raw BibTeX field into display text.
+
+    Decodes LaTeX escapes (``{\\~{a}}`` -> ``ã``), drops the braces that BibTeX
+    styles use to protect capitalisation (``{D}eep`` -> ``Deep``), and turns
+    ``--`` page ranges into en dashes.
+    """
+    try:
+        text = codecs.decode(text, "ulatex")
+    except (UnicodeDecodeError, ValueError):
+        # A field latexcodec cannot decode is still better shown as-is than
+        # dropped; the braces are stripped below either way.
+        pass
+    text = text.replace("{", "").replace("}", "")
+    text = text.replace("---", "—").replace("--", "–")
+    return " ".join(text.split())
+
+
+def _initials(name: str) -> str:
+    """Initialise one given name, keeping compounds intact (``Jean-Luc`` -> ``J.-L.``)."""
+    parts = [part for part in re.split(r"[-\s]+", name) if part]
+    return "-".join(f"{part[0]}." for part in parts)
+
+
+def _format_person(person: Person) -> str:
+    """Format one author as ``F. M. van der Surname``."""
+    initials = [
+        _initials(_clean(name))
+        for name in list(person.first_names) + list(person.middle_names)
+        if _clean(name)
+    ]
+    surname = " ".join(
+        _clean(part) for part in list(person.prelast_names) + list(person.last_names)
+    )
+    return " ".join(initials + [surname]).strip()
+
+
+def _format_authors(persons: Iterable[Person], max_names: int = 8) -> str:
+    """Join authors, abbreviating long lists with ``et al.``.
+
+    Author lists in ultrasound papers run long (CAMUS has fourteen), and a
+    fourteen-name list crowds out the title it is meant to introduce. Lists
+    longer than ``max_names`` are cut to the first six followed by ``et al.``.
+    """
+    persons = list(persons)
+    # BibTeX spells an abridged author list as "... and others"; pybtex hands
+    # that back as a Person named "others".
+    truncated = bool(persons) and _format_person(persons[-1]).lower() == "others"
+    if truncated:
+        persons = persons[:-1]
+
+    names = [_format_person(person) for person in persons]
+    if not names:
+        return ""
+    if truncated:
+        return ", ".join(names) + ", et al."
+    if len(names) > max_names:
+        return ", ".join(names[:6]) + ", et al."
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return ", ".join(names[:-1]) + ", and " + names[-1]
+
+
+def _link_target(fields: dict) -> tuple[str, str] | None:
+    """Return the ``(url, label)`` to link an entry with, if it has one.
+
+    DOIs registered by arXiv (``10.48550/arXiv.XXXX.YYYYY``) are rewritten to
+    the arXiv abstract page: it is the page a reader actually wants, and it is
+    the form the docstrings used before this directive existed.
+    """
+    for field in _URL_FIELDS:
+        value = fields.get(field, "").strip()
+        if not value:
+            continue
+        if field == "doi":
+            if value.lower().startswith("10.48550/arxiv."):
+                arxiv_id = value.split(".", 2)[-1]
+                return f"https://arxiv.org/abs/{arxiv_id}", f"arXiv:{arxiv_id}"
+            return f"https://doi.org/{value}", f"doi.org/{value}"
+        if field == "eprint":
+            archive = fields.get("archiveprefix", "arXiv").strip() or "arXiv"
+            if archive.lower() == "arxiv":
+                return f"https://arxiv.org/abs/{value}", f"arXiv:{value}"
+            continue
+        return value, value
+    return None
+
+
+def _venue(entry: Entry) -> tuple[str, bool]:
+    """Return the entry's venue and whether it needs an ``in`` prefix."""
+    fields = entry.fields
+    if entry.type in ("inproceedings", "conference", "incollection"):
+        return fields.get("booktitle", ""), True
+    for field in ("journal", "publisher", "school", "institution", "howpublished"):
+        if fields.get(field):
+            return fields[field], False
+    return "", False
+
+
+def _entry_nodes(key: str, entry: Entry) -> nodes.paragraph:
+    """Render one BibTeX entry as a paragraph of docutils nodes.
+
+    Nodes are built directly rather than by generating reStructuredText and
+    re-parsing it: titles routinely contain ``*``, backslashes and backticks,
+    all of which would need escaping on the way through the parser.
+    """
+    fields = {name.lower(): value for name, value in entry.fields.items()}
+    para = nodes.paragraph()
+    para["classes"].append("citation-entry")
+
+    authors = _format_authors(entry.persons.get("author") or entry.persons.get("editor") or [])
+    if authors:
+        para += nodes.Text(f"{authors}, ")
+
+    title = _clean(fields.get("title", key))
+    # Books and theses are the work itself, so their title is set in italics;
+    # for papers the title is quoted and the venue is italicised instead.
+    if entry.type in ("book", "phdthesis", "mastersthesis"):
+        para += nodes.emphasis(text=title)
+        para += nodes.Text(". ")
+    else:
+        para += nodes.Text("“")
+        para += nodes.Text(title)
+        para += nodes.Text(",” ")
+
+    venue, needs_in = _venue(entry)
+    if venue:
+        if needs_in:
+            para += nodes.Text("in ")
+        para += nodes.emphasis(text=_clean(venue))
+
+    details = []
+    if fields.get("volume"):
+        details.append(f"vol. {_clean(fields['volume'])}")
+    if fields.get("number"):
+        details.append(f"no. {_clean(fields['number'])}")
+    if fields.get("pages"):
+        pages = _clean(fields["pages"])
+        label = "pp." if "–" in pages or "," in pages else "p."
+        details.append(f"{label} {pages}")
+    if fields.get("year"):
+        details.append(_clean(fields["year"]))
+
+    if details:
+        para += nodes.Text(f"{', ' if venue else ''}{', '.join(details)}")
+    para += nodes.Text(".")
+
+    note = fields.get("note", "").strip()
+    # dblp-sourced entries carry a "Conference Name: ..." note that just
+    # repeats the journal; anything else the note says is worth showing.
+    if note and not note.lower().startswith("conference name:"):
+        para += nodes.Text(f" {_clean(note)}.")
+
+    link = _link_target(fields)
+    if link:
+        url, label = link
+        para += nodes.Text(" ")
+        reference = nodes.reference("", "", internal=False, refuri=url)
+        reference += nodes.Text(label)
+        para += reference
+
+    return para
+
+
+def _load_bibliography(app) -> dict[str, Entry]:
+    """Parse every file in :confval:`bibtex_bibfiles` into one key -> entry map.
+
+    Duplicate keys across files are reported: sphinxcontrib-bibtex requires
+    keys to be unique across the whole bibliography, so a duplicate would make
+    ``:cite:`` ambiguous even though this directive could resolve it.
+    """
+    cache_key = str(app.srcdir)
+    if cache_key in _BIB_CACHE:
+        return _BIB_CACHE[cache_key]
+
+    entries: dict[str, Entry] = {}
+    for bibfile in app.config.bibtex_bibfiles:
+        path = Path(app.srcdir) / bibfile
+        if not path.is_file():
+            logger.warning("citation: bibtex file not found: %s", path, type="citation")
+            continue
+        try:
+            database = parse_file(str(path))
+        except Exception as exc:  # pybtex raises a variety of parse errors
+            logger.warning("citation: could not parse %s: %s", path, exc, type="citation")
+            continue
+        for key, entry in database.entries.items():
+            if key in entries:
+                logger.warning(
+                    "citation: duplicate bibtex key %r (also in %s)", key, path, type="citation"
+                )
+            entries[key] = entry
+
+    _BIB_CACHE[cache_key] = entries
+    return entries
+
+
+class CitationDirective(Directive):
+    """``.. citation:: key[, key...]`` -- a reference block built from BibTeX."""
+
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+    has_content = True
+    option_spec = {"title": unchanged}
+
+    def run(self):
+        keys = [key.strip() for key in self.arguments[0].replace(",", " ").split() if key.strip()]
+        bibliography = _load_bibliography(self.state.document.settings.env.app)
+
+        admonition = nodes.admonition()
+        admonition["classes"] = ["admonition", "citation-admonition"]
+
+        title = self.options.get("title") or ("Reference" if len(keys) == 1 else "References")
+        admonition += nodes.title(title, title)
+
+        for key in keys:
+            entry = bibliography.get(key)
+            if entry is None:
+                logger.warning(
+                    "citation: unknown bibtex key %r; add it to one of the files in "
+                    "bibtex_bibfiles",
+                    key,
+                    location=(self.state.document["source"], self.lineno),
+                    type="citation",
+                )
+                problem = nodes.paragraph()
+                problem["classes"].append("citation-entry")
+                problem += nodes.problematic("", f"Unknown citation key: {key}")
+                admonition += problem
+                continue
+            admonition += _entry_nodes(key, entry)
+
+        if self.content:
+            self.state.nested_parse(self.content, self.content_offset, admonition)
+
+        return [admonition]
+
+
+def setup(app):
+    """Register the ``citation`` directive."""
+    # sphinxcontrib.bibtex owns ``bibtex_bibfiles``; this directive only reads
+    # it, so make sure it exists even if that extension loads after this one.
+    app.setup_extension("sphinxcontrib.bibtex")
+    app.add_directive("citation", CitationDirective)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -102,4 +102,5 @@ The following list contains some of the papers that have been published using ``
    stevens2026nuclear
    nolan2026task
    federici2026informative
+   afrakhteh2026heavy
    stevens2026ultrasound

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx_reredirects",  # for redirecting empty toc entries
     "sphinx.ext.mathjax",  # for rendering math in the documentation
     "tyroprogram",  # local: auto-documents the tyro CLI (docs/source/_ext/tyroprogram.py)
+    "citation",  # local: the .. citation:: block (docs/source/_ext/citation.py)
 ]
 
 autodoc_mock_imports = [
@@ -116,8 +117,11 @@ html_favicon = "../_static/zea-logo-fav-32px.png"
 # for index
 modindex_common_prefix = ["zea."]
 
-# for bibtex
-bibtex_bibfiles = ["../../paper/paper.bib"]
+# for bibtex. Both files feed :cite: and the local .. citation:: directive,
+# so keys have to stay unique across the two:
+#   paper.bib      -- zea's own citation and the papers-using-zea list
+#   references.bib -- external work cited from the API docs and docstrings
+bibtex_bibfiles = ["../../paper/paper.bib", "references.bib"]
 
 # for redirecting empty toc items to their parent
 redirects = {

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -258,6 +258,29 @@ The documentation uses `Sphinx <https://www.sphinx-doc.org/>`_ and generally is 
             raise ValueError("param1 must be non-negative")
          return True
 
+.. _citing-papers:
+
+**Citing papers.** If your contribution implements a method, model, algorithm or
+dataset from a paper, attribute the authors with the ``.. citation::`` directive
+instead of writing the reference out by hand:
+
+1. Add the paper to `docs/source/references.bib
+   <https://github.com/tue-bmd/zea/blob/main/docs/source/references.bib>`_, using a
+   ``<surname><year><first title word>`` key (``paper/paper.bib`` is only for
+   ``zea``'s own citation and the papers-using-``zea`` list).
+2. Cite it from the docstring:
+
+   .. code-block:: rst
+
+      .. citation:: luijten2020adaptive
+
+   Pass several keys at once with ``.. citation:: key1, key2``, and add a note --
+   a link to the reference implementation, say -- as an indented block below.
+3. Build the docs; an unknown key is reported as a warning.
+
+Keep any "this is a ``zea`` implementation" remark in its own ``.. important::``
+block, so the citation block holds nothing but the reference.
+
 The overall structure of the documentation is manually designed, but the API documentation is auto-generated based on the docstrings in the code. To generate the docs locally you can run:
 
 .. code-block:: shell

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -1,0 +1,264 @@
+% References cited from the zea documentation and docstrings via the
+% ``.. citation::`` directive (see docs/source/_ext/citation.py).
+%
+% This file is for *external* work that zea builds on: beamformers, models,
+% metrics and datasets whose papers are cited from the API docs. Papers written
+% with zea, and the toolbox's own citation, live in ``paper/paper.bib`` instead.
+% Both files are listed in ``bibtex_bibfiles``, so keys must be unique across
+% the two and either file can be cited from anywhere in the docs.
+%
+% Keys follow the convention already used in paper/paper.bib:
+% ``<first author surname><year><first significant title word>``.
+
+% -- Beamforming --------------------------------------------------------------
+
+@inproceedings{hollman1999coherence,
+  author       = {Hollman, K. W. and Rigby, K. W. and O'Donnell, M.},
+  booktitle    = {1999 IEEE Ultrasonics Symposium Proceedings},
+  doi          = {10.1109/ULTSYM.1999.849225},
+  pages        = {1257--1260},
+  title        = {{C}oherence {F}actor of {S}peckle from a {M}ulti-{R}ow {P}robe},
+  volume       = {2},
+  year         = {1999}
+}
+
+@article{li2003adaptive,
+  author       = {Li, Pai-Chi and Li, Meng-Lin},
+  doi          = {10.1109/TUFFC.2003.1182117},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {2},
+  pages        = {128--141},
+  title        = {{A}daptive {I}maging {U}sing the {G}eneralized {C}oherence {F}actor},
+  volume       = {50},
+  year         = {2003}
+}
+
+@article{synnevag2007adaptive,
+  author       = {Synnev{\aa}g, Johan-Fredrik and Austeng, Andreas and Holm, Sverre},
+  doi          = {10.1109/TUFFC.2007.431},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {8},
+  pages        = {1606--1613},
+  title        = {{A}daptive {B}eamforming {A}pplied to {M}edical {U}ltrasound {I}maging},
+  volume       = {54},
+  year         = {2007}
+}
+
+@article{vignon2008capon,
+  author       = {Vignon, Fran{\c{c}}ois and Burcher, Michael R.},
+  doi          = {10.1109/TUFFC.2008.686},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {3},
+  pages        = {619--628},
+  title        = {{C}apon {B}eamforming in {M}edical {U}ltrasound {I}maging with {F}ocused {B}eams},
+  volume       = {55},
+  year         = {2008}
+}
+
+@article{bottenus2018recovery,
+  author       = {Bottenus, Nick},
+  doi          = {10.1109/TUFFC.2017.2773495},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {1},
+  pages        = {30--38},
+  title        = {{R}ecovery of the {C}omplete {D}ata {S}et from {F}ocused {T}ransmit {B}eams},
+  volume       = {65},
+  year         = {2018}
+}
+
+@article{ali2020extending,
+  author       = {Ali, Rehman and Herickhoff, Carl D. and Hyun, Dongwoon and Dahl, Jeremy J. and
+                  Bottenus, Nick},
+  doi          = {10.1109/TUFFC.2019.2961875},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {5},
+  pages        = {943--956},
+  title        = {{E}xtending {R}etrospective {E}ncoding for {R}obust {R}ecovery of the
+                  {M}ultistatic {D}ata {S}et},
+  volume       = {67},
+  year         = {2020}
+}
+
+@article{lafci2022expediting,
+  author       = {Lafci, Berkan and Robin, Justine and De{\'{a}}n-Ben, Xos{\'{e}} Lu{\'{i}}s and
+                  Razansky, Daniel},
+  doi          = {10.1109/TUFFC.2022.3172713},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {10},
+  pages        = {2837--2848},
+  title        = {{E}xpediting {I}mage {A}cquisition in {R}eflection {U}ltrasound {C}omputed
+                  {T}omography},
+  volume       = {69},
+  year         = {2022}
+}
+
+% -- Image processing, display and metrics ------------------------------------
+
+@article{yu2002speckle,
+  author       = {Yu, Yongjian and Acton, Scott T.},
+  doi          = {10.1109/TIP.2002.804276},
+  journal      = {{IEEE} Transactions on Image Processing},
+  number       = {11},
+  pages        = {1260--1270},
+  title        = {{S}peckle {R}educing {A}nisotropic {D}iffusion},
+  volume       = {11},
+  year         = {2002}
+}
+
+@article{bottenus2021histogram,
+  author       = {Bottenus, Nick and Byram, Brett C. and Hyun, Dongwoon},
+  doi          = {10.1109/TUFFC.2020.3035965},
+  journal      = {{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control},
+  number       = {5},
+  pages        = {1487--1495},
+  title        = {{H}istogram {M}atching for {V}isual {U}ltrasound {I}mage {C}omparison},
+  volume       = {68},
+  year         = {2021}
+}
+
+@inproceedings{zhang2018unreasonable,
+  author       = {Zhang, Richard and Isola, Phillip and Efros, Alexei A. and Shechtman, Eli and
+                  Wang, Oliver},
+  booktitle    = {{IEEE/CVF} Conference on Computer Vision and Pattern Recognition (CVPR)},
+  doi          = {10.1109/CVPR.2018.00068},
+  pages        = {586--595},
+  title        = {{T}he {U}nreasonable {E}ffectiveness of {D}eep {F}eatures as a {P}erceptual
+                  {M}etric},
+  year         = {2018}
+}
+
+@article{li2025speckle2self,
+  author       = {Li, Xuesong and Navab, Nassir and Jiang, Zhongliang},
+  doi          = {10.48550/arXiv.2507.06828},
+  journal      = {Medical Image Analysis},
+  title        = {{S}peckle2{S}elf: {S}elf-{S}upervised {U}ltrasound {S}peckle {R}eduction
+                  {W}ithout {C}lean {D}ata},
+  year         = {2025}
+}
+
+% -- Segmentation and quantification models -----------------------------------
+
+@article{vanknippenberg2022unsupervised,
+  author       = {van Knippenberg, Luuk and van Sloun, Ruud J. G. and Mischi, Massimo and
+                  de Ruijter, Joerik and Lopata, Richard and Bouwman, R. Arthur},
+  doi          = {10.1016/j.cmpb.2022.107037},
+  journal      = {Computer Methods and Programs in Biomedicine},
+  pages        = {107037},
+  title        = {{U}nsupervised {D}omain {A}daptation {M}ethod for {S}egmenting {C}ross-{S}ectional
+                  {CCA} {I}mages},
+  volume       = {225},
+  year         = {2022}
+}
+
+@article{vandevyver2025regional,
+  author       = {Van De Vyver, Gilles and M{\aa}s{\o}y, Svein-Erik and Dalen, H{\aa}vard and
+                  Grenne, Bj{\o}rnar Leangen and Holte, Espen and Olaisen, Sindre Hellum and
+                  Nyberg, John and {\O}stvik, Andreas and L{\o}vstakken, Lasse and
+                  Smistad, Erik},
+  doi          = {10.1016/j.ultrasmedbio.2024.12.008},
+  journal      = {Ultrasound in Medicine \& Biology},
+  number       = {4},
+  pages        = {638--649},
+  title        = {{R}egional {I}mage {Q}uality {S}coring for 2-{D} {E}chocardiography {U}sing
+                  {D}eep {L}earning},
+  volume       = {51},
+  year         = {2025}
+}
+
+@article{vandevyver2025generative,
+  author       = {Van De Vyver, Gilles and Lenz, Aksel Try and Smistad, Erik and
+                  Olaisen, Sindre Hellum and Grenne, Bj{\o}rnar and Holte, Espen and
+                  Dalen, H{\aa}vard and L{\o}vstakken, Lasse},
+  doi          = {10.1038/s41598-025-21938-y},
+  journal      = {Scientific Reports},
+  title        = {{G}enerative {A}ugmentations for {I}mproved {C}ardiac {U}ltrasound
+                  {S}egmentation {U}sing {D}iffusion {M}odels},
+  year         = {2025}
+}
+
+@article{ouyang2020video,
+  author       = {Ouyang, David and He, Bryan and Ghorbani, Amirata and Yuan, Neal and
+                  Ebinger, Joseph and Langlotz, Curtis P. and Heidenreich, Paul A. and
+                  Harrington, Robert A. and Liang, David H. and Ashley, Euan A. and Zou, James Y.},
+  doi          = {10.1038/s41586-020-2145-8},
+  journal      = {Nature},
+  number       = {7802},
+  pages        = {252--256},
+  title        = {{V}ideo-{B}ased {AI} for {B}eat-to-{B}eat {A}ssessment of {C}ardiac {F}unction},
+  volume       = {580},
+  year         = {2020}
+}
+
+@article{duffy2022high,
+  author       = {Duffy, Grant and Cheng, Paul P. and Yuan, Neal and He, Bryan and
+                  Kwan, Alan C. and Shun-Shin, Matthew J. and Alexander, Kevin M. and
+                  Ebinger, Joseph and Lungren, Matthew P. and Rader, Florian and
+                  Liang, David H. and Schnittger, Ingela and Ashley, Euan A. and Zou, James Y. and
+                  Patel, Jignesh and Witteles, Ronald and Cheng, Susan and Ouyang, David},
+  doi          = {10.1001/jamacardio.2021.6059},
+  journal      = {{JAMA} Cardiology},
+  number       = {4},
+  pages        = {386--395},
+  title        = {{H}igh-{T}hroughput {P}recision {P}henotyping of {L}eft {V}entricular
+                  {H}ypertrophy with {C}ardiovascular {D}eep {L}earning},
+  volume       = {7},
+  year         = {2022}
+}
+
+@article{bernard2016standardized,
+  author       = {Bernard, Olivier and others},
+  doi          = {10.1109/TMI.2015.2503890},
+  journal      = {{IEEE} Transactions on Medical Imaging},
+  number       = {4},
+  pages        = {967--977},
+  title        = {{S}tandardized {E}valuation {S}ystem for {L}eft {V}entricular {S}egmentation
+                  {A}lgorithms in 3{D} {E}chocardiography},
+  volume       = {35},
+  year         = {2016}
+}
+
+% -- Network architectures and generative modelling ---------------------------
+
+@inproceedings{peebles2023scalable,
+  author       = {Peebles, William and Xie, Saining},
+  booktitle    = {{IEEE/CVF} International Conference on Computer Vision (ICCV)},
+  doi          = {10.48550/arXiv.2212.09748},
+  pages        = {4195--4205},
+  title        = {{S}calable {D}iffusion {M}odels with {T}ransformers},
+  year         = {2023}
+}
+
+@inproceedings{chen2018encoder,
+  author       = {Chen, Liang-Chieh and Zhu, Yukun and Papandreou, George and Schroff, Florian and
+                  Adam, Hartwig},
+  booktitle    = {European Conference on Computer Vision (ECCV)},
+  doi          = {10.48550/arXiv.1802.02611},
+  title        = {{E}ncoder-{D}ecoder with {A}trous {S}eparable {C}onvolution for {S}emantic
+                  {I}mage {S}egmentation},
+  year         = {2018}
+}
+
+@article{chen2017rethinking,
+  author       = {Chen, Liang-Chieh and Papandreou, George and Schroff, Florian and Adam, Hartwig},
+  doi          = {10.48550/arXiv.1706.05587},
+  journal      = {arXiv preprint},
+  title        = {{R}ethinking {A}trous {C}onvolution for {S}emantic {I}mage {S}egmentation},
+  year         = {2017}
+}
+
+@article{nibali2018numerical,
+  author       = {Nibali, Aiden and He, Zhen and Morgan, Stuart and Prendergast, Luke},
+  doi          = {10.48550/arXiv.1711.08229},
+  journal      = {arXiv preprint},
+  title        = {{N}umerical {C}oordinate {R}egression with {C}onvolutional {N}eural {N}etworks},
+  year         = {2018}
+}
+
+@inproceedings{chung2024decomposed,
+  author       = {Chung, Hyungjin and Lee, Suhyeon and Ye, Jong Chul},
+  booktitle    = {International Conference on Learning Representations (ICLR)},
+  doi          = {10.48550/arXiv.2303.05754},
+  title        = {{D}ecomposed {D}iffusion {S}ampler for {A}ccelerating {L}arge-{S}cale {I}nverse
+                  {P}roblems},
+  year         = {2024}
+}

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -129,10 +129,12 @@
 
 @article{li2025speckle2self,
   author       = {Li, Xuesong and Navab, Nassir and Jiang, Zhongliang},
-  doi          = {10.48550/arXiv.2507.06828},
+  doi          = {10.1016/j.media.2025.103755},
   journal      = {Medical Image Analysis},
+  pages        = {103755},
   title        = {{S}peckle2{S}elf: {S}elf-{S}upervised {U}ltrasound {S}peckle {R}eduction
                   {W}ithout {C}lean {D}ata},
+  volume       = {106},
   year         = {2025}
 }
 
@@ -171,8 +173,11 @@
                   Dalen, H{\aa}vard and L{\o}vstakken, Lasse},
   doi          = {10.1038/s41598-025-21938-y},
   journal      = {Scientific Reports},
+  number       = {1},
+  pages        = {38013},
   title        = {{G}enerative {A}ugmentations for {I}mproved {C}ardiac {U}ltrasound
                   {S}egmentation {U}sing {D}iffusion {M}odels},
+  volume       = {15},
   year         = {2025}
 }
 
@@ -206,7 +211,16 @@
 }
 
 @article{bernard2016standardized,
-  author       = {Bernard, Olivier and others},
+  author       = {Bernard, Olivier and Bosch, Johan G. and Heyde, Brecht and
+                  Alessandrini, Martino and Barbosa, Daniel and Camarasu-Pop, Sorina and
+                  Cervenansky, Frederic and Valette, S{\'{e}}bastien and Mirea, Oana and
+                  Bernier, Michel and Jodoin, Pierre-Marc and Domingos, Joao Sousa and
+                  Stebbing, Richard V. and Keraudren, Kevin and Oktay, Ozan and
+                  Caballero, Jose and Shi, Wei and Rueckert, Daniel and Milletari, Fausto and
+                  Ahmadi, Seyed-Ahmad and Smistad, Erik and Lindseth, Frank and
+                  van Stralen, Maartje and Wang, Chen and Smedby, {\"{O}}rjan and
+                  Donal, Erwan and Monaghan, Mark and Papachristidis, Alex and
+                  Geleijnse, Marcel L. and Galli, Elena and D'hooge, Jan},
   doi          = {10.1109/TMI.2015.2503890},
   journal      = {{IEEE} Transactions on Medical Imaging},
   number       = {4},
@@ -248,7 +262,7 @@
 
 @article{nibali2018numerical,
   author       = {Nibali, Aiden and He, Zhen and Morgan, Stuart and Prendergast, Luke},
-  doi          = {10.48550/arXiv.1711.08229},
+  doi          = {10.48550/arXiv.1801.07372},
   journal      = {arXiv preprint},
   title        = {{N}umerical {C}oordinate {R}egression with {C}onvolutional {N}eural {N}etworks},
   year         = {2018}

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -110,7 +110,7 @@
 
 @inproceedings{penninga2025deep,
   author       = {Simon W. Penninga and
-                  Hans Van Gorp and
+                  Hans van Gorp and
                   Ruud J. G. van Sloun},
   bibsource    = {dblp computer science bibliography, https://dblp.org},
   biburl       = {https://dblp.org/rec/conf/icassp/PenningaGS25.bib},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -79,8 +79,11 @@
                   Ruud J. G. van Sloun},
   doi          = {10.1109/TMI.2025.3645849},
   journal      = {{IEEE} Trans. Medical Imaging},
+  number       = {5},
+  pages        = {2053--2064},
   title        = {{H}igh {V}olume {R}ate 3{D} {U}ltrasound {R}econstruction with {D}iffusion {M}odels},
-  year         = {2025}
+  volume       = {45},
+  year         = {2026}
 }
 
 @article{nolan2024active,
@@ -103,7 +106,8 @@
                   Massimo Mischi},
   journal      = {IEEE Open Journal of Ultrasonics, Ferroelectrics, and Frequency Control},
   title        = {{A}ctive {I}nference for {C}losed-loop {T}ransmit {B}eamsteering in {F}etal {D}oppler {U}ltrasound},
-  pages        = {1--1},
+  volume       = {5},
+  pages        = {276--280},
   year         = {2025},
   doi          = {10.1109/OJUFFC.2025.3636108}
 }
@@ -301,7 +305,7 @@
   doi          = {10.1117/1.3360308},
   journal      = {Journal of biomedical optics},
   number       = {2},
-  pages        = {021314--021314},
+  pages        = {021314},
   publisher    = {Society of Photo-Optical Instrumentation Engineers},
   title        = {k-{W}ave: {M}{A}{T}{L}{A}{B} toolbox for the simulation and reconstruction of photoacoustic wave fields},
   volume       = {15},

--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -427,13 +427,24 @@
   year         = {2026}
 }
 
+@inproceedings{afrakhteh2026heavy,
+  author       = {Sajjad Afrakhteh and
+                  Tristan S. W. Stevens and
+                  Ruud J. G. van Sloun},
+  booktitle    = {European Signal Processing Conference (EUSIPCO), Bruges, Belgium},
+  title        = {{H}eavy-{T}ailed {D}enoising {D}iffusion for {H}igh {F}rame {R}ate {U}ltrasound {C}oherent {P}lane-{W}ave {C}ompounding},
+  year         = {2026}
+}
+
 @inproceedings{federici2026informative,
   author       = {Beatrice Federici and
                   Ruud J. G. van Sloun and
                   Massimo Mischi},
   booktitle    = {{IEEE} International Conference on Acoustics, Speech and Signal
                   Processing (ICASSP), Barcelona, Spain},
-  title        = {Information Seeking Transmit Beamforming for Cognitive Ultrasound},
+  doi          = {10.1109/ICASSP55912.2026.11463288},
+  pages        = {20277--20281},
+  title        = {Information-Seeking Transmit Beamforming for Cognitive Ultrasound},
   year         = {2026}
 }
 

--- a/zea/agent/selection.py
+++ b/zea/agent/selection.py
@@ -148,7 +148,10 @@ class GreedyEntropy(LinesActionModel):
         This function computes the Gaussian error between each pair of pixels in the
         set of particles provided. This can be used to approximate the entropy of
         a Gaussian mixture model, where the particles are the means of the Gaussians.
-        For more details see Section 4 here: https://arxiv.org/abs/2406.14388
+
+        .. citation:: nolan2024active
+
+            See Section 4 for the derivation of this entropy approximation.
 
         Args:
             particles (Tensor): Particles of shape (batch_size, n_particles, ...pixels)

--- a/zea/data/convert/camus.py
+++ b/zea/data/convert/camus.py
@@ -22,15 +22,7 @@ Dataset splits:
    The CAMUS dataset is available free of charge strictly for non-commercial
    scientific research purposes only.
 
-.. admonition:: Reference
-
-   S\\. Leclerc, E. Smistad, J. Pedrosa, A. Ostvik, F. Cervenansky, F. Espinosa,
-   T. Espeland, E. A. R. Berg, P.-M. Jodoin, T. Grenier, C. Lartizien,
-   J. D'hooge, L. Lovstakken and O. Bernard.
-   *Deep Learning for Segmentation Using an Open Large-Scale Dataset in
-   2D Echocardiography.*
-   IEEE Transactions on Medical Imaging, vol. 38, no. 9, pp. 2198-2210, 2019.
-   `DOI: 10.1109/TMI.2019.2900516 <https://doi.org/10.1109/TMI.2019.2900516>`_
+.. citation:: leclerc2019deep
 
 .. rubric:: Links
 

--- a/zea/data/convert/cetus.py
+++ b/zea/data/convert/cetus.py
@@ -23,13 +23,7 @@ Dataset splits:
    The CETUS dataset is available free of charge strictly for non-commercial
    scientific research purposes only.
 
-.. admonition:: Reference
-
-   O. Bernard, et al.
-   *Standardized Evaluation System for Left Ventricular Segmentation Algorithms
-   in 3D Echocardiography.*
-   IEEE Transactions on Medical Imaging, vol. 35, no. 4, pp. 967-977, April 2016.
-   `DOI: 10.1109/tmi.2015.2503890 <https://doi.org/10.1109/tmi.2015.2503890>`_
+.. citation:: bernard2016standardized
 
 .. rubric:: Links
 

--- a/zea/data/convert/picmus.py
+++ b/zea/data/convert/picmus.py
@@ -18,12 +18,7 @@ The dataset comprises three partitions:
    The only request is to refer properly to PICMUS - The Plane Wave Imaging Challenge
    in Medical UltraSound and quote the proceeding paper.
 
-.. admonition:: Reference
-
-   H. Liebgott, A. Rodriguez-Molares, F. Cervenansky, J. D'hooge and O. Bernard.
-   *Plane-Wave Imaging Challenge in Medical Ultrasound.*
-   2016 IEEE International Ultrasonics Symposium (IUS), Tours, France, 2016, pp. 1-4.
-   `DOI: 10.1109/ULTSYM.2016.7728908 <https://doi.org/10.1109/ULTSYM.2016.7728908>`_
+.. citation:: liebgott2016plane
 
 .. rubric:: Links
 

--- a/zea/display.py
+++ b/zea/display.py
@@ -192,14 +192,10 @@ def histogram_match(
     visual as well as quantitative comparison. Matching the histogram of an image to a
     reference (typically a conventional B-mode image) puts the two on a common scale.
 
-    .. admonition:: Reference
+    .. citation:: bottenus2021histogram
 
-        N. Bottenus, B. Byram, and D. Hyun, "Histogram Matching for Visual Ultrasound
-        Image Comparison," *IEEE Transactions on Ultrasonics, Ferroelectrics, and Frequency
-        Control*, vol. 68, no. 5, pp. 1487-1495, 2021.
-        https://doi.org/10.1109/TUFFC.2020.3035965
-
-        Their MATLAB implementation, referred to above as the reference implementation:
+        Their MATLAB implementation, referred to above as the reference
+        implementation:
         https://github.com/nbottenus/histogram_matching/blob/main/histmatch.m
 
     Args:

--- a/zea/func/ultrasound.py
+++ b/zea/func/ultrasound.py
@@ -846,12 +846,7 @@ def dehaze_nuclear_diffusion(
         This function requires a diffusion model with Nuclear Diffusion guidance.
         Initialize your model with ``guidance="nuclear-dps"`` and ``operator="linear_interp"``.
 
-    .. admonition:: Reference
-
-        T. S. W. Stevens, O. Nolan, J.-L. Robert, and R. J. G. van Sloun,
-        "Nuclear Diffusion Models for Low-Rank Background Suppression in Videos,"
-        *IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)*, 2026.
-        https://arxiv.org/abs/2509.20886
+    .. citation:: stevens2026nuclear
 
     """  # noqa: E501
 

--- a/zea/metrics.py
+++ b/zea/metrics.py
@@ -223,12 +223,7 @@ def smsle(y_true, y_pred, *, dynamic_range: float = 60.0):
     Both inputs are normalized by their own maximum absolute value before log
     compression, so the metric is invariant to the overall scale of either input.
 
-    .. admonition:: Reference
-
-        Luijten, B., Cohen, R., de Bruijn, F. J., Schmeitz, H. A. W., Mischi, M.,
-        Eldar, Y. C., & van Sloun, R. J. G. (2020). Adaptive Ultrasound Beamforming
-        Using Deep Learning. *IEEE Transactions on Medical Imaging, 39*\\ (12),
-        3967-3978. https://doi.org/10.1109/TMI.2020.3008537
+    .. citation:: luijten2020adaptive
 
     Args:
         y_true (tensor): Ground truth values.

--- a/zea/models/carotid_segmenter.py
+++ b/zea/models/carotid_segmenter.py
@@ -10,11 +10,8 @@ To try this model, simply load one of the available presets:
 
 .. important::
     This is a ``zea`` implementation of the model.
-    For the original paper see:
 
-    van Knippenberg, Luuk, et al.
-    "Unsupervised domain adaptation method for segmenting cross-sectional CCA images."
-    *https://doi.org/10.1016/j.cmpb.2022.107037*
+.. citation:: vanknippenberg2022unsupervised
 
 .. seealso::
     A tutorial notebook where this model is used:
@@ -56,9 +53,7 @@ class CarotidSegmenter(BaseModel):
 
         Based on U-Net architecture.
 
-        Original implementation of paper:
-            - "Unsupervised domain adaptation method for segmenting cross-sectional CCA images"
-            - https://doi.org/10.1016/j.cmpb.2022.107037
+        .. citation:: vanknippenberg2022unsupervised
         """
 
         super().__init__(

--- a/zea/models/deeplabv3.py
+++ b/zea/models/deeplabv3.py
@@ -1,4 +1,7 @@
-"""DeepLabV3+ architecture for multi-class segmentation. For more details see https://arxiv.org/abs/1802.02611."""
+"""DeepLabV3+ architecture for multi-class segmentation.
+
+.. citation:: chen2018encoder
+"""
 
 import keras
 from keras import layers, ops
@@ -52,7 +55,7 @@ def DilatedSpatialPyramidPooling(dspp_input):
     - 1x1 convolution branch
     - 3x3 convolutions with dilation rates 6, 12, and 18
 
-    Reference: https://arxiv.org/abs/1706.05587
+    .. citation:: chen2017rethinking
 
     Args:
         dspp_input (Tensor): Input feature tensor from encoder
@@ -92,7 +95,7 @@ def DeeplabV3Plus(image_shape, num_classes, pretrained_weights=None):
     3. Decoder: Simple decoder with skip connections
     4. Output: Final segmentation prediction
 
-    Reference: https://arxiv.org/abs/1802.02611
+    .. citation:: chen2018encoder
 
     Args:
         image_shape (tuple): Input image shape as (height, width, channels)

--- a/zea/models/diffusion.py
+++ b/zea/models/diffusion.py
@@ -1138,7 +1138,7 @@ class DDS(DiffusionGuidance):
     """
     Decomposed Diffusion Sampling guidance.
 
-    Reference paper: https://arxiv.org/pdf/2303.05754
+    .. citation:: chung2024decomposed
     """
 
     def setup(self):
@@ -1351,12 +1351,7 @@ class NuclearDiffusion(DPS):
         operator: Forward operator defining the measurement model.
         disable_jit: Whether to disable JIT compilation.
 
-    .. admonition:: Reference
-
-        T. Stevens, O. Nolan, J. L. Robert, and R. J. G. van Sloun,
-        "Nuclear Diffusion Models for Low-Rank Background Suppression in Videos,"
-        *IEEE International Conference on Acoustics, Speech and Signal Processing (ICASSP)*, 2026.
-        https://arxiv.org/abs/2509.20886
+    .. citation:: stevens2026nuclear
 
     """  # noqa: E501
 

--- a/zea/models/dit.py
+++ b/zea/models/dit.py
@@ -27,10 +27,7 @@ The architecture follows the original DiT with **adaLN-Zero** conditioning:
 5. A final adaLN-modulated linear layer projects each token back to its pixel
    patch, and the patches are reassembled (unpatchified) into an image.
 
-.. seealso::
-
-    Peebles & Xie, *Scalable Diffusion Models with Transformers*, 2023.
-    https://arxiv.org/abs/2212.09748
+.. citation:: peebles2023scalable
 """
 
 from __future__ import annotations

--- a/zea/models/echonet.py
+++ b/zea/models/echonet.py
@@ -11,10 +11,9 @@ To try this model, simply load one of the available presets:
 
 .. important::
     This is a ``zea`` implementation of the model.
-    For the original paper and code, see `here <https://echonet.github.io/dynamic/>`_.
+    For the original code, see `here <https://echonet.github.io/dynamic/>`_.
 
-    Ouyang, David, et al. "Video-based AI for beat-to-beat assessment of cardiac function."
-    *Nature 580.7802 (2020): 252-256*
+.. citation:: ouyang2020video
 
 .. seealso::
     A tutorial notebook where this model is used:

--- a/zea/models/echonetlvh.py
+++ b/zea/models/echonetlvh.py
@@ -10,11 +10,9 @@ To try this model, simply load one of the available presets:
 
 .. important::
     This is a ``zea`` implementation of the model.
-    For the original paper and code, see `here <https://echonet.github.io/lvh/>`_.
+    For the original code, see `here <https://echonet.github.io/lvh/>`_.
 
-    Duffy, Grant, et al.
-    "High-throughput precision phenotyping of left ventricular hypertrophy with cardiovascular deep learning."
-    *JAMA cardiology 7.4 (2022): 386-395*
+.. citation:: duffy2022high
 
 .. seealso::
     A tutorial notebook where this model is used:
@@ -132,7 +130,7 @@ class EchoNetLVH(BaseModel):
         This implements a differentiable version of taking the max of a heatmap
         by computing the weighted average of coordinates.
 
-        Reference: https://arxiv.org/pdf/1711.08229
+        .. citation:: nibali2018numerical
 
         Args:
             mask (Tensor): Heatmap of shape [B, H, W]

--- a/zea/models/hvae/__init__.py
+++ b/zea/models/hvae/__init__.py
@@ -12,6 +12,8 @@ To try this model, simply load one of the available presets:
     This is a ``zea`` implementation of the model.
     For the original code, see `here <https://github.com/swpenninga/hvae>`_.
 
+.. citation:: penninga2025deep
+
 .. seealso::
     A tutorial notebook where this model is used:
     :doc:`../notebooks/models/hvae_model_example`.

--- a/zea/models/lpips.py
+++ b/zea/models/lpips.py
@@ -10,11 +10,9 @@ To try this model, simply load one of the available presets:
 
 .. important::
     This is a ``zea`` implementation of the model.
-    For the original paper and code, see `here <https://github.com/richzhang/PerceptualSimilarity>`_.
+    For the original code, see `here <https://github.com/richzhang/PerceptualSimilarity>`_.
 
-    Zhang, Richard, et al.
-    "The Unreasonable Effectiveness of Deep Features as a Perceptual Metric."
-    *https://arxiv.org/abs/1801.03924*
+.. citation:: zhang2018unreasonable
 
 .. seealso::
     A tutorial notebook where this model is used:

--- a/zea/models/lv_segmentation.py
+++ b/zea/models/lv_segmentation.py
@@ -16,11 +16,9 @@ it is the state-of-the-art model for left ventricle segmentation on the CAMUS da
 
 .. important::
     This is a ``zea`` implementation of the model.
-    For the original paper and code, see `here <https://github.com/GillesVanDeVyver/EchoGAINS>`_.
+    For the original code, see `here <https://github.com/GillesVanDeVyver/EchoGAINS>`_.
 
-    Van De Vyver, Gilles, et al.
-    "Generative augmentations for improved cardiac ultrasound segmentation using diffusion models."
-    *https://arxiv.org/abs/2502.20100*
+.. citation:: vandevyver2025generative
 
 .. seealso::
     A tutorial notebook where this model is used:

--- a/zea/models/regional_quality.py
+++ b/zea/models/regional_quality.py
@@ -18,10 +18,9 @@ it is the state-of-the-art model for left ventricle segmentation on the CAMUS da
 
 .. important::
     This is a ``zea`` implementation of the model.
-    For the original paper and code, see `here <https://github.com/GillesVanDeVyver/arqee>`_.
+    For the original code, see `here <https://github.com/GillesVanDeVyver/arqee>`_.
 
-    Van De Vyver, et al. "Regional Image Quality Scoring for 2-D Echocardiography Using Deep Learning."
-    *Ultrasound in Medicine & Biology 51.4 (2025): 638-649*
+.. citation:: vandevyver2025regional
 
 .. seealso::
     A tutorial notebook where this model is used:

--- a/zea/models/speckle2self.py
+++ b/zea/models/speckle2self.py
@@ -27,8 +27,9 @@ Architecture notes
 .. important::
 
     This is a ``zea`` implementation of the model.
-    For the original `paper <https://arxiv.org/abs/2507.06828>`_ and `
-    code <https://github.com/noseefood/speckle2self>`_.
+    For the original code, see `here <https://github.com/noseefood/speckle2self>`_.
+
+.. citation:: li2025speckle2self
 
 .. note::
 

--- a/zea/ops/pipeline.py
+++ b/zea/ops/pipeline.py
@@ -1661,10 +1661,7 @@ class CoherenceFactor(Operation):
     The beamformed output is the standard DAS sum weighted by CF per transmit,
     then compounded across transmits.
 
-    .. admonition:: Reference
-
-        Hollman, K. W., Rigby, K. W., & O'Donnell, M. (1999).
-        Coherence factor of speckle from a multi-row probe. IEEE Ultrasonics Symposium.
+    .. citation:: hollman1999coherence
 
     Args:
         **kwargs: Additional arguments passed to the Operation base class.
@@ -1750,12 +1747,7 @@ class GeneralizedCoherenceFactor(Operation):
     where :math:`\mathcal{M}_0 = \{k : k \leq m_0\} \cup \{k : k \geq N - m_0\}`
     is the low spatial-frequency region controlled by :math:`m_0`.
 
-    .. admonition:: Reference
-
-        Li, P. C., & Li, M. L. (2003).
-        "Adaptive imaging using the generalized coherence factor."
-        IEEE Transactions on Ultrasonics, Ferroelectrics, and Frequency Control,
-        50(2), 128-141.
+    .. citation:: li2003adaptive
 
     Args:
         m_zero (int): Cutoff frequency index for the low-frequency spatial region.
@@ -1886,15 +1878,7 @@ class MinimumVariance(Operation):
         into a triangular artefact. Set ``parameters.f_number = 0`` and let MV adapt
         the aperture itself.
 
-    .. admonition:: References
-
-        Synnevåg, J.-F., Austeng, A. and Holm, S., "Adaptive beamforming applied to
-        medical ultrasound imaging," *IEEE Trans. Ultrason. Ferroelectr. Freq.
-        Control* **54** (8), 2007. https://doi.org/10.1109/TUFFC.2007.431
-
-        Vignon, F. and Burcher, M. R., "Capon beamforming in medical ultrasound
-        imaging with focused beams," *IEEE Trans. Ultrason. Ferroelectr. Freq.
-        Control* **55** (3), 2008. https://doi.org/10.1109/TUFFC.2008.686
+    .. citation:: synnevag2007adaptive, vignon2008capon
 
     Args:
         subarray_size (int or None): Sub-aperture length :math:`M`. Smaller values are
@@ -2115,19 +2099,10 @@ class Refocus(Operation):
     **output** has shape ``(n_el, n_ax, n_el, n_ch)``, where the new first
     axis indexes the decoded virtual transmit elements.
 
-    .. admonition:: References
+    .. citation:: bottenus2018recovery, ali2020extending
 
-        Bottenus, N. (2018).
-        "Recovery of the complete data set from focused transmit beams."
-        *IEEE Transactions on Ultrasonics, Ferroelectrics, and Frequency
-        Control*, 65(1), 30–38.
-
-        Ali, R., Dahl, J., & Bottenus, N. (2019).
-        "Extending Retrospective Encoding for Robust Recovery of the Multistatic Dataset."
-        *IEEE Transactions on Ultrasonics, Ferroelectrics, and Frequency
-        Control*, 67(5), 943–956.
-
-        https://github.com/nbottenus/REFoCUS
+        See the `REFoCUS <https://github.com/nbottenus/REFoCUS>`_ repository for a
+        reference implementation.
 
     Args:
         method (str): Inversion method. One of:

--- a/zea/ops/ultrasound.py
+++ b/zea/ops/ultrasound.py
@@ -1015,9 +1015,11 @@ class Downsample(Operation):
 class AnisotropicDiffusion(Operation):
     """Speckle Reducing Anisotropic Diffusion (SRAD) filter.
 
-    Reference:
-    - https://doi.org/10.1109/TIP.2002.804276
-    - https://nl.mathworks.com/matlabcentral/fileexchange/54044-image-despeckle-filtering-toolbox
+    .. citation:: yu2002speckle
+
+        See also the `Image Despeckle Filtering Toolbox
+        <https://nl.mathworks.com/matlabcentral/fileexchange/54044-image-despeckle-filtering-toolbox>`_
+        on MATLAB Central.
     """
 
     def call(self, niter=100, lmbda=0.1, rect=None, eps=1e-6, **kwargs):

--- a/zea/ops/usct.py
+++ b/zea/ops/usct.py
@@ -46,13 +46,7 @@ class USCTReflectivityDAS(Operation):
     based on the reflection ultrasound computed tomography (RUCT) approach for
     ring-array systems described below.
 
-    .. admonition:: Reference
-
-       B. Lafci, J. Robin, X. L. Deán-Ben and D. Razansky.
-       *Expediting Image Acquisition in Reflection Ultrasound Computed Tomography.*
-       IEEE Transactions on Ultrasonics, Ferroelectrics, and Frequency Control,
-       69(10):2837-2848, 2022.
-       `DOI: 10.1109/TUFFC.2022.3172713 <https://doi.org/10.1109/TUFFC.2022.3172713>`_
+    .. citation:: lafci2022expediting
 
     .. seealso::
 


### PR DESCRIPTION
Paper attribution in the docs was written by hand, so it drifted: some references sat in `.. admonition:: Reference`, others inside `.. important::` or a bare `Reference:` line, each with its own formatting and its own way of linking a DOI. This makes every reference render identically, from one source of truth.

### A `citation` directive

```rst
.. citation:: luijten2020adaptive

.. citation:: bottenus2018recovery, ali2020extending

    See the `REFoCUS <https://github.com/nbottenus/REFoCUS>`_ repository for a
    reference implementation.
```

Keys resolve against every file in `bibtex_bibfiles`, so `.. citation::` and `:cite:` share one pool of references. Unknown keys are build warnings. Works in docstrings as well as `.rst`.

### The rest

- **`docs/source/references.bib`** — a second bibliography for external work zea builds on. `paper/paper.bib` keeps its role: zea's own citation and the papers-using-zea list.
- **`docs/_static/custom.css`** — a `citation-admonition` style using furo's admonition variables, light and dark.
- **26 attribution blocks converted** across ops, beamformers, metrics, display, models, agent and the dataset converters. Where a `.. important:: This is a zea implementation` block also carried the paper, the caveat stays and the reference moves into its own `.. citation::`.
- **A note in `contributing.rst`** telling contributors to attribute papers this way.

### Metadata fixes found along the way

- Ali et al. (Refocus) was cited as 2019, but the issue quoted (67(5), 943–956) is 2020 — and was missing two authors, Herickhoff and Hyun.
- EchoGAINS was cited as an arXiv preprint; it's since been published in Scientific Reports.
- EchoNet cites Ouyang et al. *Nature* 2020, a different paper from the `ouyang2019echonet` dataset entry already in `paper.bib`. Both are kept.
- `paper.bib` spelled `Hans Van Gorp` in first-last form, which BibTeX parses as a middle name and rendered as "H. V. Gorp".
- `zea.models.hvae` had no paper attribution at all, only a code link; now cites `penninga2025deep`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a standardized citation directive for displaying paper references throughout the documentation and API references.
  - Added a bibliography covering cited research, with support for multiple references, notes, links, and validation warnings.
  - Updated existing documentation references to use consistent, linked citations.
  - Added contributor guidance for adding and formatting citations.

- **Style**
  - Added light- and dark-theme styling for citation blocks, including document icons and improved formatting for multi-entry references.

- **Reference Updates**
  - Corrected and completed several bibliographic details in the paper references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->