### PR TITLE
Make README logo link to getting started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/tue-bmd/zea/main/docs/_static/zea-logo.png" width="140" alt="zea logo">
+  <a href="https://zea.readthedocs.io/en/latest/getting-started.html"><img src="https://raw.githubusercontent.com/tue-bmd/zea/main/docs/_static/zea-logo.png" width="140" alt="zea logo"></a>
 </p>
 
 <h1 align="center">zea</h1>


### PR DESCRIPTION
One-line change in the readme - if a user clicks the logo, link them to the "Getting started" page instead of a full-screen version of the logo. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Made the README logo clickable, linking readers to the Zea getting-started documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->